### PR TITLE
feat: add admin moderation for listings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import FreelancerHub from "./pages/FreelancerHub";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import Messages from "./pages/Messages";
+import AdminModeration from "./pages/AdminModeration";
 
 const queryClient = new QueryClient();
 
@@ -37,6 +38,7 @@ export const AppRoutes = () => (
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
     <Route path="/terms-of-service" element={<TermsOfService />} />
     <Route path="/messages" element={<Messages />} />
+    <Route path="/admin/moderation" element={<AdminModeration />} />
     <Route path="*" element={<NotFound />} />
   </Routes>
 );

--- a/src/__tests__/AppRoutes.test.tsx
+++ b/src/__tests__/AppRoutes.test.tsx
@@ -18,6 +18,7 @@ jest.mock('../pages/FreelancerHub', () => ({ default: () => <div>Freelancer Hub 
 jest.mock('../pages/PrivacyPolicy', () => ({ default: () => <div>Privacy Policy Page</div> }));
 jest.mock('../pages/TermsOfService', () => ({ default: () => <div>Terms Of Service Page</div> }));
 jest.mock('../pages/Messages', () => ({ default: () => <div>Messages Page</div> }));
+jest.mock('../pages/AdminModeration', () => ({ default: () => <div>Admin Moderation Page</div> }));
 
 const routes = [
   { path: '/', text: 'Home Page' },
@@ -33,6 +34,7 @@ const routes = [
   { path: '/privacy-policy', text: 'Privacy Policy Page' },
   { path: '/terms-of-service', text: 'Terms Of Service Page' },
   { path: '/messages', text: 'Messages Page' },
+  { path: '/admin/moderation', text: 'Admin Moderation Page' },
 ];
 
 describe('AppRoutes', () => {

--- a/src/pages/AdminModeration.tsx
+++ b/src/pages/AdminModeration.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import AppLayout from '@/components/AppLayout';
+import { Button } from '@/components/ui/button';
+import { supabase } from '@/lib/supabase';
+
+interface Listing {
+  id: string;
+  title: string;
+  type: 'product' | 'service';
+  seller_id: string;
+}
+
+const AdminModeration = () => {
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPending = async () => {
+      const { data, error } = await supabase
+        .from<Listing>('listings')
+        .select('*')
+        .eq('status', 'pending');
+
+      if (!error && data) {
+        setListings(data);
+      }
+      setLoading(false);
+    };
+
+    fetchPending();
+  }, []);
+
+  const handleDecision = async (listing: Listing, approve: boolean) => {
+    const status = approve ? 'approved' : 'rejected';
+
+    const { error } = await supabase
+      .from('listings')
+      .update({ status })
+      .eq('id', listing.id);
+
+    if (!error) {
+      // Notify seller via Supabase edge function and in-app message
+      await supabase.functions.invoke('notify-seller', {
+        body: { sellerId: listing.seller_id, listingId: listing.id, status },
+      });
+
+      await supabase.from('notifications').insert({
+        user_id: listing.seller_id,
+        message: `Your listing "${listing.title}" was ${status}.`,
+      });
+
+      setListings(prev => prev.filter(l => l.id !== listing.id));
+    }
+  };
+
+  return (
+    <AppLayout>
+      <div className="max-w-4xl mx-auto py-8">
+        <h1 className="text-3xl font-bold mb-6">Pending Listings</h1>
+        {loading ? (
+          <p>Loading...</p>
+        ) : listings.length === 0 ? (
+          <p>No pending listings.</p>
+        ) : (
+          <ul className="space-y-4">
+            {listings.map(listing => (
+              <li
+                key={listing.id}
+                className="border rounded p-4 flex items-center justify-between"
+              >
+                <div>
+                  <p className="font-semibold">{listing.title}</p>
+                  <p className="text-sm text-gray-500">{listing.type}</p>
+                </div>
+                <div className="space-x-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => handleDecision(listing, false)}
+                  >
+                    Reject
+                  </Button>
+                  <Button onClick={() => handleDecision(listing, true)}>
+                    Approve
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </AppLayout>
+  );
+};
+
+export default AdminModeration;

--- a/supabase/listings_policies.sql
+++ b/supabase/listings_policies.sql
@@ -1,0 +1,27 @@
+-- Enable row level security on listings table
+alter table public.listings enable row level security;
+
+-- Allow admins to view pending listings
+create policy "Admins can view pending listings" on public.listings
+for select using (
+  status = 'pending' and
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid() and p.account_type = 'admin'
+  )
+);
+
+-- Only admins can approve or reject listings
+create policy "Admins can moderate listings" on public.listings
+for update using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid() and p.account_type = 'admin'
+  )
+) with check (
+  status in ('approved','rejected') and
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid() and p.account_type = 'admin'
+  )
+);


### PR DESCRIPTION
## Summary
- add AdminModeration page to review pending listings
- route page in app and test coverage
- add RLS policies ensuring only admins can moderate listings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7faf9bc808328a392bb0be2f48109