### PR TITLE
Add ChatBot component and OpenAI proxy

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -16,6 +16,9 @@ app.use('/users', userRoutes);
 const authRoutes = require('./routes/auth');
 app.use('/auth', authRoutes);
 
+const chatbotRoutes = require('./routes/chatbot');
+app.use('/chatbot', chatbotRoutes);
+
 app.use(errorHandler);
 
 process.on('unhandledRejection', (reason) => {

--- a/backend/routes/chatbot.js
+++ b/backend/routes/chatbot.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router();
+const Joi = require('joi');
+const validate = require('../middleware/validate');
+
+const messageSchema = Joi.object({
+  message: Joi.string().required()
+});
+
+router.post('/', validate(messageSchema), async (req, res, next) => {
+  try {
+    const { message } = req.body;
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: message }]
+      })
+    });
+    const data = await response.json();
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/src/components/ChatBot.tsx
+++ b/src/components/ChatBot.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const ChatBot = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text) return;
+    const userMessage: Message = { role: 'user', content: text };
+    setMessages((prev) => [...prev, userMessage]);
+    setInput('');
+    try {
+      const res = await fetch('/chatbot', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+      });
+      const data = await res.json();
+      const reply =
+        data.choices?.[0]?.message?.content?.trim() || 'No response';
+      const botMessage: Message = { role: 'assistant', content: reply };
+      setMessages((prev) => [...prev, botMessage]);
+    } catch (err: any) {
+      setMessages((prev) => [
+        ...prev,
+        { role: 'assistant', content: `Error: ${err.message}` }
+      ]);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 w-80 bg-white border rounded-lg shadow-lg flex flex-col max-h-96">
+      <div className="flex-1 overflow-y-auto p-2 space-y-2">
+        {messages.map((msg, idx) => (
+          <div
+            key={idx}
+            className={`text-sm ${msg.role === 'user' ? 'text-right' : ''}`}
+          >
+            <span
+              className={`inline-block px-2 py-1 rounded ${
+                msg.role === 'user'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200'
+              }`}
+            >
+              {msg.content}
+            </span>
+          </div>
+        ))}
+      </div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          sendMessage();
+        }}
+        className="p-2 border-t flex gap-2"
+      >
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a message..."
+          className="flex-1"
+        />
+        <Button type="submit">Send</Button>
+      </form>
+    </div>
+  );
+};
+
+export default ChatBot;

--- a/src/pages/FreelancerHub.tsx
+++ b/src/pages/FreelancerHub.tsx
@@ -7,13 +7,15 @@ import { DonateButton } from '@/components/DonateButton';
 import AppLayout from '@/components/AppLayout';
 import IndustryMatcher from '@/components/industry/IndustryMatcher';
 import { Users, Lightbulb, Heart, Target } from 'lucide-react';
+import ChatBot from '@/components/ChatBot';
 
 const FreelancerHub = () => {
   const [activeTab, setActiveTab] = useState('directory');
 
   return (
-    <AppLayout>
-      <div className="min-h-screen bg-gray-50">
+    <>
+      <AppLayout>
+        <div className="min-h-screen bg-gray-50">
         <div className="bg-gradient-to-r from-blue-600 to-emerald-600 text-white py-16">
           <div className="max-w-6xl mx-auto px-6">
             <div className="flex items-center justify-between">
@@ -89,7 +91,9 @@ const FreelancerHub = () => {
           </Tabs>
         </div>
       </div>
-    </AppLayout>
+      </AppLayout>
+      <ChatBot />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- create ChatBot UI component with message list and input
- proxy user messages to OpenAI Chat Completions via new backend route
- mount ChatBot widget on FreelancerHub page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b873c575d88328a6c7598aba58df9e