### PR TITLE
Protect log history endpoint with auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ VITE_MAX_PAYMENT_AMOUNT="1000000"
 # Environment
 VITE_APP_ENV="development"
 VITE_APP_NAME="WATHACI CONNECT"
+
+# Monitoring
+LOGS_API_TOKEN="set-a-secure-random-token"

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,13 @@ Run the backend tests with:
 npm --prefix backend test
 ```
 
+## Log Collection Endpoint
+
+- `POST /api/logs` stores application logs sent from the frontend or edge functions.
+- `GET /api/logs/history` returns the most recent log entries and **requires** the
+  `LOGS_API_TOKEN` bearer token. Set this token in your environment to protect
+  log history access.
+
 
 ## Supabase Edge Functions
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -27,7 +27,10 @@ const limiter = rateLimit({
 app.use(limiter); // Basic rate limiting
 
 const userRoutes = require('./routes/users');
+const logRoutes = require('./routes/logs');
+
 app.use('/users', userRoutes);
+app.use('/api/logs', logRoutes);
 
 const PORT = process.env.PORT || 3000;
 if (require.main === module) {

--- a/backend/routes/logs.js
+++ b/backend/routes/logs.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const Joi = require('joi');
+
+const validate = require('../middleware/validate');
+
+const router = express.Router();
+
+const MAX_LOG_HISTORY = 1000;
+const logs = [];
+
+const logSchema = Joi.object({
+  level: Joi.string()
+    .valid('error', 'warn', 'info', 'debug')
+    .default('info'),
+  message: Joi.string().min(1).required(),
+  timestamp: Joi.string().isoDate().optional(),
+}).unknown(true);
+
+const LOGS_API_TOKEN = process.env.LOGS_API_TOKEN;
+
+const extractToken = (authorizationHeader = '') => {
+  const header = authorizationHeader.trim();
+  if (header.toLowerCase().startsWith('bearer ')) {
+    return header.slice(7).trim();
+  }
+  return header || null;
+};
+
+const requireLogHistoryAuth = (req, res, next) => {
+  if (!LOGS_API_TOKEN) {
+    return res.status(403).json({ error: 'Log history access is not configured' });
+  }
+
+  const providedToken = extractToken(req.get('authorization') || '');
+  if (!providedToken || providedToken !== LOGS_API_TOKEN) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  next();
+};
+
+router.post('/', validate(logSchema), (req, res) => {
+  const logEntry = {
+    ...req.body,
+    timestamp: req.body.timestamp ?? new Date().toISOString(),
+  };
+
+  logs.push(logEntry);
+  if (logs.length > MAX_LOG_HISTORY) {
+    logs.shift();
+  }
+
+  res.status(201).json({ status: 'logged' });
+});
+
+router.get('/history', requireLogHistoryAuth, (req, res) => {
+  const requestedLimit = Number.parseInt(req.query.limit, 10);
+  const limit = Number.isFinite(requestedLimit) && requestedLimit > 0
+    ? Math.min(requestedLimit, logs.length)
+    : logs.length;
+
+  const startIndex = Math.max(logs.length - limit, 0);
+  const history = logs.slice(startIndex).reverse();
+
+  res.json({ logs: history });
+});
+
+module.exports = router;

--- a/test/backend-response.test.js
+++ b/test/backend-response.test.js
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import app from '../backend/index.js';
+
+process.env.LOGS_API_TOKEN = 'test-logs-token';
+
+const { default: app } = await import('../backend/index.js');
 
 // Ensure the server still responds after adding security middleware
 // Uses dynamic port to avoid conflicts
@@ -20,6 +23,40 @@ test('POST /users returns provided user data', async () => {
   assert.deepStrictEqual(data, {
     user: { name: 'Alice', email: 'alice@example.com' },
   });
+
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test('GET /api/logs/history requires auth and returns stored logs', async () => {
+  const server = app.listen(0);
+  const { port } = server.address();
+
+  const logRes = await fetch(`http://localhost:${port}/api/logs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      level: 'error',
+      message: 'Payment verification failed',
+      context: { reference: 'ref_123' },
+    }),
+  });
+
+  assert.strictEqual(logRes.status, 201);
+
+  const unauthorized = await fetch(`http://localhost:${port}/api/logs/history`);
+  assert.strictEqual(unauthorized.status, 401);
+
+  const historyRes = await fetch(`http://localhost:${port}/api/logs/history`, {
+    headers: { Authorization: `Bearer ${process.env.LOGS_API_TOKEN}` },
+  });
+
+  assert.strictEqual(historyRes.status, 200);
+  const historyData = await historyRes.json();
+  assert.ok(Array.isArray(historyData.logs));
+  assert.ok(
+    historyData.logs.some((entry) => entry.message === 'Payment verification failed'),
+    'Expected the stored log entry to be present in the history response',
+  );
 
   await new Promise((resolve) => server.close(resolve));
 });


### PR DESCRIPTION
## Summary
- add an Express logs router that stores log entries and secures the history endpoint with a bearer token
- expose the logs router through the backend app and document the new configuration
- update the sample environment file and backend tests to cover authenticated log history access

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68f0a949f5f48328bddec906d16d8030