### PR TITLE
Validate mobile money fields and sanitize payment description

### DIFF
--- a/src/lib/services/lenco-payment-service.ts
+++ b/src/lib/services/lenco-payment-service.ts
@@ -200,6 +200,21 @@ export class LencoPaymentService {
       return { isValid: false, error: 'Payment description is required' };
     }
 
+    // Sanitize description length and remove potential HTML tags
+    const sanitizedDescription = request.description.replace(/<[^>]*>/g, '').trim();
+    const MAX_DESCRIPTION_LENGTH = 200;
+    request.description = sanitizedDescription.slice(0, MAX_DESCRIPTION_LENGTH);
+
+    if (request.payment_method === 'mobile_money') {
+      if (!request.provider) {
+        return { isValid: false, error: 'Mobile money provider is required' };
+      }
+
+      if (!request.phone || !validatePhoneNumber(request.phone, this.config.country)) {
+        return { isValid: false, error: 'Valid mobile money phone number is required' };
+      }
+    }
+
     return { isValid: true };
   }
 

--- a/src/lib/testing/payment-test-suite.ts
+++ b/src/lib/testing/payment-test-suite.ts
@@ -54,6 +54,32 @@ export class PaymentTestSuite {
       category: 'validation'
     },
     {
+      name: 'Missing Provider',
+      description: 'Test mobile money payment without provider',
+      testData: {
+        amount: 50,
+        phone: '0978123456',
+        email: 'test@example.com',
+        name: 'Test User',
+        description: 'Test payment'
+      },
+      expectedResult: 'failure',
+      category: 'validation'
+    },
+    {
+      name: 'Missing Phone Number',
+      description: 'Test mobile money payment without phone number',
+      testData: {
+        amount: 50,
+        provider: 'mtn',
+        email: 'test@example.com',
+        name: 'Test User',
+        description: 'Test payment'
+      },
+      expectedResult: 'failure',
+      category: 'validation'
+    },
+    {
       name: 'Invalid Email',
       description: 'Test payment with invalid email',
       testData: {


### PR DESCRIPTION
## Summary
- require mobile money `provider` and validated `phone` in payment request validation
- sanitize payment `description` by stripping HTML and limiting length
- expand payment test suite to cover missing provider and phone cases

## Testing
- `npm test`
- `npm run test:jest` *(fails: Test Suites: 0 of 19 total)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c317bd255c8328bdd2026a76060a53