### PR TITLE
Add About page with team member query

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import Messages from "./pages/Messages";
 import FeedbackWidget from "@/components/FeedbackWidget";
+import About from "./pages/About";
 
 const queryClient = new QueryClient();
 
@@ -35,6 +36,7 @@ export const AppRoutes = () => (
     <Route path="/profile-review" element={<ProfileReview />} />
     <Route path="/subscription-plans" element={<SubscriptionPlans />} />
     <Route path="/partnership-hub" element={<PartnershipHub />} />
+    <Route path="/about" element={<About />} />
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
     <Route path="/terms-of-service" element={<TermsOfService />} />
     <Route path="/messages" element={<Messages />} />

--- a/src/components/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard.tsx
@@ -1,0 +1,35 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
+export interface TeamMember {
+  id: string | number;
+  name: string;
+  role: string;
+  bio?: string;
+  avatar_url?: string;
+}
+
+interface TeamMemberCardProps {
+  member: TeamMember;
+}
+
+export const TeamMemberCard = ({ member }: TeamMemberCardProps) => (
+  <Card className="flex flex-col items-center text-center">
+    <CardHeader className="flex flex-col items-center">
+      <Avatar className="w-24 h-24 mb-4">
+        <AvatarImage src={member.avatar_url} alt={member.name} />
+        <AvatarFallback>{member.name?.charAt(0)}</AvatarFallback>
+      </Avatar>
+      <CardTitle>{member.name}</CardTitle>
+      <p className="text-sm text-muted-foreground">{member.role}</p>
+    </CardHeader>
+    {member.bio && (
+      <CardContent>
+        <p className="text-sm">{member.bio}</p>
+      </CardContent>
+    )}
+  </Card>
+);
+
+export default TeamMemberCard;
+

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,37 @@
+import AppLayout from '@/components/AppLayout';
+import TeamMemberCard, { TeamMember } from '@/components/TeamMemberCard';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabase';
+
+const fetchTeamMembers = async (): Promise<TeamMember[]> => {
+  const { data, error } = await supabase.from('team_members').select('*');
+  if (error) throw error;
+  return data as TeamMember[];
+};
+
+const About = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['team_members'],
+    queryFn: fetchTeamMembers,
+  });
+
+  return (
+    <AppLayout>
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-4xl font-bold mb-8 text-center">Meet the Team</h1>
+        {isLoading && <p>Loading team members...</p>}
+        {error && <p>Failed to load team members.</p>}
+        {data && (
+          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+            {data.map(member => (
+              <TeamMemberCard key={member.id} member={member} />
+            ))}
+          </div>
+        )}
+      </div>
+    </AppLayout>
+  );
+};
+
+export default About;
+


### PR DESCRIPTION
## Summary
- create TeamMemberCard component for displaying team members
- add About page that fetches team_members via React Query and shows cards in responsive grid
- register About route

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b870e24f748328b00dbeeca8ae4c89