### PR TITLE
feat: add schema validation and tests for GetStarted form

### DIFF
--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -1,4 +1,7 @@
 import { useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -7,61 +10,84 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Checkbox } from '@/components/ui/checkbox';
 import { Link, useNavigate } from 'react-router-dom';
 import { User, Mail, Lock, Building, Eye, EyeOff } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
-export const GetStarted = () => {
-  const [formData, setFormData] = useState({
-    firstName: '',
-    lastName: '',
-    email: '',
-    password: '',
-    confirmPassword: '',
-    company: '',
-    accountType: '',
-    agreeToTerms: false
+
+// Validation schema
+const getStartedSchema = z
+  .object({
+    firstName: z.string().min(1, 'First name is required'),
+    lastName: z.string().min(1, 'Last name is required'),
+    email: z
+      .string()
+      .min(1, 'Email is required')
+      .email('Please enter a valid email address'),
+    password: z
+      .string()
+      .min(8, 'Password must be at least 8 characters long')
+      .regex(/[a-z]/, 'Password must include a lowercase letter')
+      .regex(/[A-Z]/, 'Password must include an uppercase letter')
+      .regex(/\d/, 'Password must include a number'),
+    confirmPassword: z.string().min(1, 'Please confirm your password'),
+    company: z.string().optional(),
+    accountType: z.string().min(1, 'Account type is required'),
+    agreeToTerms: z
+      .boolean()
+      .refine((val) => val === true, {
+        message: 'You must agree to the terms and conditions',
+      }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    path: ['confirmPassword'],
+    message: 'Passwords do not match',
   });
+
+type GetStartedFormData = z.infer<typeof getStartedSchema>;
+
+export const GetStarted = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
+  const [serverError, setServerError] = useState('');
   const navigate = useNavigate();
-  const { toast } = useToast();
   const { signUp } = useAppContext();
 
-  const handleInputChange = (field: string, value: string | boolean) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
-  };
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors, isValid },
+  } = useForm<GetStartedFormData>({
+    resolver: zodResolver(getStartedSchema),
+    mode: 'onChange',
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      email: '',
+      password: '',
+      confirmPassword: '',
+      company: '',
+      accountType: '',
+      agreeToTerms: false,
+    },
+  });
 
-  const handleSignUp = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const onSubmit = async (data: GetStartedFormData) => {
     setLoading(true);
-    setError('');
-
-    if (formData.password !== formData.confirmPassword) {
-      setError('Passwords do not match');
-      setLoading(false);
-      return;
-    }
-
-    if (!formData.agreeToTerms) {
-      setError('Please agree to the terms and conditions');
-      setLoading(false);
-      return;
-    }
+    setServerError('');
 
     try {
-      await signUp(formData.email, formData.password, {
-        first_name: formData.firstName,
-        last_name: formData.lastName,
-        company: formData.company,
-        account_type: formData.accountType,
-        full_name: `${formData.firstName} ${formData.lastName}`,
-        profile_completed: false
+      await signUp(data.email, data.password, {
+        first_name: data.firstName,
+        last_name: data.lastName,
+        company: data.company,
+        account_type: data.accountType,
+        full_name: `${data.firstName} ${data.lastName}`,
+        profile_completed: false,
       });
-      
+
       navigate('/profile-setup');
     } catch (error: any) {
-      setError(error.message);
+      setServerError(error.message);
     } finally {
       setLoading(false);
     }
@@ -70,176 +96,196 @@ export const GetStarted = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-emerald-50 flex items-center justify-center p-4">
       <Card className="w-full max-w-lg">
-        <CardHeader className="text-center">
-          <img
-            src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
-            alt="WATHACI CONNECT"
-            loading="lazy"
-            decoding="async"
-            className="h-20 w-auto mx-auto mb-4 drop-shadow-lg"
-          />
-          <CardTitle className="text-2xl">Get Started</CardTitle>
-          <CardDescription>Create your WATHACI account</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {error && (
-            <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">
-              {error}
-            </div>
-          )}
-          
-          <form onSubmit={handleSignUp} className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="firstName">First Name</Label>
-                <div className="relative">
-                  <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="firstName"
-                    placeholder="First name"
-                    value={formData.firstName}
-                    onChange={(e) => handleInputChange('firstName', e.target.value)}
-                    className="pl-10"
-                    required
-                  />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="lastName">Last Name</Label>
-                <Input
-                  id="lastName"
-                  placeholder="Last name"
-                  value={formData.lastName}
-                  onChange={(e) => handleInputChange('lastName', e.target.value)}
-                  required
-                />
-              </div>
-            </div>
-            
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <div className="relative">
-                <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="Enter your email"
-                  value={formData.email}
-                  onChange={(e) => handleInputChange('email', e.target.value)}
-                  className="pl-10"
-                  required
-                />
-              </div>
-            </div>
-            
-            <div className="space-y-2">
-              <Label htmlFor="company">Company (Optional)</Label>
-              <div className="relative">
-                <Building className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                <Input
-                  id="company"
-                  placeholder="Company name"
-                  value={formData.company}
-                  onChange={(e) => handleInputChange('company', e.target.value)}
-                  className="pl-10"
-                />
-              </div>
-            </div>
-            
-            <div className="space-y-2">
-              <Label htmlFor="accountType">Account Type</Label>
-              <Select onValueChange={(value) => handleInputChange('accountType', value)} required>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select account type" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="sole_proprietor">Sole Proprietor</SelectItem>
-                  <SelectItem value="professional">Professional</SelectItem>
-                  <SelectItem value="sme">Small & Medium Enterprise</SelectItem>
-                  <SelectItem value="investor">Investor</SelectItem>
-                  <SelectItem value="donor">Donor</SelectItem>
-                  <SelectItem value="government">Government Institution</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="password"
-                    type={showPassword ? 'text' : 'password'}
-                    placeholder="Password"
-                    value={formData.password}
-                    onChange={(e) => handleInputChange('password', e.target.value)}
-                    className="pl-10 pr-10"
-                    required
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
-                  >
-                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="confirmPassword">Confirm Password</Label>
-                <div className="relative">
-                  <Input
-                    id="confirmPassword"
-                    type={showConfirmPassword ? 'text' : 'password'}
-                    placeholder="Confirm password"
-                    value={formData.confirmPassword}
-                    onChange={(e) => handleInputChange('confirmPassword', e.target.value)}
-                    className="pr-10"
-                    required
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                    className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
-                  >
-                    {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                </div>
-              </div>
-            </div>
-            
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="terms"
-                checked={formData.agreeToTerms}
-                onCheckedChange={(checked) => handleInputChange('agreeToTerms', checked as boolean)}
-              />
-              <Label htmlFor="terms" className="text-sm">
-                I agree to the{' '}
-                <Link to="/terms" className="text-blue-600 hover:underline">
-                  Terms of Service
-                </Link>{' '}
-                and{' '}
-                <Link to="/privacy" className="text-blue-600 hover:underline">
-                  Privacy Policy
-                </Link>
-              </Label>
-            </div>
-            
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? 'Creating Account...' : 'Create Account'}
-            </Button>
-          </form>
-          
-          <div className="text-center text-sm text-gray-600">
-            Already have an account?{' '}
-            <Link to="/signin" className="text-blue-600 hover:underline font-medium">
-              Sign In
-            </Link>
+      <CardHeader className="text-center">
+        <img
+          src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
+          alt="WATHACI CONNECT"
+          loading="lazy"
+          decoding="async"
+          className="h-20 w-auto mx-auto mb-4 drop-shadow-lg"
+        />
+        <CardTitle className="text-2xl">Get Started</CardTitle>
+        <CardDescription>Create your WATHACI account</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {serverError && (
+          <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">
+            {serverError}
           </div>
-        </CardContent>
-      </Card>
+        )}
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="firstName">First Name</Label>
+              <div className="relative">
+                <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                <Input
+                  id="firstName"
+                  placeholder="First name"
+                  {...register('firstName')}
+                  className={`pl-10 ${errors.firstName ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
+                />
+              </div>
+              {errors.firstName && (
+                <p className="text-sm text-red-600 mt-1">{errors.firstName.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="lastName">Last Name</Label>
+              <Input
+                id="lastName"
+                placeholder="Last name"
+                {...register('lastName')}
+                className={errors.lastName ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}
+              />
+              {errors.lastName && (
+                <p className="text-sm text-red-600 mt-1">{errors.lastName.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+              <Input
+                id="email"
+                type="email"
+                placeholder="Enter your email"
+                {...register('email')}
+                className={`pl-10 ${errors.email ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
+              />
+            </div>
+            {errors.email && (
+              <p className="text-sm text-red-600 mt-1">{errors.email.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="company">Company (Optional)</Label>
+            <div className="relative">
+              <Building className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+              <Input
+                id="company"
+                placeholder="Company name"
+                {...register('company')}
+                className="pl-10"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="accountType">Account Type</Label>
+            <Controller
+              name="accountType"
+              control={control}
+              render={({ field }) => (
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select account type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="sole_proprietor">Sole Proprietor</SelectItem>
+                    <SelectItem value="professional">Professional</SelectItem>
+                    <SelectItem value="sme">Small & Medium Enterprise</SelectItem>
+                    <SelectItem value="investor">Investor</SelectItem>
+                    <SelectItem value="donor">Donor</SelectItem>
+                    <SelectItem value="government">Government Institution</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.accountType && (
+              <p className="text-sm text-red-600 mt-1">{errors.accountType.message}</p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                <Input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="Password"
+                  {...register('password')}
+                  className={`pl-10 pr-10 ${errors.password ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+              {errors.password && (
+                <p className="text-sm text-red-600 mt-1">{errors.password.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">Confirm Password</Label>
+              <div className="relative">
+                <Input
+                  id="confirmPassword"
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  placeholder="Confirm password"
+                  {...register('confirmPassword')}
+                  className={`pr-10 ${errors.confirmPassword ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+              {errors.confirmPassword && (
+                <p className="text-sm text-red-600 mt-1">{errors.confirmPassword.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <Controller
+              name="agreeToTerms"
+              control={control}
+              render={({ field }) => (
+                <Checkbox id="terms" checked={field.value} onCheckedChange={field.onChange} />
+              )}
+            />
+            <Label htmlFor="terms" className="text-sm">
+              I agree to the{' '}
+              <Link to="/terms" className="text-blue-600 hover:underline">
+                Terms of Service
+              </Link>{' '}
+              and{' '}
+              <Link to="/privacy" className="text-blue-600 hover:underline">
+                Privacy Policy
+              </Link>
+            </Label>
+          </div>
+          {errors.agreeToTerms && (
+            <p className="text-sm text-red-600 mt-1">{errors.agreeToTerms.message}</p>
+          )}
+
+          <Button type="submit" className="w-full" disabled={!isValid || loading}>
+            {loading ? 'Creating Account...' : 'Create Account'}
+          </Button>
+        </form>
+
+        <div className="text-center text-sm text-gray-600">
+          Already have an account?{' '}
+          <Link to="/signin" className="text-blue-600 hover:underline font-medium">
+            Sign In
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
     </div>
   );
 };
+

--- a/src/pages/__tests__/GetStarted.test.tsx
+++ b/src/pages/__tests__/GetStarted.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { GetStarted } from '../GetStarted';
+
+// Mock the AppContext
+jest.mock('@/contexts/AppContext', () => ({
+  useAppContext: () => ({
+    signUp: jest.fn().mockResolvedValue({}),
+  }),
+}));
+
+const GetStartedWrapper = () => (
+  <BrowserRouter>
+    <GetStarted />
+  </BrowserRouter>
+);
+
+beforeAll(() => {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserver;
+});
+
+describe('GetStarted Validation', () => {
+  it('shows validation error for invalid email format', async () => {
+    render(<GetStartedWrapper />);
+
+    const emailInput = screen.getByLabelText(/email/i);
+    fireEvent.change(emailInput, { target: { value: 'invalid-email' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a valid email address')).toBeTruthy();
+    });
+  });
+
+  it('shows validation error for weak password', async () => {
+    render(<GetStartedWrapper />);
+
+    const passwordInput = screen.getByLabelText(/^password$/i);
+    fireEvent.change(passwordInput, { target: { value: '123' } });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Password must be at least 8 characters long')
+      ).toBeTruthy();
+    });
+  });
+
+  it('shows validation error when passwords do not match', async () => {
+    render(<GetStartedWrapper />);
+
+    const passwordInput = screen.getByLabelText(/^password$/i);
+    const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
+
+    fireEvent.change(passwordInput, { target: { value: 'Password1' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'Password2' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Passwords do not match')).toBeTruthy();
+    });
+  });
+
+  it('requires accepting terms and disables submission until the form is valid', async () => {
+    render(<GetStartedWrapper />);
+
+    const submitButton = screen.getByRole('button', { name: /create account/i });
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: 'John' },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: 'Doe' },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: 'Password1' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'Password1' },
+    });
+
+    fireEvent.click(screen.getByText('Select account type'));
+    fireEvent.click(screen.getByRole('option', { name: 'Professional' }));
+
+    // Terms not accepted yet, button should remain disabled
+    expect(submitButton).toBeDisabled();
+
+    // Accept terms
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
+    });
+
+    // Uncheck to trigger validation error
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('You must agree to the terms and conditions')
+      ).toBeTruthy();
+      expect(submitButton).toBeDisabled();
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- integrate Zod validation in GetStarted page with real-time feedback and submit guard
- add unit tests covering validation rules for GetStarted

## Testing
- `npm run test:jest` *(fails: TypeScript errors in unrelated test suites)*
- `npx jest src/pages/__tests__/GetStarted.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c47b15e82083289e34e5a1f1ec4e74