### PR TITLE
Add audit logger service and admin audit log page

### DIFF
--- a/backend/services/auditLogger.ts
+++ b/backend/services/auditLogger.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+const LOG_DIR = path.join(__dirname, '..', 'logs');
+const LOG_FILE = path.join(LOG_DIR, 'audit.log');
+
+function ensureLogFile() {
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+  if (!fs.existsSync(LOG_FILE)) {
+    fs.writeFileSync(LOG_FILE, '', { mode: 0o600 });
+  }
+}
+
+export interface DonationLogEntry {
+  action: 'created' | 'refunded';
+  donationId: string;
+  amount: number;
+  userId?: string;
+  timestamp: string;
+}
+
+function logDonationEvent(entry: Omit<DonationLogEntry, 'timestamp'>) {
+  ensureLogFile();
+  const record: DonationLogEntry = {
+    ...entry,
+    timestamp: new Date().toISOString(),
+  };
+  fs.appendFileSync(LOG_FILE, JSON.stringify(record) + '\n', {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+}
+
+export const logDonationCreated = (
+  donationId: string,
+  amount: number,
+  userId?: string,
+) => {
+  logDonationEvent({ action: 'created', donationId, amount, userId });
+};
+
+export const logDonationRefunded = (
+  donationId: string,
+  amount: number,
+  userId?: string,
+) => {
+  logDonationEvent({ action: 'refunded', donationId, amount, userId });
+};
+
+export default { logDonationCreated, logDonationRefunded };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import FreelancerHub from "./pages/FreelancerHub";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import Messages from "./pages/Messages";
+import AuditLog from "./pages/admin/AuditLog";
 
 const queryClient = new QueryClient();
 
@@ -37,6 +38,7 @@ export const AppRoutes = () => (
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
     <Route path="/terms-of-service" element={<TermsOfService />} />
     <Route path="/messages" element={<Messages />} />
+    <Route path="/admin/audit-log" element={<AuditLog />} />
     <Route path="*" element={<NotFound />} />
   </Routes>
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import FreelancerHub from "./pages/FreelancerHub";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import Messages from "./pages/Messages";
+import AuditLog from "./pages/admin/AuditLog";
 
 const queryClient = new QueryClient();
 
@@ -37,6 +38,7 @@ export const AppRoutes = () => (
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
     <Route path="/terms-of-service" element={<TermsOfService />} />
     <Route path="/messages" element={<Messages />} />
+    <Route path="/admin/audit-log" element={<AuditLog />} />
     <Route path="*" element={<NotFound />} />
   </Routes>
 );

--- a/src/__tests__/AppRoutes.test.tsx
+++ b/src/__tests__/AppRoutes.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../pages/FreelancerHub', () => ({ default: () => <div>Freelancer Hub Pa
 vi.mock('../pages/PrivacyPolicy', () => ({ default: () => <div>Privacy Policy Page</div> }));
 vi.mock('../pages/TermsOfService', () => ({ default: () => <div>Terms Of Service Page</div> }));
 vi.mock('../pages/Messages', () => ({ default: () => <div>Messages Page</div> }));
+vi.mock('../pages/admin/AuditLog', () => ({ default: () => <div>Audit Log Page</div> }));
 
 const routes = [
   { path: '/', text: 'Home Page' },
@@ -33,6 +34,7 @@ const routes = [
   { path: '/privacy-policy', text: 'Privacy Policy Page' },
   { path: '/terms-of-service', text: 'Terms Of Service Page' },
   { path: '/messages', text: 'Messages Page' },
+  { path: '/admin/audit-log', text: 'Audit Log Page' },
 ];
 
 describe('AppRoutes', () => {

--- a/src/pages/admin/AuditLog.tsx
+++ b/src/pages/admin/AuditLog.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import AppLayout from '@/components/AppLayout';
+
+type LogEvent = 'created' | 'refunded';
+
+interface AuditLogEntry {
+  id: string;
+  event: LogEvent;
+  donationId: string;
+  amount: number;
+  userId?: string;
+  timestamp: string;
+}
+
+const PAGE_SIZE = 10;
+
+const AuditLog = () => {
+  const [logs, setLogs] = useState<AuditLogEntry[]>([]);
+  const [page, setPage] = useState(1);
+  const [filter, setFilter] = useState<'all' | LogEvent>('all');
+
+  useEffect(() => {
+    const fetchLogs = async () => {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        limit: PAGE_SIZE.toString(),
+      });
+      if (filter !== 'all') {
+        params.append('event', filter);
+      }
+      try {
+        const res = await fetch(`/api/audit-logs?${params.toString()}`);
+        if (res.ok) {
+          const data = await res.json();
+          setLogs(data.items || []);
+        }
+      } catch {
+        setLogs([]);
+      }
+    };
+    fetchLogs();
+  }, [page, filter]);
+
+  const nextPage = () => setPage((p) => p + 1);
+  const prevPage = () => setPage((p) => Math.max(1, p - 1));
+
+  return (
+    <AppLayout>
+      <div className="container mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Audit Log</h1>
+
+        <div className="mb-4">
+          <label className="mr-2">Filter:</label>
+          <select
+            value={filter}
+            onChange={(e) => {
+              setFilter(e.target.value as 'all' | LogEvent);
+              setPage(1);
+            }}
+            className="border rounded px-2 py-1"
+          >
+            <option value="all">All</option>
+            <option value="created">Created</option>
+            <option value="refunded">Refunded</option>
+          </select>
+        </div>
+
+        <table className="min-w-full bg-white border">
+          <thead>
+            <tr>
+              <th className="px-4 py-2 border">Timestamp</th>
+              <th className="px-4 py-2 border">Event</th>
+              <th className="px-4 py-2 border">Donation ID</th>
+              <th className="px-4 py-2 border">Amount</th>
+              <th className="px-4 py-2 border">User ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {logs.map((log) => (
+              <tr key={log.id}>
+                <td className="px-4 py-2 border">
+                  {new Date(log.timestamp).toLocaleString()}
+                </td>
+                <td className="px-4 py-2 border capitalize">{log.event}</td>
+                <td className="px-4 py-2 border">{log.donationId}</td>
+                <td className="px-4 py-2 border">{log.amount}</td>
+                <td className="px-4 py-2 border">{log.userId || '-'}</td>
+              </tr>
+            ))}
+            {logs.length === 0 && (
+              <tr>
+                <td colSpan={5} className="text-center py-4">
+                  No entries found
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+
+        <div className="flex justify-between items-center mt-4">
+          <button
+            onClick={prevPage}
+            disabled={page === 1}
+            className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <span>Page {page}</span>
+          <button
+            onClick={nextPage}
+            className="px-4 py-2 bg-gray-200 rounded"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default AuditLog;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- create audit logger service to securely persist donation events
- add admin audit log page with filter and pagination
- wire audit log route and test coverage

## Testing
- `npm test`
- `npx vitest run` *(fails: ReferenceError: userService is not defined and other errors)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2af43e0cc8328829edd316b02998d