### PR TITLE
feat: use Wathaci Connect logo on get started form

### DIFF
--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -71,9 +71,13 @@ export const GetStarted = () => {
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-emerald-50 flex items-center justify-center p-4">
       <Card className="w-full max-w-lg">
         <CardHeader className="text-center">
-          <div className="mx-auto w-12 h-12 bg-gradient-to-br from-blue-600 to-emerald-600 rounded-lg flex items-center justify-center mb-4">
-            <span className="text-white font-bold text-xl">W</span>
-          </div>
+          <img
+            src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
+            alt="WATHACI CONNECT"
+            loading="lazy"
+            decoding="async"
+            className="h-20 w-auto mx-auto mb-4 drop-shadow-lg"
+          />
           <CardTitle className="text-2xl">Get Started</CardTitle>
           <CardDescription>Create your WATHACI account</CardDescription>
         </CardHeader>


### PR DESCRIPTION
## Summary
- replace placeholder W with official Wathaci Connect logo on sign-up form

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c3fbf709a48328b04b2f209119fb2e