### PR TITLE
Ensure Get Started registers users in backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -15,7 +15,8 @@ npm --prefix backend test
 
 ## API Endpoints
 
-- `POST /users` – Validates and echoes user payloads using Joi.
+- `POST /users` – Validates sign-up payloads, sanitizes input, prevents duplicate registrations by email, and stores the latest
+  registration in memory.
 - `POST /api/logs` – Accepts client-side error and activity logs, sanitizes payloads, stores a rolling in-memory history (up to 1000 entries), and
   prints them to the server console for monitoring.
 - `GET /api/logs` – Returns the most recent 50 log entries for operational diagnostics.

--- a/backend/middleware/validate.js
+++ b/backend/middleware/validate.js
@@ -3,7 +3,11 @@ const sanitizeHtml = require('sanitize-html');
 
 const sanitizeObject = (obj) => {
   if (typeof obj === 'string') {
-    return sanitizeHtml(obj);
+    return sanitizeHtml(obj, {
+      allowedTags: [],
+      allowedAttributes: {},
+      allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+    });
   }
   if (Array.isArray(obj)) {
     return obj.map(sanitizeObject);

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,16 +1,54 @@
 const express = require('express');
-const router = express.Router();
+const { randomUUID } = require('crypto');
 const Joi = require('joi');
 const validate = require('../middleware/validate');
 
+const router = express.Router();
+
+const ACCOUNT_TYPES = [
+  'sole_proprietor',
+  'professional',
+  'sme',
+  'investor',
+  'donor',
+  'government',
+];
+
 const userSchema = Joi.object({
-  name: Joi.string().required(),
-  email: Joi.string().email().required()
+  firstName: Joi.string().trim().min(1).required(),
+  lastName: Joi.string().trim().min(1).required(),
+  email: Joi.string().email().required(),
+  accountType: Joi.string()
+    .valid(...ACCOUNT_TYPES)
+    .required(),
+  company: Joi.string().trim().allow('', null).optional(),
+  mobileNumber: Joi.string().trim().allow('', null).optional(),
 });
 
+const registeredUsers = new Map();
+
 router.post('/', validate(userSchema), (req, res) => {
-  const user = req.body; // already sanitized in middleware
-  res.json({ user });
+  const { firstName, lastName, email, accountType, company, mobileNumber } = req.body;
+  const normalizedEmail = email.toLowerCase();
+
+  if (registeredUsers.has(normalizedEmail)) {
+    return res.status(409).json({ error: 'User already registered' });
+  }
+
+  const user = {
+    id: randomUUID(),
+    firstName,
+    lastName,
+    email: normalizedEmail,
+    accountType,
+    company: company ? company : null,
+    mobileNumber: mobileNumber ? mobileNumber : null,
+    registeredAt: new Date().toISOString(),
+  };
+
+  registeredUsers.set(normalizedEmail, user);
+
+  return res.status(201).json({ user });
 });
 
 module.exports = router;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}

--- a/src/lib/api/register-user.ts
+++ b/src/lib/api/register-user.ts
@@ -1,0 +1,82 @@
+const normalizeBaseUrl = (baseUrl: string | undefined) => {
+  if (!baseUrl) return '';
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+};
+
+const API_BASE_URL = normalizeBaseUrl(import.meta.env.VITE_API_BASE_URL);
+
+export type RegisterUserPayload = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  accountType: string;
+  company?: string | null;
+  mobileNumber?: string | null;
+};
+
+export type RegisterUserResponse = {
+  user: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    accountType: string;
+    company: string | null;
+    mobileNumber: string | null;
+    registeredAt: string;
+  };
+};
+
+const buildEndpoint = () => {
+  if (API_BASE_URL) {
+    return `${API_BASE_URL}/users`;
+  }
+  return '/users';
+};
+
+const extractErrorMessage = (data: unknown) => {
+  if (typeof data === 'object' && data && 'error' in data) {
+    const errorValue = (data as { error?: unknown }).error;
+    if (typeof errorValue === 'string' && errorValue.trim().length > 0) {
+      return errorValue;
+    }
+  }
+  return null;
+};
+
+export const registerUser = async (
+  payload: RegisterUserPayload,
+): Promise<RegisterUserResponse> => {
+  const endpoint = buildEndpoint();
+
+  let response: Response;
+
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (error) {
+    throw new Error('Unable to reach registration service. Please try again later.');
+  }
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch (error) {
+    if (!response.ok) {
+      throw new Error('Failed to register user with backend');
+    }
+    throw error;
+  }
+
+  if (!response.ok) {
+    const errorMessage = extractErrorMessage(data) || 'Failed to register user with backend';
+    throw new Error(errorMessage);
+  }
+
+  return data as RegisterUserResponse;
+};

--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -12,6 +12,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { User, Mail, Lock, Building, Eye, EyeOff, Phone } from 'lucide-react';
 import { useAppContext } from '@/contexts/AppContext';
 import { validatePhoneNumber } from '@/lib/payment-config';
+import { registerUser } from '@/lib/api/register-user';
 
 // Validation schema
 const getStartedSchema = z
@@ -95,6 +96,18 @@ export const GetStarted = () => {
         mobile_number: data.mobileNumber || null,
         full_name: `${data.firstName} ${data.lastName}`,
         profile_completed: false,
+      });
+
+      const trimmedCompany = data.company?.trim();
+      const trimmedMobile = data.mobileNumber?.trim();
+
+      await registerUser({
+        firstName: data.firstName.trim(),
+        lastName: data.lastName.trim(),
+        email: data.email.trim(),
+        accountType: data.accountType,
+        company: trimmedCompany ? trimmedCompany : null,
+        mobileNumber: trimmedMobile ? trimmedMobile : null,
       });
 
       navigate('/profile-setup');
@@ -322,10 +335,10 @@ export const GetStarted = () => {
           
           {/* Development bypass for testing - only show in dev mode */}
           {import.meta.env.DEV && (
-            <Button 
-              type="button" 
-              variant="outline" 
-              className="w-full mt-2" 
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full mt-2"
               onClick={async () => {
                 setLoading(true);
                 setServerError('');
@@ -336,6 +349,15 @@ export const GetStarted = () => {
                     account_type: 'sole_proprietor',
                     full_name: 'Dev Test',
                     profile_completed: false,
+                  });
+
+                  await registerUser({
+                    firstName: 'Dev',
+                    lastName: 'Test',
+                    email: 'dev-test@example.com',
+                    accountType: 'sole_proprietor',
+                    company: null,
+                    mobileNumber: null,
                   });
                   navigate('/profile-setup');
                 } catch (error: any) {

--- a/test/backend-response.test.js
+++ b/test/backend-response.test.js
@@ -5,21 +5,49 @@ import app from '../backend/index.js';
 // Ensure the server still responds after adding security middleware
 // Uses dynamic port to avoid conflicts
 
-test('POST /users returns provided user data', async () => {
+test('POST /users registers sanitized user payloads', async () => {
   const server = app.listen(0);
   const { port } = server.address();
 
   const res = await fetch(`http://localhost:${port}/users`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name: 'Alice', email: 'alice@example.com' }),
+    body: JSON.stringify({
+      firstName: ' Alice ',
+      lastName: ' <b>Ngoma</b> ',
+      email: 'ALICE@example.com',
+      accountType: 'sme',
+      company: '<i>Acme Corp</i>',
+      mobileNumber: '+260 96 1234567',
+    }),
   });
 
-  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.status, 201);
   const data = await res.json();
-  assert.deepStrictEqual(data, {
-    user: { name: 'Alice', email: 'alice@example.com' },
+
+  assert.ok(data.user.id);
+  assert.strictEqual(data.user.firstName, 'Alice');
+  assert.strictEqual(data.user.lastName, 'Ngoma');
+  assert.strictEqual(data.user.email, 'alice@example.com');
+  assert.strictEqual(data.user.accountType, 'sme');
+  assert.strictEqual(data.user.company, 'Acme Corp');
+  assert.strictEqual(data.user.mobileNumber, '+260 96 1234567');
+  assert.ok(Date.parse(data.user.registeredAt));
+
+  const duplicateRes = await fetch(`http://localhost:${port}/users`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      firstName: 'Alice',
+      lastName: 'Ngoma',
+      email: 'alice@example.com',
+      accountType: 'sme',
+    }),
   });
+
+  assert.strictEqual(duplicateRes.status, 409);
+  const duplicateBody = await duplicateRes.json();
+  assert.deepStrictEqual(duplicateBody, { error: 'User already registered' });
 
   await new Promise((resolve) => server.close(resolve));
 });


### PR DESCRIPTION
## Summary
- update the Express /users route to validate the Get Started payload, sanitize input, prevent duplicates, and document the new behavior
- add a frontend API helper and wire the Get Started flow (including the dev shortcut) to register users with the backend after Supabase sign-up
- strengthen sanitization middleware and expand backend tests to cover the new behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f0ace7f4288328a4ab589bdd08a392