### PR TITLE
feat: add team members table migration and seed script

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -363,3 +363,18 @@ console.log('Auth:', health.details.auth);
 2. Use `healthCheck()` for comprehensive status
 3. Check browser network tab for request details
 4. Enable Supabase logging for detailed query information
+## Additional Tables
+
+### `team_members` Table
+
+```sql
+id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+name TEXT NOT NULL,
+role TEXT NOT NULL,
+bio TEXT,
+avatar TEXT,
+expertise TEXT[],
+qualifications TEXT[]
+```
+
+The `team_members` table stores profiles displayed on team pages and can be seeded using the `scripts/seed-team-members.ts` script.

--- a/scripts/seed-team-members.ts
+++ b/scripts/seed-team-members.ts
@@ -1,0 +1,73 @@
+/**
+ * Seed script for initial team members
+ *
+ * This script inserts initial records into the `team_members` table.
+ * It expects Supabase environment variables to be available.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+
+function loadEnv() {
+  const envPath = resolve(process.cwd(), '.env');
+  try {
+    const envFile = readFileSync(envPath, 'utf8');
+    for (const line of envFile.split('\n')) {
+      const match = line.match(/^\s*([^#=]+?)\s*=\s*(.*)\s*$/);
+      if (!match) continue;
+      const key = match[1].trim();
+      let value = match[2].trim();
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) {
+        process.env[key] = value;
+      }
+    }
+  } catch {
+    // Ignore if .env does not exist
+  }
+}
+
+loadEnv();
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Missing Supabase configuration');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function seed() {
+  const { error } = await supabase.from('team_members').upsert([
+    {
+      name: 'Jane Doe',
+      role: 'Chief Executive Officer',
+      bio: 'Visionary leader with over 10 years in the industry.',
+      avatar: 'https://example.com/avatars/jane.jpg',
+      expertise: ['Leadership', 'Strategy'],
+      qualifications: ['MBA']
+    },
+    {
+      name: 'John Smith',
+      role: 'Chief Technology Officer',
+      bio: 'Tech enthusiast focused on scalable solutions.',
+      avatar: 'https://example.com/avatars/john.jpg',
+      expertise: ['Engineering', 'AI'],
+      qualifications: ['MSc Computer Science']
+    }
+  ]);
+
+  if (error) {
+    console.error('Failed to seed team_members:', error.message);
+    process.exit(1);
+  }
+
+  console.log('team_members table seeded successfully');
+}
+
+seed();

--- a/supabase/migrations/001_create_team_members_table.sql
+++ b/supabase/migrations/001_create_team_members_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS public.team_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    role TEXT NOT NULL,
+    bio TEXT,
+    avatar TEXT,
+    expertise TEXT[],
+    qualifications TEXT[]
+);


### PR DESCRIPTION
## Summary
- add SQL migration for team_members table
- create TypeScript seed script with sample team members
- document new table in DATABASE_SETUP.md

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b870d640d48328ad4099f6baf87be9