### PR TITLE
feat: guard protected routes with PrivateRoute

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import Messages from "./pages/Messages";
 import AboutUs from "./pages/AboutUs";
+import { PrivateRoute } from "./components/PrivateRoute";
 
 const queryClient = new QueryClient();
 
@@ -36,11 +37,25 @@ export const AppRoutes = () => (
     <Route path="/profile-review" element={<ProfileReview />} />
     <Route path="/subscription-plans" element={<SubscriptionPlans />} />
     <Route path="/partnership-hub" element={<PartnershipHub />} />
-    <Route path="/funding-hub" element={<FundingHub />} />
+    <Route
+      path="/funding-hub"
+      element={
+        <PrivateRoute>
+          <FundingHub />
+        </PrivateRoute>
+      }
+    />
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
     <Route path="/terms-of-service" element={<TermsOfService />} />
     <Route path="/about-us" element={<AboutUs />} />
-    <Route path="/messages" element={<Messages />} />
+    <Route
+      path="/messages"
+      element={
+        <PrivateRoute>
+          <Messages />
+        </PrivateRoute>
+      }
+    />
     <Route path="*" element={<NotFound />} />
   </Routes>
 );

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAppContext } from '@/contexts/AppContext';
+
+interface PrivateRouteProps {
+  children: ReactNode;
+}
+
+export const PrivateRoute = ({ children }: PrivateRouteProps) => {
+  const { user, loading } = useAppContext();
+
+  if (loading) {
+    return null;
+  }
+
+  if (!user) {
+    return <Navigate to="/signin" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default PrivateRoute;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add `PrivateRoute` component to redirect unauthenticated users to sign-in
- wrap messages and funding hub routes with `PrivateRoute`
- test routing redirection for protected routes

## Testing
- `npm test`
- `npx vitest run src/__tests__/AppRoutes.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c47ab03e2483289d4f0a0a25859a6b