### PR TITLE
Improve Supabase auth handling for sign-up and profile creation

### DIFF
--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -16,6 +16,7 @@ export interface User {
   account_type?: AccountType;
   created_at?: string;
   updated_at?: string;
+  user_metadata?: Record<string, any>;
 }
 
 export type AccountType = 


### PR DESCRIPTION
## Summary
- persist Supabase auth metadata on user objects and forward it during sign up
- defer profile creation when Supabase blocks inserts until email verification and bootstrap profiles when users sign in
- update AppContext unit tests to cover metadata flow and deferred profile creation scenarios

## Testing
- npm run test
- npm run typecheck
- npm run test:jest -- src/contexts/__tests__/AppContext.test.tsx *(fails: TypeScript compile errors in existing subscription-service test helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68f0617e53b48328b4ed12fa2c5b3d5c