### PR TITLE
chore: validate payment config fields

### DIFF
--- a/docs/PAYMENT_INTEGRATION_GUIDE.md
+++ b/docs/PAYMENT_INTEGRATION_GUIDE.md
@@ -79,6 +79,14 @@ VITE_APP_ENV="development"
 VITE_APP_NAME="WATHACI CONNECT"
 ```
 
+These payment configuration values are mandatory. The application validates that
+`VITE_PAYMENT_CURRENCY`, `VITE_PAYMENT_COUNTRY`, `VITE_PLATFORM_FEE_PERCENTAGE`,
+`VITE_MIN_PAYMENT_AMOUNT` and `VITE_MAX_PAYMENT_AMOUNT` are present and that the
+numeric fields contain valid numbers. If any of these are missing or invalid,
+warnings such as "Payment currency not configured" or "Platform fee percentage
+not configured or invalid" will be logged and payment features will be
+disabled.
+
 ### Development vs Production
 
 **Development Settings:**

--- a/src/lib/payment-config.ts
+++ b/src/lib/payment-config.ts
@@ -69,12 +69,54 @@ export const getPaymentConfig = (): PaymentConfig => {
 // Validate payment configuration
 export const validatePaymentConfig = (config: PaymentConfig): boolean => {
   if (!config.publicKey) {
-    console.warn('Payment Warning: Lenco public key not configured - payment features will be disabled');
+    console.warn(
+      'Payment Warning: Lenco public key not configured - payment features will be disabled'
+    );
     return false;
   }
-  
+
   if (!config.apiUrl) {
-    console.warn('Payment Warning: Lenco API URL not configured - payment features will be disabled');
+    console.warn(
+      'Payment Warning: Lenco API URL not configured - payment features will be disabled'
+    );
+    return false;
+  }
+
+  if (!config.currency) {
+    console.warn(
+      'Payment Warning: Payment currency not configured - payment features will be disabled'
+    );
+    return false;
+  }
+
+  if (!config.country) {
+    console.warn(
+      'Payment Warning: Payment country not configured - payment features will be disabled'
+    );
+    return false;
+  }
+
+  if (
+    typeof config.platformFeePercentage !== 'number' ||
+    isNaN(config.platformFeePercentage)
+  ) {
+    console.warn(
+      'Payment Warning: Platform fee percentage not configured or invalid - payment features will be disabled'
+    );
+    return false;
+  }
+
+  if (typeof config.minAmount !== 'number' || isNaN(config.minAmount)) {
+    console.warn(
+      'Payment Warning: Minimum payment amount not configured or invalid - payment features will be disabled'
+    );
+    return false;
+  }
+
+  if (typeof config.maxAmount !== 'number' || isNaN(config.maxAmount)) {
+    console.warn(
+      'Payment Warning: Maximum payment amount not configured or invalid - payment features will be disabled'
+    );
     return false;
   }
 


### PR DESCRIPTION
## Summary
- validate currency, country, platform fee percentage, and min/max amounts in `validatePaymentConfig`
- document required payment config variables and new validation warnings

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c317982a9883289927d3817e9aed07