### PR TITLE
feat: add LinkedIn links to bio cards

### DIFF
--- a/src/components/FreelancerDirectory.tsx
+++ b/src/components/FreelancerDirectory.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
-import { Star, MapPin, Clock, Search, Filter } from 'lucide-react';
+import { Star, MapPin, Clock, Search, Filter, Linkedin } from 'lucide-react';
 import PriceNegotiation from '@/components/PriceNegotiation';
 import { supabase } from '@/lib/supabase';
 
@@ -24,6 +24,7 @@ interface Freelancer {
   profile_image_url?: string;
   availability_status: string;
   years_experience: number;
+  linkedin_url?: string;
 }
 
 export const FreelancerDirectory = () => {
@@ -140,6 +141,17 @@ export const FreelancerDirectory = () => {
               />
               <CardTitle className="text-xl">{freelancer.name}</CardTitle>
               <p className="text-gray-600">{freelancer.title}</p>
+              {freelancer.linkedin_url && (
+                <a
+                  href={freelancer.linkedin_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-center text-blue-600 hover:underline mt-2 text-sm"
+                >
+                  <Linkedin className="w-4 h-4 mr-1" />
+                  LinkedIn
+                </a>
+              )}
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between mb-4">

--- a/src/components/FreelancerMatcher.tsx
+++ b/src/components/FreelancerMatcher.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { supabase } from '@/lib/supabase';
-import { Search, MapPin, DollarSign, Star, Loader2 } from 'lucide-react';
+import { Search, MapPin, DollarSign, Star, Loader2, Linkedin } from 'lucide-react';
 
 interface Freelancer {
   avatar?: string;
@@ -19,6 +19,7 @@ interface Freelancer {
   hourly_rate?: number;
   rating?: number;
   reviews_count?: number;
+  linkedin_url?: string;
 }
 
 export const FreelancerMatcher = () => {
@@ -135,6 +136,17 @@ export const FreelancerMatcher = () => {
                     </div>
                     
                     <p className="text-gray-700 mb-3">{freelancer.bio}</p>
+                    {freelancer.linkedin_url && (
+                      <a
+                        href={freelancer.linkedin_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center text-sm text-blue-600 hover:underline mb-3"
+                      >
+                        <Linkedin className="w-4 h-4 mr-1" />
+                        LinkedIn
+                      </a>
+                    )}
                     
                     <div className="flex flex-wrap gap-2 mb-3">
                       {freelancer.skills?.slice(0, 5).map((skill: string, skillIdx: number) => (

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Linkedin } from "lucide-react";
 
 export default function AboutUs() {
   return (
@@ -36,6 +37,16 @@ export default function AboutUs() {
           <p>
             📧 kasamwa@wathaci.com
             <br />📱 +260 964 283 538
+            <br />
+            <a
+              href="https://www.linkedin.com/in/kasamwa-kachomba/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center text-blue-600 hover:underline mt-2"
+            >
+              <Linkedin className="w-4 h-4 mr-1" />
+              LinkedIn
+            </a>
           </p>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- allow freelancers to provide a LinkedIn URL
- display a LinkedIn icon link on freelancer bio cards
- add LinkedIn icon link to team bio on About Us page

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c41867ace88328a89b2319104559b8