### PR TITLE
Fix hero background layout to restore home page sections

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,15 +4,15 @@ import { Link } from 'react-router-dom';
 
 const HeroSection = () => {
   return (
-    <section className="relative py-20">
-      <div 
-        className="fixed inset-0 bg-center bg-cover"
+    <section className="relative overflow-hidden py-20">
+      <div
+        className="absolute inset-0 bg-center bg-cover pointer-events-none"
         style={{
           backgroundImage:
             "url('/images/ChatGPT%20Image%20Sep%2014%2C%202025%2C%2011_09_30%20PM.png')",
         }}
       />
-      <div className="absolute inset-0 bg-gradient-to-br from-orange-50/70 via-white/60 to-green-50/70" />
+      <div className="absolute inset-0 bg-gradient-to-br from-orange-50/70 via-white/60 to-green-50/70 pointer-events-none" />
       <div className="relative z-10 max-w-6xl mx-auto px-6">
         <div className="text-center mb-16">
           <div className="mb-8">


### PR DESCRIPTION
## Summary
- constrain the hero background image and gradient to the hero section so later sections remain visible
- prevent the background layers from intercepting interactions by disabling pointer events

## Testing
- npm run lint *(fails: existing @typescript-eslint/ban-ts-comment violations in backend and test files)*

------
https://chatgpt.com/codex/tasks/task_e_68f038c63a108328b1bf7c921393412a