### PR TITLE
chore: add lighthouse and accessibility test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+
+## Testing
+
+Lighthouse and automated accessibility checks are available via npm scripts.
+
+```bash
+# Run accessibility tests powered by jest-axe
+npm run test:accessibility
+
+# Generate a Lighthouse report (requires a running dev server)
+npm run test:lighthouse
+```
+
+Make sure project dependencies are installed before executing the test commands.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "node --test",
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",
-    "test:accessibility": "jest --testPathPatterns=\"accessibility\""
+    "test:accessibility": "jest --testPathPatterns=\"accessibility\"",
+    "test:lighthouse": "lighthouse http://localhost:5173 --quiet --no-update-notifier --chrome-flags='--headless'"
   },
   "dependencies": {
     "@eslint/js": "^9.9.0",
@@ -101,6 +102,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "lighthouse": "^12.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add npm script for Lighthouse auditing and include Lighthouse dependency
- document how to run accessibility and Lighthouse tests

## Testing
- `npm run test:accessibility` *(fails: jest: not found)*
- `npm run test:lighthouse` *(fails: lighthouse: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dd813070832887109c158754a114