### PR TITLE
Add About Us and Funding Hub navigation links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,12 +13,14 @@ import { SignIn } from "./pages/SignIn";
 import { GetStarted } from "./pages/GetStarted";
 import { SubscriptionPlans } from "./pages/SubscriptionPlans";
 import { PartnershipHub } from "./pages/PartnershipHub";
+import FundingHub from "./pages/FundingHub";
 import { ProfileSetup } from "./pages/ProfileSetup";
 import { ProfileReview } from "./components/ProfileReview";
 import FreelancerHub from "./pages/FreelancerHub";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import Messages from "./pages/Messages";
+import AboutUs from "./pages/AboutUs";
 
 const queryClient = new QueryClient();
 
@@ -34,8 +36,10 @@ export const AppRoutes = () => (
     <Route path="/profile-review" element={<ProfileReview />} />
     <Route path="/subscription-plans" element={<SubscriptionPlans />} />
     <Route path="/partnership-hub" element={<PartnershipHub />} />
+    <Route path="/funding-hub" element={<FundingHub />} />
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
     <Route path="/terms-of-service" element={<TermsOfService />} />
+    <Route path="/about-us" element={<AboutUs />} />
     <Route path="/messages" element={<Messages />} />
     <Route path="*" element={<NotFound />} />
   </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,9 @@ const Header = () => {
     { name: 'Marketplace', href: '/marketplace' },
     { name: 'Freelancer Hub', href: '/freelancer-hub' },
     { name: 'Resources', href: '/resources' },
-    { name: 'Partnership Hub', href: '/partnership-hub' }
+    { name: 'Partnership Hub', href: '/partnership-hub' },
+    { name: 'Funding Hub', href: '/funding-hub' },
+    { name: 'About Us', href: '/about-us' }
   ];
 
   const handleSignOut = async () => {

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -42,7 +42,7 @@ describe('Header', () => {
 
     renderHeader();
 
-    const navLinks = ['Home', 'Marketplace', 'Freelancer Hub', 'Resources', 'Partnership Hub'];
+    const navLinks = ['Home', 'Marketplace', 'Freelancer Hub', 'Resources', 'Partnership Hub', 'Funding Hub', 'About Us'];
     navLinks.forEach((text) => {
       expect(screen.getByText(text)).toBeInTheDocument();
     });

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -1,0 +1,24 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function AboutUs() {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-3xl font-bold text-center">About Us</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <p>
+            WATHACI CONNECT empowers entrepreneurs and organizations by linking them with the
+            resources, partners, and funding needed to grow their impact across Zambia.
+          </p>
+          <p>
+            Our platform fosters collaboration and innovation through AI-powered matching tools,
+            comprehensive business resources, and a vibrant community of stakeholders.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add routing and navigation entries for Funding Hub and new About Us page
- Implement simple About Us page content
- Update header tests to cover new navigation links

## Testing
- `npm test`
- `npm run test:jest` *(fails: no tests found / hang)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2cba8f7d88328b2cad47e392cd2b2