### PR TITLE
feat: add funding matcher functions

### DIFF
--- a/backend/supabase-functions/funding-data.ts
+++ b/backend/supabase-functions/funding-data.ts
@@ -1,0 +1,130 @@
+export interface FundingOpportunity {
+  id: string;
+  title: string;
+  organization: string;
+  description: string;
+  amount: number; // in USD for simplicity
+  deadline: string; // ISO date string
+  sectors: string[];
+  countries: string[];
+  type: string;
+  requirements: string[];
+}
+
+export interface Professional {
+  id: string;
+  name: string;
+  expertise: string[];
+  experience: string;
+  successRate: number; // 0-1
+  rating: number; // 0-5
+  hourlyRate: string;
+  availability: string;
+}
+
+export const fundingOpportunities: FundingOpportunity[] = [
+  {
+    id: 'pepfar-2024',
+    title: 'PEPFAR Small Grants Program',
+    organization: 'U.S. Embassy Lusaka',
+    description: 'Community-based HIV/AIDS projects for Zambian organizations.',
+    amount: 50000,
+    deadline: '2024-04-30',
+    sectors: ['healthcare', 'community'],
+    countries: ['zambia'],
+    type: 'Grant',
+    requirements: ['Zambian registration', 'HIV/AIDS focus']
+  },
+  {
+    id: 'tef-2024',
+    title: 'Tony Elumelu Foundation Entrepreneurship Programme',
+    organization: 'Tony Elumelu Foundation',
+    description: 'Seed capital and training for African startups in any sector.',
+    amount: 5000,
+    deadline: '2024-03-31',
+    sectors: ['agriculture', 'technology', 'services', 'manufacturing'],
+    countries: ['zambia', 'nigeria', 'kenya', 'ghana'],
+    type: 'Seed Funding',
+    requirements: ['African-owned business', '0-3 years old']
+  },
+  {
+    id: 'usadf-2024',
+    title: 'USADF Grants for African-owned SMEs',
+    organization: 'U.S. African Development Foundation',
+    description: 'Up to $250k for growth-oriented, impact-focused businesses.',
+    amount: 250000,
+    deadline: '2024-08-31',
+    sectors: ['agriculture', 'renewable', 'technology'],
+    countries: ['zambia', 'kenya', 'uganda', 'ghana'],
+    type: 'Grant',
+    requirements: ['African ownership', 'Impact metrics']
+  },
+  {
+    id: 'ceec-2024',
+    title: 'CEEC Matching Grants',
+    organization: 'Citizens Economic Empowerment Commission',
+    description: 'Zambian government financing for priority sectors.',
+    amount: 100000,
+    deadline: '2024-06-30',
+    sectors: ['agriculture', 'manufacturing', 'tourism'],
+    countries: ['zambia'],
+    type: 'Matching Grant',
+    requirements: ['Zambian SMEs', 'Co-financing required']
+  },
+  {
+    id: 'afawa-2024',
+    title: 'AFAWA Guarantee for Growth',
+    organization: 'African Development Bank',
+    description: 'Risk-sharing facility to boost lending to women-owned SMEs.',
+    amount: 500000,
+    deadline: '2024-12-31',
+    sectors: ['all'],
+    countries: ['zambia', 'kenya', 'tanzania'],
+    type: 'Guarantee',
+    requirements: ['Women-owned business', 'Through partner bank']
+  }
+];
+
+export const professionals: Professional[] = [
+  {
+    id: 'bongohive',
+    name: 'BongoHive Consult',
+    expertise: ['technology', 'grant writing', 'social enterprise'],
+    experience: '10 years',
+    successRate: 0.8,
+    rating: 4.8,
+    hourlyRate: 'ZMW 500',
+    availability: 'Available'
+  },
+  {
+    id: 'impact-capital-africa',
+    name: 'Impact Capital Africa',
+    expertise: ['agriculture', 'investor readiness', 'fundraising'],
+    experience: '8 years',
+    successRate: 0.75,
+    rating: 4.7,
+    hourlyRate: 'ZMW 600',
+    availability: 'Available'
+  },
+  {
+    id: 'grant-thornton-zambia',
+    name: 'Grant Thornton Zambia',
+    expertise: ['finance', 'audit', 'grant management'],
+    experience: '15 years',
+    successRate: 0.7,
+    rating: 4.6,
+    hourlyRate: 'ZMW 800',
+    availability: 'Limited'
+  },
+  {
+    id: 'ngoma-consulting',
+    name: 'Ngoma Consulting Services',
+    expertise: ['community', 'healthcare', 'education'],
+    experience: '12 years',
+    successRate: 0.65,
+    rating: 4.5,
+    hourlyRate: 'ZMW 450',
+    availability: 'Available'
+  }
+];
+

--- a/backend/supabase-functions/funding-matcher.ts
+++ b/backend/supabase-functions/funding-matcher.ts
@@ -1,0 +1,78 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { fundingOpportunities } from './funding-data.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+interface BusinessProfile {
+  businessType: string;
+  sector: string;
+  stage?: string;
+  location: string;
+  employees?: string;
+}
+
+interface FundingNeeds {
+  amount: string;
+  purpose?: string;
+  timeline?: string;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { businessProfile, fundingNeeds }: { businessProfile: BusinessProfile; fundingNeeds: FundingNeeds } = await req.json();
+
+    const matches = fundingOpportunities.map((opp) => {
+      let score = 0;
+      const reasons: string[] = [];
+
+      if (opp.sectors.includes(businessProfile.sector.toLowerCase()) || opp.sectors.includes('all')) {
+        score += 40;
+        reasons.push(`Matches sector ${businessProfile.sector}`);
+      }
+
+      if (opp.countries.includes(businessProfile.location.toLowerCase())) {
+        score += 30;
+        reasons.push(`Available in ${businessProfile.location}`);
+      }
+
+      const amount = parseFloat(fundingNeeds.amount);
+      if (!isNaN(amount) && amount <= opp.amount) {
+        score += 30;
+        reasons.push('Requested amount within limit');
+      }
+
+      return {
+        title: opp.title,
+        provider: opp.organization,
+        description: opp.description,
+        max_amount: opp.amount,
+        funding_type: opp.type,
+        application_deadline: opp.deadline,
+        match_score: score,
+        reasoning: reasons.join('; ')
+      };
+    })
+    .filter(match => match.match_score > 0)
+    .sort((a, b) => b.match_score - a.match_score)
+    .slice(0, 5);
+
+    return new Response(
+      JSON.stringify({ matches }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
+    );
+  } catch (error) {
+    console.error('Funding matcher error:', error);
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+    );
+  }
+});

--- a/backend/supabase-functions/live-funding-matcher.ts
+++ b/backend/supabase-functions/live-funding-matcher.ts
@@ -1,0 +1,72 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { fundingOpportunities } from './funding-data.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+async function fetchGrantsGov() {
+  const url = 'https://www.grants.gov/grantsws/rest/opportunities/search?keyword=Zambia&startRecordNum=0&sortBy=closeDate&orderBy=asc';
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch grants.gov');
+  const data = await res.json();
+  return (data.opportunities?.opportunity || []).map((opp: any) => ({
+    id: opp.id || opp.opportunityId,
+    title: opp.title || opp.opportunityTitle,
+    organization: opp.agency || opp.agencyName,
+    amount: 'See notice',
+    deadline: opp.closeDate || opp.closeDateDisplay,
+    sectors: ['all'],
+    countries: ['zambia'],
+    type: 'Grant',
+    matchScore: 50,
+    successRate: 0.5,
+    requirements: []
+  }));
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { action } = await req.json();
+    if (action !== 'fetch_live_opportunities') {
+      throw new Error('Unknown action');
+    }
+
+    let opportunities = [];
+    try {
+      opportunities = await fetchGrantsGov();
+    } catch (err) {
+      console.error('External fetch failed, using static data:', err);
+      opportunities = fundingOpportunities.map((opp) => ({
+        id: opp.id,
+        title: opp.title,
+        organization: opp.organization,
+        amount: `Up to $${opp.amount.toLocaleString()}`,
+        deadline: opp.deadline,
+        sectors: opp.sectors,
+        countries: opp.countries,
+        type: opp.type,
+        matchScore: 80,
+        successRate: 0.6,
+        requirements: opp.requirements
+      }));
+    }
+
+    return new Response(
+      JSON.stringify({ opportunities }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
+    );
+  } catch (error) {
+    console.error('Live funding matcher error:', error);
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+    );
+  }
+});

--- a/backend/supabase-functions/matched-professionals.ts
+++ b/backend/supabase-functions/matched-professionals.ts
@@ -1,0 +1,41 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { professionals, fundingOpportunities } from './funding-data.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { opportunityId } = await req.json();
+    const opportunity = fundingOpportunities.find(o => o.id === opportunityId);
+    if (!opportunity) {
+      throw new Error('Opportunity not found');
+    }
+
+    const matches = professionals.map((prof) => {
+      const overlap = prof.expertise.filter(skill =>
+        opportunity.sectors.includes(skill.toLowerCase()) || opportunity.sectors.includes('all')
+      );
+      const matchScore = Math.round((overlap.length / opportunity.sectors.length) * 100);
+      return { ...prof, matchScore };
+    }).filter(p => p.matchScore > 0);
+
+    return new Response(
+      JSON.stringify({ professionals: matches }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
+    );
+  } catch (error) {
+    console.error('Matched professionals error:', error);
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add sample funding opportunities and professional directories
- implement funding matcher edge function
- add live opportunity fetch with fallback data
- match professionals to selected funding opportunities

## Testing
- `npm test`
- `npm run test:accessibility`
- `npm run test:lighthouse` *(fails: CHROME_PATH env variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d10e2fe88328b97748827f07768f