### PR TITLE
Improve auth state management and runtime payment setup

### DIFF
--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -113,6 +113,7 @@ export interface UserSubscription {
   start_date: string;
   end_date: string;
   payment_status: 'paid' | 'pending' | 'failed';
+  payment_reference?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/lib/payment-config.ts
+++ b/src/lib/payment-config.ts
@@ -57,7 +57,16 @@ const DEFAULT_DEV_PUBLIC_KEY = 'pub-dea560c94d379a23e7b85a265d7bb9acbd585481e6e1
 
 const resolveRuntimeValue = (key: string): string | undefined => {
   try {
-    const viteValue = (import.meta as any)?.env?.[key];
+    const importMeta = (() => {
+      try {
+        // eslint-disable-next-line no-eval
+        return (0, eval)('import.meta');
+      } catch {
+        return undefined;
+      }
+    })();
+
+    const viteValue = importMeta?.env?.[key];
     if (viteValue) {
       return viteValue as string;
     }

--- a/src/lib/services/base-service.ts
+++ b/src/lib/services/base-service.ts
@@ -18,11 +18,12 @@ export abstract class BaseService<T = any> {
    */
   async findById(id: string, select: string = '*'): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
-      () => supabase
-        .from(this.tableName)
-        .select(select)
-        .eq('id', id)
-        .single(),
+      async () =>
+        supabase
+          .from(this.tableName)
+          .select(select)
+          .eq('id', id)
+          .single(),
       `${this.tableName}.findById`
     );
   }
@@ -68,10 +69,11 @@ export abstract class BaseService<T = any> {
 
         const totalCount = result.count || 0;
         const totalPages = Math.ceil(totalCount / limit);
+        const records = (result.data || []) as T[];
 
         return {
           data: {
-            data: result.data || [],
+            data: records,
             count: totalCount,
             page,
             totalPages,
@@ -89,11 +91,12 @@ export abstract class BaseService<T = any> {
    */
   async create(data: Partial<T>): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
-      () => supabase
-        .from(this.tableName)
-        .insert(data)
-        .select()
-        .single(),
+      async () =>
+        supabase
+          .from(this.tableName)
+          .insert(data)
+          .select()
+          .single(),
       `${this.tableName}.create`
     );
   }
@@ -103,12 +106,13 @@ export abstract class BaseService<T = any> {
    */
   async update(id: string, data: Partial<T>): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
-      () => supabase
-        .from(this.tableName)
-        .update({ ...data, updated_at: new Date().toISOString() })
-        .eq('id', id)
-        .select()
-        .single(),
+      async () =>
+        supabase
+          .from(this.tableName)
+          .update({ ...data, updated_at: new Date().toISOString() })
+          .eq('id', id)
+          .select()
+          .single(),
       `${this.tableName}.update`
     );
   }
@@ -118,11 +122,12 @@ export abstract class BaseService<T = any> {
    */
   async upsert(data: Partial<T>): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
-      () => supabase
-        .from(this.tableName)
-        .upsert(data)
-        .select()
-        .single(),
+      async () =>
+        supabase
+          .from(this.tableName)
+          .upsert(data)
+          .select()
+          .single(),
       `${this.tableName}.upsert`
     );
   }
@@ -149,15 +154,16 @@ export abstract class BaseService<T = any> {
    */
   async softDelete(id: string): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
-      () => supabase
-        .from(this.tableName)
-        .update({ 
-          deleted_at: new Date().toISOString(),
-          updated_at: new Date().toISOString() 
-        })
-        .eq('id', id)
-        .select()
-        .single(),
+      async () =>
+        supabase
+          .from(this.tableName)
+          .update({
+            deleted_at: new Date().toISOString(),
+            updated_at: new Date().toISOString()
+          })
+          .eq('id', id)
+          .select()
+          .single(),
       `${this.tableName}.softDelete`
     );
   }

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -8,26 +8,45 @@
 export { BaseService } from './base-service';
 
 // User and Profile services
-export { 
-  UserService, 
-  ProfileService, 
-  userService, 
-  profileService 
+import {
+  UserService,
+  ProfileService,
+  userService,
+  profileService,
 } from './user-service';
 
+export {
+  UserService,
+  ProfileService,
+  userService,
+  profileService,
+};
+
 // Subscription services
+import {
+  SubscriptionService,
+  TransactionService,
+  subscriptionService,
+  transactionService,
+} from './subscription-service';
+
 export {
   SubscriptionService,
   TransactionService,
   subscriptionService,
-  transactionService
-} from './subscription-service';
+  transactionService,
+};
 
 // Resource purchase services
+import {
+  ResourcePurchaseService,
+  resourcePurchaseService,
+} from './resource-purchase-service';
+
 export {
   ResourcePurchaseService,
-  resourcePurchaseService
-} from './resource-purchase-service';
+  resourcePurchaseService,
+};
 
 // Enhanced Supabase client and utilities
 export { 

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -153,7 +153,7 @@ export class UserService extends BaseService<User> {
    */
   async searchUsers(query: string): Promise<DatabaseResponse<Array<{ id: string; full_name: string; email: string }>>> {
     return withErrorHandling(
-      () =>
+      async () =>
         supabase
           .from('profiles')
           .select('id, full_name, email')
@@ -174,11 +174,12 @@ export class ProfileService extends BaseService<Profile> {
    */
   async getByUserId(userId: string): Promise<DatabaseResponse<Profile>> {
     return withErrorHandling(
-      () => supabase
-        .from('profiles')
-        .select('*')
-        .eq('id', userId)
-        .single(),
+      async () =>
+        supabase
+          .from('profiles')
+          .select('*')
+          .eq('id', userId)
+          .single(),
       'ProfileService.getByUserId'
     );
   }
@@ -326,9 +327,10 @@ export class ProfileService extends BaseService<Profile> {
    */
   async getProfileWithSubscription(userId: string) {
     return withErrorHandling(
-      () => supabase
-        .from('profiles')
-        .select(`
+      async () =>
+        supabase
+          .from('profiles')
+          .select(`
           *,
           subscriptions:user_subscriptions(
             id,
@@ -339,8 +341,8 @@ export class ProfileService extends BaseService<Profile> {
             subscription_plans(name, features, category)
           )
         `)
-        .eq('id', userId)
-        .single(),
+          .eq('id', userId)
+          .single(),
       'ProfileService.getProfileWithSubscription'
     );
   }
@@ -414,7 +416,9 @@ export class ProfileService extends BaseService<Profile> {
 
         const allRequiredFields = [
           ...requiredFields,
-          ...(profile.account_type ? accountTypeSpecificFields[profile.account_type] || [] : [])
+          ...(profile.account_type
+            ? accountTypeSpecificFields[profile.account_type as AccountType] || []
+            : []),
         ];
 
         const completedFields = allRequiredFields.filter(field => {

--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -39,7 +39,7 @@ export const testConnection = async (): Promise<boolean> => {
 
 // Enhanced error handling wrapper with network error detection
 export const withErrorHandling = async <T>(
-  operation: () => Promise<{ data: T | null; error: any }>,
+  operation: () => PromiseLike<{ data: T | null; error: any }>,
   context: string
 ): Promise<{ data: T | null; error: Error | null }> => {
   try {


### PR DESCRIPTION
## Summary
- enhance the global auth context so sign-in and sign-up return structured auth state, eagerly refresh profile data, and create a fallback profile when Supabase has not opened a session yet
- harden shared services by allowing Supabase helpers to consume promise-like builders, adding missing subscription metadata types, and deferring environment lookups for payments/collaboration to runtime-safe helpers
- update tests and mocks so authentication flows work with the richer context contract

## Testing
- npm run test:jest -- AppContext *(fails: React act warnings and context expectations need to be updated for new async state handling)*

------
https://chatgpt.com/codex/tasks/task_e_68f059906414832897e010e0a0c75e2e