### PR TITLE
feat: add user search to messaging

### DIFF
--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -121,6 +121,21 @@ export class UserService extends BaseService<User> {
       'UserService.signOut'
     );
   }
+
+  /**
+   * Search users by name or email
+   */
+  async searchUsers(query: string): Promise<DatabaseResponse<Array<{ id: string; full_name: string; email: string }>>> {
+    return withErrorHandling(
+      () =>
+        supabase
+          .from('profiles')
+          .select('id, full_name, email')
+          .or(`full_name.ilike.%${query}%,email.ilike.%${query}%`)
+          .limit(10),
+      'UserService.searchUsers'
+    );
+  }
 }
 
 export class ProfileService extends BaseService<Profile> {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add Supabase-backed searchUsers service
- replace recipient text box with searchable dropdown
- test selecting a recipient when composing messages

## Testing
- `npm test`
- `npx vitest run src/components/messaging/__tests__/MessageCenter.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c47a9365108328903330f2773792d3