### PR TITLE
Add category filtering to freelancer directory

### DIFF
--- a/src/components/FreelancerDirectory.tsx
+++ b/src/components/FreelancerDirectory.tsx
@@ -24,13 +24,14 @@ interface Freelancer {
   profile_image_url?: string;
   availability_status: string;
   years_experience: number;
+  category?: string | null;
 }
 
 export const FreelancerDirectory = () => {
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState('');
-  const [selectedLocation, setSelectedLocation] = useState('');
-  const [priceRange, setPriceRange] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('all');
+  const [selectedLocation, setSelectedLocation] = useState('all-locations');
+  const [priceRange, setPriceRange] = useState('all-prices');
   const [freelancers, setFreelancers] = useState<Freelancer[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -54,19 +55,23 @@ export const FreelancerDirectory = () => {
     }
   };
 
-  const filteredFreelancers = freelancers.filter(freelancer => {
+  const filteredFreelancers = freelancers.filter((freelancer) => {
     const matchesSearch = freelancer.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          freelancer.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          freelancer.skills.some(skill => skill.toLowerCase().includes(searchTerm.toLowerCase()));
-    
-    const matchesLocation = !selectedLocation || selectedLocation === 'all-locations' || 
+
+    const matchesCategory = selectedCategory === 'all' || !selectedCategory
+      ? true
+      : freelancer.category?.toLowerCase() === selectedCategory.toLowerCase();
+
+    const matchesLocation = !selectedLocation || selectedLocation === 'all-locations' ||
                            freelancer.location.toLowerCase().includes(selectedLocation.toLowerCase());
-    const matchesPrice = !priceRange || priceRange === 'all-prices' || 
+    const matchesPrice = !priceRange || priceRange === 'all-prices' ||
       (priceRange === 'low' && freelancer.hourly_rate < 25) ||
       (priceRange === 'medium' && freelancer.hourly_rate >= 25 && freelancer.hourly_rate < 50) ||
       (priceRange === 'high' && freelancer.hourly_rate >= 50);
 
-    return matchesSearch && matchesLocation && matchesPrice;
+    return matchesSearch && matchesCategory && matchesLocation && matchesPrice;
   });
 
   return (
@@ -215,8 +220,8 @@ export const FreelancerDirectory = () => {
       ) : filteredFreelancers.length === 0 ? (
         <div className="text-center py-12">
           <p className="text-gray-500 text-lg">No freelancers found matching your criteria.</p>
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             onClick={() => {
               setSearchTerm('');
               setSelectedCategory('all');

--- a/src/components/__tests__/FreelancerDirectory.test.tsx
+++ b/src/components/__tests__/FreelancerDirectory.test.tsx
@@ -1,0 +1,147 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement, ReactNode } from 'react';
+import { FreelancerDirectory } from '../FreelancerDirectory';
+import { supabase } from '@/lib/supabase';
+
+type MockSelectItemProps = { value: string; children: ReactNode };
+type MockSelectProps = { value: string; onValueChange: (value: string) => void; children: ReactNode };
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/ui/select', () => {
+  const React = require('react');
+
+  const SelectItem = ({ value, children }: MockSelectItemProps) => (
+    <option value={value}>{children}</option>
+  );
+
+  const SelectContent = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+  const Select = ({ value, onValueChange, children }: MockSelectProps) => {
+    const options: ReactElement<MockSelectItemProps>[] = [];
+
+    React.Children.forEach(children, (child: ReactNode) => {
+      if (!React.isValidElement(child)) return;
+
+      const element = child as ReactElement<any>;
+
+      if (element.type === SelectContent) {
+        React.Children.forEach(element.props.children, (option: ReactNode) => {
+          if (React.isValidElement(option)) {
+            const optionElement = option as ReactElement<MockSelectItemProps>;
+
+            if (optionElement.type === SelectItem) {
+              options.push(optionElement);
+            }
+          }
+        });
+      } else if (element.type === SelectItem) {
+        options.push(element as ReactElement<MockSelectItemProps>);
+      }
+    });
+
+    return (
+      <select value={value} onChange={(event) => onValueChange(event.target.value)}>
+        {options.map((option) => (
+          <option key={option.props.value} value={option.props.value}>
+            {option.props.children}
+          </option>
+        ))}
+      </select>
+    );
+  };
+
+  const SelectTrigger = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  const SelectValue = () => null;
+
+  return {
+    Select,
+    SelectTrigger,
+    SelectValue,
+    SelectContent,
+    SelectItem,
+    SelectGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectLabel: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectSeparator: () => null,
+    SelectScrollUpButton: () => null,
+    SelectScrollDownButton: () => null,
+  };
+});
+
+describe('FreelancerDirectory', () => {
+  const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
+
+  beforeEach(() => {
+    mockedSupabase.from.mockReset();
+
+    const freelancers = [
+      {
+        id: '1',
+        name: 'Alice Designer',
+        title: 'UI/UX Specialist',
+        bio: 'Experienced designer',
+        skills: ['Figma', 'Sketch'],
+        hourly_rate: 40,
+        currency: 'USD',
+        location: 'Lusaka',
+        country: 'Zambia',
+        rating: 4.8,
+        reviews_count: 24,
+        profile_image_url: null,
+        availability_status: 'available',
+        years_experience: 5,
+        category: 'design',
+      },
+      {
+        id: '2',
+        name: 'Bob Builder',
+        title: 'Full Stack Developer',
+        bio: 'Seasoned developer',
+        skills: ['React', 'Node.js'],
+        hourly_rate: 55,
+        currency: 'USD',
+        location: 'Ndola',
+        country: 'Zambia',
+        rating: 4.6,
+        reviews_count: 18,
+        profile_image_url: null,
+        availability_status: 'available',
+        years_experience: 7,
+        category: 'tech',
+      },
+    ];
+
+    const eqMock = jest.fn().mockResolvedValue({ data: freelancers, error: null });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    mockedSupabase.from.mockImplementation(() => ({ select: selectMock } as any));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('filters freelancers by selected category', async () => {
+    const user = userEvent.setup();
+
+    render(<FreelancerDirectory />);
+
+    expect(await screen.findByText('Alice Designer')).toBeInTheDocument();
+    expect(screen.getByText('Bob Builder')).toBeInTheDocument();
+
+    const [categorySelect] = screen.getAllByRole('combobox');
+
+    await user.selectOptions(categorySelect, 'design');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Bob Builder')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Alice Designer')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- pull the freelancer category from Supabase data and include it in the filter state
- treat "all" filter values as pass-through defaults while combining category matching with the existing filters
- add a Jest regression test that mocks the select UI and proves category selections narrow the rendered freelancers

## Testing
- npm run test:jest -- --runTestsByPath src/components/__tests__/FreelancerDirectory.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d3072653ec8328b07208944d6250c2