### PR TITLE
Add Amukena Mukumbuta team bio

### DIFF
--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -5,14 +5,19 @@ interface TeamMember {
   name: string;
   title: string;
   bio: string;
-  email: string;
-  phone: string;
+  email?: string;
+  phone?: string;
   image?: string;
   linkedin_url?: string;
 }
 
 export default function AboutUs() {
   const teamMembers: TeamMember[] = [
+    {
+      name: "Amukena Mukumbuta",
+      title: "Team Lead",
+      bio: "Amukena Mukumbuta is a results-driven SME champion with 15+ years’ experience in operations, compliance, and donor-funded project management. Amukena has overseen £2M+ SME-focused programmes, cutting compliance risks and building systems that help entrepreneurs thrive. Amukena is passionate about unlocking growth for SMEs through practical support—whether it’s compliance guidance, access to finance, or digital transformation. Beyond his corporate role, he leads Wathaci Corporate Services and 440 A.M. Enterprises, platforms designed to equip Zambian SMEs with the tools, networks, and strategies they need to scale sustainably.",
+    },
     {
       name: "Kasamwa Kachomba",
       title: "Lead Consultant",
@@ -67,8 +72,8 @@ export default function AboutUs() {
                   {member.bio}
                 </p>
                 <div className="text-sm text-gray-600 mt-4">
-                  <p>📧 {member.email}</p>
-                  <p>📱 {member.phone}</p>
+                  {member.email && <p>📧 {member.email}</p>}
+                  {member.phone && <p>📱 {member.phone}</p>}
                   {member.linkedin_url && (
                     <a
                       href={member.linkedin_url}


### PR DESCRIPTION
## Summary
- add Amukena Mukumbuta bio card before Kasamwa Kachomba on About Us page
- allow optional contact info and render email and phone only when provided

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:jest` *(fails: TypeScript errors in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c43eb755048328a3738fb6afc0a433