### PR TITLE
feat: fetch funding data from Supabase

### DIFF
--- a/backend/supabase-functions/funding-data.ts
+++ b/backend/supabase-functions/funding-data.ts
@@ -3,7 +3,7 @@ export interface FundingOpportunity {
   title: string;
   organization: string;
   description: string;
-  amount: number; // in USD for simplicity
+  amount: number;
   deadline: string; // ISO date string
   sectors: string[];
   countries: string[];
@@ -22,109 +22,39 @@ export interface Professional {
   availability: string;
 }
 
-export const fundingOpportunities: FundingOpportunity[] = [
-  {
-    id: 'pepfar-2024',
-    title: 'PEPFAR Small Grants Program',
-    organization: 'U.S. Embassy Lusaka',
-    description: 'Community-based HIV/AIDS projects for Zambian organizations.',
-    amount: 50000,
-    deadline: '2024-04-30',
-    sectors: ['healthcare', 'community'],
-    countries: ['zambia'],
-    type: 'Grant',
-    requirements: ['Zambian registration', 'HIV/AIDS focus']
-  },
-  {
-    id: 'tef-2024',
-    title: 'Tony Elumelu Foundation Entrepreneurship Programme',
-    organization: 'Tony Elumelu Foundation',
-    description: 'Seed capital and training for African startups in any sector.',
-    amount: 5000,
-    deadline: '2024-03-31',
-    sectors: ['agriculture', 'technology', 'services', 'manufacturing'],
-    countries: ['zambia', 'nigeria', 'kenya', 'ghana'],
-    type: 'Seed Funding',
-    requirements: ['African-owned business', '0-3 years old']
-  },
-  {
-    id: 'usadf-2024',
-    title: 'USADF Grants for African-owned SMEs',
-    organization: 'U.S. African Development Foundation',
-    description: 'Up to $250k for growth-oriented, impact-focused businesses.',
-    amount: 250000,
-    deadline: '2024-08-31',
-    sectors: ['agriculture', 'renewable', 'technology'],
-    countries: ['zambia', 'kenya', 'uganda', 'ghana'],
-    type: 'Grant',
-    requirements: ['African ownership', 'Impact metrics']
-  },
-  {
-    id: 'ceec-2024',
-    title: 'CEEC Matching Grants',
-    organization: 'Citizens Economic Empowerment Commission',
-    description: 'Zambian government financing for priority sectors.',
-    amount: 100000,
-    deadline: '2024-06-30',
-    sectors: ['agriculture', 'manufacturing', 'tourism'],
-    countries: ['zambia'],
-    type: 'Matching Grant',
-    requirements: ['Zambian SMEs', 'Co-financing required']
-  },
-  {
-    id: 'afawa-2024',
-    title: 'AFAWA Guarantee for Growth',
-    organization: 'African Development Bank',
-    description: 'Risk-sharing facility to boost lending to women-owned SMEs.',
-    amount: 500000,
-    deadline: '2024-12-31',
-    sectors: ['all'],
-    countries: ['zambia', 'kenya', 'tanzania'],
-    type: 'Guarantee',
-    requirements: ['Women-owned business', 'Through partner bank']
+// Helper to work in both Deno (Supabase Edge Functions) and Node (tests)
+function getEnv(key: string): string | undefined {
+  // @ts-ignore - Deno may not exist in Node environment
+  if (typeof Deno !== 'undefined' && Deno?.env) {
+    // @ts-ignore
+    return Deno.env.get(key);
   }
-];
+  return process.env[key];
+}
 
-export const professionals: Professional[] = [
-  {
-    id: 'bongohive',
-    name: 'BongoHive Consult',
-    expertise: ['technology', 'grant writing', 'social enterprise'],
-    experience: '10 years',
-    successRate: 0.8,
-    rating: 4.8,
-    hourlyRate: 'ZMW 500',
-    availability: 'Available'
-  },
-  {
-    id: 'impact-capital-africa',
-    name: 'Impact Capital Africa',
-    expertise: ['agriculture', 'investor readiness', 'fundraising'],
-    experience: '8 years',
-    successRate: 0.75,
-    rating: 4.7,
-    hourlyRate: 'ZMW 600',
-    availability: 'Available'
-  },
-  {
-    id: 'grant-thornton-zambia',
-    name: 'Grant Thornton Zambia',
-    expertise: ['finance', 'audit', 'grant management'],
-    experience: '15 years',
-    successRate: 0.7,
-    rating: 4.6,
-    hourlyRate: 'ZMW 800',
-    availability: 'Limited'
-  },
-  {
-    id: 'ngoma-consulting',
-    name: 'Ngoma Consulting Services',
-    expertise: ['community', 'healthcare', 'education'],
-    experience: '12 years',
-    successRate: 0.65,
-    rating: 4.5,
-    hourlyRate: 'ZMW 450',
-    availability: 'Available'
+const SUPABASE_URL = getEnv('SUPABASE_URL') ?? '';
+const SUPABASE_KEY = getEnv('SUPABASE_ANON_KEY') ?? '';
+
+async function fetchFromTable<T>(table: string): Promise<T[]> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${table}?select=*`, {
+    headers: {
+      apikey: SUPABASE_KEY,
+      Authorization: `Bearer ${SUPABASE_KEY}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${table}`);
   }
-];
+
+  return res.json() as Promise<T[]>;
+}
+
+export function fetchFundingOpportunities(): Promise<FundingOpportunity[]> {
+  return fetchFromTable<FundingOpportunity>('funding_opportunities');
+}
+
+export function fetchProfessionals(): Promise<Professional[]> {
+  return fetchFromTable<Professional>('professionals');
+}
 

--- a/backend/supabase-functions/funding-matcher.ts
+++ b/backend/supabase-functions/funding-matcher.ts
@@ -1,5 +1,5 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { fundingOpportunities } from './funding-data.ts';
+import { fetchFundingOpportunities } from './funding-data.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -29,7 +29,9 @@ serve(async (req) => {
   try {
     const { businessProfile, fundingNeeds }: { businessProfile: BusinessProfile; fundingNeeds: FundingNeeds } = await req.json();
 
-    const matches = fundingOpportunities.map((opp) => {
+    const opportunities = await fetchFundingOpportunities();
+
+    const matches = opportunities.map((opp) => {
       let score = 0;
       const reasons: string[] = [];
 

--- a/backend/supabase-functions/matched-professionals.ts
+++ b/backend/supabase-functions/matched-professionals.ts
@@ -1,5 +1,5 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { professionals, fundingOpportunities } from './funding-data.ts';
+import { fetchProfessionals, fetchFundingOpportunities } from './funding-data.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -14,12 +14,14 @@ serve(async (req) => {
 
   try {
     const { opportunityId } = await req.json();
-    const opportunity = fundingOpportunities.find(o => o.id === opportunityId);
+    const opportunities = await fetchFundingOpportunities();
+    const opportunity = opportunities.find(o => o.id === opportunityId);
     if (!opportunity) {
       throw new Error('Opportunity not found');
     }
 
-    const matches = professionals.map((prof) => {
+    const profs = await fetchProfessionals();
+    const matches = profs.map((prof) => {
       const overlap = prof.expertise.filter(skill =>
         opportunity.sectors.includes(skill.toLowerCase()) || opportunity.sectors.includes('all')
       );

--- a/src/lib/__tests__/funding-data.integration.test.ts
+++ b/src/lib/__tests__/funding-data.integration.test.ts
@@ -1,0 +1,71 @@
+// Integration tests for funding-data API client
+
+const mockData = [
+  {
+    id: '1',
+    title: 'Test',
+    organization: 'Org',
+    description: 'Desc',
+    amount: 1000,
+    deadline: '2024-01-01',
+    sectors: ['tech'],
+    countries: ['zambia'],
+    type: 'Grant',
+    requirements: [],
+  },
+];
+
+describe('funding-data API client', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetModules();
+  });
+
+  it('retrieves funding opportunities', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    }) as any;
+
+    const { fetchFundingOpportunities } = await import(
+      '../../../backend/supabase-functions/funding-data'
+    );
+
+    const data = await fetchFundingOpportunities();
+    expect(data).toEqual(mockData);
+  });
+
+  it('handles funding opportunity errors', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as any;
+
+    const { fetchFundingOpportunities } = await import(
+      '../../../backend/supabase-functions/funding-data'
+    );
+
+    await expect(fetchFundingOpportunities()).rejects.toThrow(
+      'Failed to fetch funding_opportunities'
+    );
+  });
+
+  it('retrieves professionals', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    }) as any;
+
+    const { fetchProfessionals } = await import(
+      '../../../backend/supabase-functions/funding-data'
+    );
+
+    const data = await fetchProfessionals();
+    expect(data).toEqual(mockData);
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace hardcoded funding and professional lists with Supabase REST client
- update edge functions to load data asynchronously
- add integration tests for funding API client success and error cases

## Testing
- `npm test`
- `npm run test:jest` *(fails: LencoPayment, Header, AppContext, MessageCenter, StatsSection, AppRoutes, LencoPayment tests, others)*

------
https://chatgpt.com/codex/tasks/task_e_68c47b058f348328b32182076fa026d9