### PR TITLE
feat: add AI collaboration suggestions

### DIFF
--- a/src/components/CollaborationSuggestions.tsx
+++ b/src/components/CollaborationSuggestions.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Lightbulb, Users, TrendingUp, MessageCircle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { getCollaborationSuggestions, CollaborationSuggestion } from '@/lib/services/collaboration-service';
 
 interface Suggestion {
   id: string;
@@ -27,17 +28,31 @@ export const CollaborationSuggestions = ({ userProfile }: { userProfile?: any })
 
   const generateSuggestions = async () => {
     setLoading(true);
-    
+
     try {
-      // TODO: Replace with actual AI-powered suggestion generation
-      // For now, return empty array for launch
-      setSuggestions([]);
+      const aiSuggestions = await getCollaborationSuggestions(userProfile);
+      const mapped: Suggestion[] = aiSuggestions.map((s: CollaborationSuggestion) => ({
+        id: s.id,
+        type: s.type,
+        title: s.title,
+        description: s.description,
+        matchScore: s.matchScore,
+        participants: s.participants ?? [],
+        tags: s.tags ?? [],
+        potentialValue: s.potentialValue ?? '',
+      }));
+      setSuggestions(mapped);
     } catch (error) {
       console.error('Error generating suggestions:', error);
+      toast({
+        title: 'Failed to load suggestions',
+        description: 'Please try again later.',
+        variant: 'destructive',
+      });
       setSuggestions([]);
+    } finally {
+      setLoading(false);
     }
-    
-    setLoading(false);
   };
 
   const handleInterest = (suggestionId: string, action: 'interested' | 'not_interested') => {

--- a/src/components/__tests__/CollaborationSuggestions.test.tsx
+++ b/src/components/__tests__/CollaborationSuggestions.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { CollaborationSuggestions } from '../CollaborationSuggestions';
+
+const mockGetSuggestions = vi.fn();
+vi.mock('@/lib/services/collaboration-service', () => ({
+  getCollaborationSuggestions: (profile: any) => mockGetSuggestions(profile),
+}));
+
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+describe('CollaborationSuggestions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders suggestions on success', async () => {
+    mockGetSuggestions.mockResolvedValue([
+      {
+        id: '1',
+        type: 'partnership',
+        title: 'Partner up',
+        description: 'desc',
+        matchScore: 80,
+        participants: ['Alice'],
+        tags: ['innovation'],
+        potentialValue: '$100',
+      },
+    ]);
+
+    render(<CollaborationSuggestions userProfile={{}} />);
+
+    expect(await screen.findByText('Partner up')).toBeInTheDocument();
+  });
+
+  it('handles failure and shows toast', async () => {
+    mockGetSuggestions.mockRejectedValue(new Error('fail'));
+
+    render(<CollaborationSuggestions userProfile={{}} />);
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalled());
+    expect(screen.getByText('No suggestions available')).toBeInTheDocument();
+  });
+});

--- a/src/lib/services/collaboration-service.ts
+++ b/src/lib/services/collaboration-service.ts
@@ -1,0 +1,43 @@
+export interface CollaborationSuggestion {
+  id: string;
+  type: 'partnership' | 'skill_exchange' | 'project' | 'mentorship';
+  title: string;
+  description: string;
+  matchScore: number;
+  participants: string[];
+  tags: string[];
+  potentialValue: string;
+}
+
+/**
+ * Fetch collaboration suggestions from the AI service based on a user's profile.
+ * The API endpoint is configured via the `VITE_COLLABORATION_API_URL` environment variable.
+ */
+export async function getCollaborationSuggestions(
+  userProfile: any
+): Promise<CollaborationSuggestion[]> {
+  const apiUrl = (import.meta as any).env?.VITE_COLLABORATION_API_URL as
+    | string
+    | undefined;
+
+  if (!apiUrl) {
+    throw new Error('COLLABORATION_API_URL is not configured');
+  }
+
+  const response = await fetch(apiUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ profile: userProfile }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  return (data.suggestions ?? []) as CollaborationSuggestion[];
+}
+
+export default {
+  getCollaborationSuggestions,
+};

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -60,3 +60,6 @@ export type ServiceType = keyof ReturnType<typeof getServiceRegistry>;
 export const getService = <T extends ServiceType>(serviceName: T): ReturnType<typeof getServiceRegistry>[T] => {
   return getServiceRegistry()[serviceName];
 };
+
+// AI-powered services
+export { getCollaborationSuggestions } from './collaboration-service';

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- integrate collaboration suggestions with AI service
- create collaboration service and tests for success/failure

## Testing
- `npm test`
- `npx vitest run src/components/__tests__/CollaborationSuggestions.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c47a8be1bc83289b6fde97ddebaf92