### PR TITLE
Adjust hero overlay opacity

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -11,7 +11,7 @@ const HeroSection = () => {
           "url('/images/ChatGPT%20Image%20Sep%2014%2C%202025%2C%2011_09_30%20PM.png')",
       }}
     >
-      <div className="absolute inset-0 bg-gradient-to-br from-orange-50/95 via-white/92 to-green-50/95" />
+      <div className="absolute inset-0 bg-gradient-to-br from-orange-50/70 via-white/60 to-green-50/70" />
       <div className="relative max-w-6xl mx-auto px-6">
         <div className="text-center mb-16">
           <div className="mb-8">


### PR DESCRIPTION
## Summary
- reduce the home page hero overlay opacity so the background image is more visible

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d22faa6b7c83289d6e825c373fe1f4