### PR TITLE
Enhance bio cards with dynamic glossy styling

### DIFF
--- a/src/components/FreelancerDirectory.tsx
+++ b/src/components/FreelancerDirectory.tsx
@@ -129,8 +129,12 @@ export const FreelancerDirectory = () => {
 
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
         {filteredFreelancers.map((freelancer) => (
-          <Card key={freelancer.id} className="hover:shadow-lg transition-shadow">
-            <CardHeader className="text-center">
+          <Card
+            key={freelancer.id}
+            className="group relative overflow-hidden bg-gradient-to-br from-white to-blue-50 shadow-md hover:shadow-2xl transition-all duration-300 hover:-translate-y-1"
+          >
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-white/40 via-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+            <CardHeader className="text-center relative z-10">
               <img
                 src={freelancer.profile_image_url || '/placeholder.svg'}
                 alt={freelancer.name}
@@ -141,7 +145,7 @@ export const FreelancerDirectory = () => {
               <CardTitle className="text-xl">{freelancer.name}</CardTitle>
               <p className="text-gray-600">{freelancer.title}</p>
             </CardHeader>
-            <CardContent>
+            <CardContent className="relative z-10">
               <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center gap-1">
                   <Star className="w-4 h-4 text-yellow-500 fill-current" />
@@ -153,7 +157,7 @@ export const FreelancerDirectory = () => {
                   <span>{freelancer.location}</span>
                 </div>
               </div>
-              
+
               <div className="mb-4">
                 <div className="flex flex-wrap gap-1 mb-2">
                   {freelancer.skills.slice(0, 3).map((skill, idx) => (
@@ -167,8 +171,13 @@ export const FreelancerDirectory = () => {
                     </Badge>
                   )}
                 </div>
+                {freelancer.bio && (
+                  <p className="text-sm text-gray-600 transition-all duration-300 max-h-16 overflow-hidden group-hover:max-h-40">
+                    {freelancer.bio}
+                  </p>
+                )}
               </div>
-              
+
               <div className="flex items-center justify-between mb-4">
                 <div>
                   <span className="text-2xl font-bold text-blue-600">${freelancer.hourly_rate}</span>
@@ -176,19 +185,23 @@ export const FreelancerDirectory = () => {
                 </div>
                 <div className="flex items-center gap-1">
                   <Clock className="w-4 h-4 text-gray-400" />
-                  <span className={`text-sm ${freelancer.availability_status === 'available' ? 'text-green-600' : 'text-orange-600'}`}>
+                  <span
+                    className={`text-sm ${freelancer.availability_status === 'available' ? 'text-green-600' : 'text-orange-600'}`}
+                  >
                     {freelancer.availability_status === 'available' ? 'Available' : 'Busy'}
                   </span>
                 </div>
               </div>
-              
+
               <Dialog>
                 <DialogTrigger asChild>
-                  <Button 
-                    className="w-full bg-orange-600 hover:bg-orange-700" 
+                  <Button
+                    className="w-full bg-orange-600 hover:bg-orange-700"
                     disabled={freelancer.availability_status !== 'available'}
                   >
-                    {freelancer.availability_status === 'available' ? 'Hire & Negotiate' : 'Join Waitlist'}
+                    {freelancer.availability_status === 'available'
+                      ? 'Hire & Negotiate'
+                      : 'Join Waitlist'}
                   </Button>
                 </DialogTrigger>
                 <DialogContent className="max-w-4xl">

--- a/src/components/FreelancerMatcher.tsx
+++ b/src/components/FreelancerMatcher.tsx
@@ -115,14 +115,18 @@ export const FreelancerMatcher = () => {
         <div className="space-y-4">
           <h2 className="text-xl font-semibold">Matched Freelancers</h2>
           {matches.map((freelancer: Freelancer, idx: number) => (
-            <Card key={idx}>
-              <CardContent className="p-6">
+            <Card
+              key={idx}
+              className="group relative overflow-hidden bg-gradient-to-br from-white to-blue-50 shadow-md hover:shadow-2xl transition-all duration-300 hover:-translate-y-1"
+            >
+              <div className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-white/40 via-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+              <CardContent className="p-6 relative z-10">
                 <div className="flex items-start gap-4">
                   <Avatar className="w-16 h-16">
                     <AvatarImage src={freelancer.avatar} alt={freelancer.name} />
                     <AvatarFallback>{freelancer.name?.charAt(0)}</AvatarFallback>
                   </Avatar>
-                  
+
                   <div className="flex-1">
                     <div className="flex justify-between items-start mb-2">
                       <div>
@@ -133,15 +137,19 @@ export const FreelancerMatcher = () => {
                         {freelancer.match_score}% Match
                       </Badge>
                     </div>
-                    
-                    <p className="text-gray-700 mb-3">{freelancer.bio}</p>
-                    
+
+                    {freelancer.bio && (
+                      <p className="text-gray-700 mb-3 transition-all duration-300 max-h-16 overflow-hidden group-hover:max-h-40">
+                        {freelancer.bio}
+                      </p>
+                    )}
+
                     <div className="flex flex-wrap gap-2 mb-3">
                       {freelancer.skills?.slice(0, 5).map((skill: string, skillIdx: number) => (
                         <Badge key={skillIdx} variant="outline">{skill}</Badge>
                       ))}
                     </div>
-                    
+
                     <div className="flex items-center gap-4 text-sm text-gray-600 mb-4">
                       <div className="flex items-center gap-1">
                         <MapPin className="w-4 h-4" />
@@ -156,7 +164,7 @@ export const FreelancerMatcher = () => {
                         {freelancer.rating} ({freelancer.reviews_count} reviews)
                       </div>
                     </div>
-                    
+
                     <div className="flex gap-2">
                       <Button className="flex-1">Contact Freelancer</Button>
                       <Button variant="outline">View Profile</Button>
@@ -170,4 +178,4 @@ export const FreelancerMatcher = () => {
       )}
     </div>
   );
-};
+}; 

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -1,6 +1,25 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
+interface TeamMember {
+  name: string;
+  title: string;
+  bio: string;
+  email: string;
+  phone: string;
+  image?: string;
+}
+
 export default function AboutUs() {
+  const teamMembers: TeamMember[] = [
+    {
+      name: "Kasamwa Kachomba",
+      title: "Lead Consultant",
+      bio: "Kasamwa Kachomba is a seasoned economist and contracts specialist known for steering complex donor-funded initiatives with precision. As Lead Consultant, he blends sharp analytical insight with hands-on project management, ensuring compliance, fostering stakeholder relationships, and unlocking funding for SMEs and institutions. His strengths include proposal development, donor engagement, team leadership, and establishing robust systems that drive sustainable growth. Passionate about empowering businesses, Kasamwa is committed to building strategic partnerships and delivering measurable impact.",
+      email: "kasamwa@wathaci.com",
+      phone: "+260 964 283 538",
+    },
+  ];
+
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl space-y-8">
       <Card>
@@ -22,21 +41,35 @@ export default function AboutUs() {
         <CardHeader>
           <CardTitle className="text-2xl font-bold text-center">Our Team</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-4 text-sm">
-          <p>
-            Kasamwa Kachomba is a seasoned economist and contracts specialist known for steering
-            complex donor-funded initiatives with precision. As Lead Consultant, he blends sharp
-            analytical insight with hands-on project management, ensuring compliance, fostering
-            stakeholder relationships, and unlocking funding for SMEs and institutions. His
-            strengths include proposal development, donor engagement, team leadership, and
-            establishing robust systems that drive sustainable growth. Passionate about empowering
-            businesses, Kasamwa is committed to building strategic partnerships and delivering
-            measurable impact.
-          </p>
-          <p>
-            📧 kasamwa@wathaci.com
-            <br />📱 +260 964 283 538
-          </p>
+        <CardContent className="grid md:grid-cols-2 gap-6">
+          {teamMembers.map((member, idx) => (
+            <Card
+              key={idx}
+              className="group relative overflow-hidden bg-gradient-to-br from-white to-blue-50 shadow-md hover:shadow-2xl transition-all duration-300 hover:-translate-y-1"
+            >
+              <div className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-white/40 via-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+              <CardHeader className="text-center relative z-10">
+                <img
+                  src={member.image || "/placeholder.svg"}
+                  alt={member.name}
+                  loading="lazy"
+                  decoding="async"
+                  className="w-20 h-20 rounded-full mx-auto mb-4 object-cover"
+                />
+                <CardTitle className="text-xl">{member.name}</CardTitle>
+                <p className="text-gray-600">{member.title}</p>
+              </CardHeader>
+              <CardContent className="relative z-10">
+                <p className="text-sm text-gray-600 transition-all duration-300 max-h-16 overflow-hidden group-hover:max-h-40">
+                  {member.bio}
+                </p>
+                <p className="text-sm text-gray-600 mt-4">
+                  📧 {member.email}
+                  <br />📱 {member.phone}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- add gradient backgrounds and hover animations for freelancer bio cards
- expand biographies on hover for richer browsing
- extend glossy card styling to About Us team profiles

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c41b4dfa5c8328916351a882b349a3