### PR TITLE
Add accessible labels to MessageCenter inputs

### DIFF
--- a/src/components/messaging/MessageCenter.tsx
+++ b/src/components/messaging/MessageCenter.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { MessageSquare, Send, User } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
@@ -136,31 +137,43 @@ export const MessageCenter = () => {
           {showCompose ? (
             <div className="space-y-4">
               <h3 className="text-lg font-semibold">Compose Message</h3>
-              <Input
-                placeholder="Recipient ID"
-                value={composeForm.recipient_id}
-                onChange={(e) => setComposeForm(prev => ({
-                  ...prev,
-                  recipient_id: e.target.value
-                }))}
-              />
-              <Input
-                placeholder="Subject"
-                value={composeForm.subject}
-                onChange={(e) => setComposeForm(prev => ({
-                  ...prev,
-                  subject: e.target.value
-                }))}
-              />
-              <Textarea
-                placeholder="Message content..."
-                rows={10}
-                value={composeForm.content}
-                onChange={(e) => setComposeForm(prev => ({
-                  ...prev,
-                  content: e.target.value
-                }))}
-              />
+              <div className="space-y-2">
+                <Label htmlFor="recipient-id">Recipient ID</Label>
+                <Input
+                  id="recipient-id"
+                  placeholder="Recipient ID"
+                  value={composeForm.recipient_id}
+                  onChange={(e) => setComposeForm(prev => ({
+                    ...prev,
+                    recipient_id: e.target.value
+                  }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="subject">Subject</Label>
+                <Input
+                  id="subject"
+                  placeholder="Subject"
+                  value={composeForm.subject}
+                  onChange={(e) => setComposeForm(prev => ({
+                    ...prev,
+                    subject: e.target.value
+                  }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="message-content">Message Content</Label>
+                <Textarea
+                  id="message-content"
+                  placeholder="Message content..."
+                  rows={10}
+                  value={composeForm.content}
+                  onChange={(e) => setComposeForm(prev => ({
+                    ...prev,
+                    content: e.target.value
+                  }))}
+                />
+              </div>
               <div className="flex gap-2">
                 <Button onClick={sendMessage}>
                   <Send className="h-4 w-4 mr-2" />

--- a/src/components/messaging/__tests__/MessageCenter.test.tsx
+++ b/src/components/messaging/__tests__/MessageCenter.test.tsx
@@ -48,9 +48,16 @@ describe('MessageCenter', () => {
 
     // Compose message
     fireEvent.click(screen.getByRole('button', { name: /compose/i }));
-    fireEvent.change(screen.getByPlaceholderText('Recipient ID'), { target: { value: 'u2' } });
-    fireEvent.change(screen.getByPlaceholderText('Subject'), { target: { value: 'New Subject' } });
-    fireEvent.change(screen.getByPlaceholderText('Message content...'), { target: { value: 'New Content' } });
+    const recipientInput = screen.getByLabelText(/recipient id/i);
+    const subjectInput = screen.getByLabelText(/subject/i);
+    const contentTextarea = screen.getByLabelText(/message content/i);
+    expect(recipientInput).toBeInTheDocument();
+    expect(subjectInput).toBeInTheDocument();
+    expect(contentTextarea).toBeInTheDocument();
+
+    fireEvent.change(recipientInput, { target: { value: 'u2' } });
+    fireEvent.change(subjectInput, { target: { value: 'New Subject' } });
+    fireEvent.change(contentTextarea, { target: { value: 'New Content' } });
 
     fireEvent.click(screen.getByRole('button', { name: /send/i }));
 
@@ -74,9 +81,9 @@ describe('MessageCenter', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: /compose/i }));
-    expect(screen.getByPlaceholderText('Recipient ID')).toHaveValue('');
-    expect(screen.getByPlaceholderText('Subject')).toHaveValue('');
-    expect(screen.getByPlaceholderText('Message content...')).toHaveValue('');
+    expect(screen.getByLabelText(/recipient id/i)).toHaveValue('');
+    expect(screen.getByLabelText(/subject/i)).toHaveValue('');
+    expect(screen.getByLabelText(/message content/i)).toHaveValue('');
   });
 });
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add Label components linked via id/htmlFor for message inputs
- assert labeled inputs in MessageCenter tests
- include testing-library setup for Vitest

## Testing
- `npx vitest run src/components/messaging/__tests__/MessageCenter.test.tsx`
- `npm run test:accessibility`


------
https://chatgpt.com/codex/tasks/task_e_68c47acda20c8328b90871eed073cd63