### PR TITLE
Add ResizeObserver ts-expect-error description

### DIFF
--- a/src/pages/__tests__/GetStarted.test.tsx
+++ b/src/pages/__tests__/GetStarted.test.tsx
@@ -22,7 +22,7 @@ beforeAll(() => {
     unobserve() {}
     disconnect() {}
   }
-  // @ts-expect-error
+  // @ts-expect-error: jsdom environment in tests does not provide ResizeObserver
   global.ResizeObserver = ResizeObserver;
 });
 


### PR DESCRIPTION
## Summary
- describe the ResizeObserver test mock's @ts-expect-error to satisfy lint expectations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f041122fc88328ba50f1009de62d7f