### PR TITLE
Add ErrorBoundary for app-level crash handling

### DIFF
--- a/src/__tests__/ErrorBoundary.test.tsx
+++ b/src/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import ErrorBoundary from '../components/ErrorBoundary';
+
+const ProblemChild = () => {
+  throw new Error('Test error');
+};
+
+describe('ErrorBoundary', () => {
+  const originalError = console.error;
+
+  beforeAll(() => {
+    console.error = vi.fn();
+  });
+
+  afterAll(() => {
+    console.error = originalError;
+  });
+
+  it('renders fallback UI when child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // You can integrate with logging infrastructure here
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" className="p-4 text-center">
+          <p>Something went wrong. Please try again.</p>
+          <button onClick={this.handleReload}>Reload</button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,11 @@
-
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import ErrorBoundary from './components/ErrorBoundary.tsx'
 
 // Remove dark mode class addition
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom';
+import { expect } from 'vitest';
+import { toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);


### PR DESCRIPTION
## Summary
- add ErrorBoundary component with fallback message and reload button
- wrap App in ErrorBoundary to catch rendering errors
- test ErrorBoundary fallback UI and set up vitest environment

## Testing
- `npm test`
- `npx vitest run` *(fails: ReferenceError: jest is not defined)*
- `npx vitest run src/__tests__/ErrorBoundary.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c47abce06883289dcacaafe6c48d5a