### PR TITLE
Add About Us home navigation arrow and session login persistence

### DIFF
--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -37,7 +37,7 @@ const createSupabaseClient = (): SupabaseClient => {
       persistSession: true,
       detectSessionInUrl: true,
       // Storage for auth tokens
-      storage: window.localStorage,
+      storage: window.sessionStorage,
     },
     global: {
       headers: {

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Linkedin } from "lucide-react";
+import { Linkedin, ArrowLeft } from "lucide-react";
+import { Link } from "react-router-dom";
 
 interface TeamMember {
   name: string;
@@ -35,6 +36,13 @@ export default function AboutUs() {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl space-y-8">
+      <Link
+        to="/"
+        className="inline-flex items-center text-sm text-blue-600 hover:underline"
+      >
+        <ArrowLeft className="mr-1 h-4 w-4" />
+        Back to Home
+      </Link>
       <Card>
         <CardHeader>
           <CardTitle className="text-3xl font-bold text-center">About Us</CardTitle>


### PR DESCRIPTION
## Summary
- add a back-to-home arrow on the About Us page
- persist auth state in session storage so users stay logged in until logout or window close

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c477b8bf608328b47e9dd1f326107f