### PR TITLE
Use environment variables for Supabase configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL="https://wfqsmvkzkxdasbhpugdc.supabase.co"
+VITE_SUPABASE_KEY="sb_publishable_8rLYlRkT8hNwBs-T7jsOAQ_pJq9gtfB"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL="https://your-project.supabase.co"
+VITE_SUPABASE_KEY="your-anon-key"

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,11 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 
 
-// Initialize Supabase client
-// Using direct values from project configuration
-const supabaseUrl = 'https://wfqsmvkzkxdasbhpugdc.supabase.co';
-const supabaseKey = 'sb_publishable_8rLYlRkT8hNwBs-T7jsOAQ_pJq9gtfB';
+// Initialize Supabase client using environment variables
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
-
 
 export { supabase };


### PR DESCRIPTION
## Summary
- replace hard-coded Supabase URL/key with `import.meta.env` variables
- document Supabase URL and key in `.env` and `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7cbae5c908328bc1dfe19b7a56b5e