### PR TITLE
Add Winston logger with Sentry integration and request logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+logs/
+.env

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const Sentry = require('@sentry/node');
+const logger = require('./logger');
+
+const app = express();
+
+if (process.env.SENTRY_DSN) {
+  Sentry.init({ dsn: process.env.SENTRY_DSN });
+  app.use(Sentry.Handlers.requestHandler());
+}
+
+// Request logging middleware
+app.use((req, res, next) => {
+  res.on('finish', () => {
+    logger.info(`${req.method} ${req.originalUrl} ${res.statusCode}`);
+  });
+  next();
+});
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Service is running' });
+});
+
+if (process.env.SENTRY_DSN) {
+  app.use(Sentry.Handlers.errorHandler());
+}
+
+// Error handling middleware
+app.use((err, req, res, next) => {
+  logger.error(err);
+  res.status(500).json({ error: 'Internal Server Error' });
+});
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => logger.info(`Server listening on port ${port}`));
+}
+
+module.exports = app;

--- a/backend/logger.js
+++ b/backend/logger.js
@@ -1,0 +1,41 @@
+const { createLogger, format, transports } = require('winston');
+const DailyRotateFile = require('winston-daily-rotate-file');
+let SentryTransport;
+try {
+  SentryTransport = require('winston-transport-sentry-node').default;
+} catch (err) {
+  SentryTransport = null;
+}
+
+const logFormat = format.combine(
+  format.timestamp(),
+  format.json()
+);
+
+const logger = createLogger({
+  level: process.env.LOG_LEVEL || 'info',
+  format: logFormat,
+  transports: [
+    new transports.Console({
+      format: format.combine(format.colorize(), format.simple()),
+    }),
+    new DailyRotateFile({
+      filename: 'logs/application-%DATE%.log',
+      datePattern: 'YYYY-MM-DD',
+      zippedArchive: true,
+      maxSize: '20m',
+      maxFiles: '14d',
+    }),
+  ],
+});
+
+if (process.env.SENTRY_DSN && SentryTransport) {
+  logger.add(
+    new SentryTransport({
+      sentry: { dsn: process.env.SENTRY_DSN },
+      level: 'error',
+    })
+  );
+}
+
+module.exports = logger;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "wathaci-connect.-v1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node backend/app.js",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@sentry/node": "^7.120.0",
+    "express": "^4.18.2",
+    "winston": "^3.9.0",
+    "winston-daily-rotate-file": "^4.7.1",
+    "winston-transport-sentry-node": "^2.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add Winston logger with log rotation and optional Sentry transport
- create Express app with request logging middleware and Sentry error tracking
- configure package with required dependencies and scripts

## Testing
- `npm test`
- `npm install express winston winston-daily-rotate-file winston-transport-sentry-node @sentry/node` *(fails: 403 Forbidden)*
- `node backend/app.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68b7b09821e88328a675eb20300f42c0