### PR TITLE
feat: map Lenco success status to completed

### DIFF
--- a/src/lib/payment-config.ts
+++ b/src/lib/payment-config.ts
@@ -41,7 +41,7 @@ export interface LencoPaymentResponse {
 
 export interface PaymentStatus {
   reference: string;
-  status: 'pending' | 'success' | 'failed' | 'cancelled';
+  status: 'pending' | 'completed' | 'failed' | 'cancelled';
   amount: number;
   currency: string;
   transaction_id?: string;

--- a/src/lib/services/lenco-payment-service.ts
+++ b/src/lib/services/lenco-payment-service.ts
@@ -235,7 +235,7 @@ export class LencoPaymentService {
    */
   private mapLencoStatus(lencoStatus: string): PaymentStatus['status'] {
     const statusMap: Record<string, PaymentStatus['status']> = {
-      'success': 'success',
+      'success': 'completed',
       'failed': 'failed',
       'pending': 'pending',
       'cancelled': 'cancelled',

--- a/src/lib/services/subscription-service.ts
+++ b/src/lib/services/subscription-service.ts
@@ -147,11 +147,11 @@ export class SubscriptionService extends BaseService<UserSubscription> {
       if (transactionResult.data) {
         await transactionService.updateTransactionStatus(
           transactionResult.data.id,
-          paymentStatus.status === 'success' ? 'completed' : 'failed'
+          paymentStatus.status === 'completed' ? 'completed' : 'failed'
         );
       }
 
-      if (paymentStatus.status === 'success') {
+      if (paymentStatus.status === 'completed') {
         // Find subscription by payment reference
         const { data: subscription, error } = await supabase
           .from('user_subscriptions')


### PR DESCRIPTION
## Summary
- map Lenco API `success` status to internal `completed`
- track completed payments in subscription service
- update payment status typing

## Testing
- `npm test`
- `npm run test:jest` *(fails: TS errors and Vitest ESM issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c317a9a3348328bcac5053e8daaaa2