### PR TITLE
Add Supabase persistence for backend registrations and logs

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -174,6 +174,31 @@ Manages payment transactions:
 - updated_at: TIMESTAMP
 ```
 
+#### `registrations` Table
+```sql
+- id: UUID (Primary Key)
+- first_name: TEXT
+- last_name: TEXT
+- email: TEXT (Unique, stored in lowercase)
+- account_type: TEXT
+- company: TEXT
+- mobile_number: TEXT
+- created_at: TIMESTAMP
+- updated_at: TIMESTAMP
+```
+
+#### `frontend_logs` Table
+```sql
+- id: UUID (Primary Key)
+- level: TEXT (info, warn, error, debug)
+- message: TEXT
+- context: JSONB
+- stack: TEXT
+- component_stack: TEXT
+- received_at: TIMESTAMP
+- created_at: TIMESTAMP
+```
+
 ## Usage Examples
 
 ### Basic User Operations

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,7 @@
 # Backend
 
-This backend uses [Express](https://expressjs.com/).
+This backend uses [Express](https://expressjs.com/) and can optionally persist
+data to Supabase when the necessary environment variables are provided.
 
 Security middleware:
 
@@ -15,12 +16,41 @@ npm --prefix backend test
 
 ## API Endpoints
 
-- `POST /users` – Validates sign-up payloads, sanitizes input, prevents duplicate registrations by email, and stores the latest
-  registration in memory.
-- `POST /api/logs` – Accepts client-side error and activity logs, sanitizes payloads, stores a rolling in-memory history (up to 1000 entries), and
-  prints them to the server console for monitoring.
+- `POST /users` – Validates sign-up payloads, sanitizes input, prevents duplicate
+  registrations by email, and persists each submission to the `registrations`
+  Supabase table when credentials are available (otherwise it falls back to an
+  in-memory store).
+- `POST /api/logs` – Accepts client-side error and activity logs, sanitizes
+  payloads, stores a rolling in-memory history (up to 1000 entries), prints them
+  to the server console for monitoring, and forwards them to the `frontend_logs`
+  Supabase table when configured.
 - `GET /api/logs` – Returns the most recent 50 log entries for operational diagnostics.
 
+## Supabase integration
+
+Set the following environment variables when deploying the backend to enable
+database persistence:
+
+```bash
+SUPABASE_URL="https://your-project.supabase.co"
+SUPABASE_SERVICE_ROLE_KEY="service-role-key"
+```
+
+The service role key is required because the backend performs server-side
+inserts regardless of user authentication. When these variables are missing the
+API still works, but data is kept only in memory.
+
+### Database schema
+
+Run the SQL files in [`backend/supabase`](./supabase) to provision the required
+tables and policies:
+
+- [`registrations.sql`](supabase/registrations.sql) creates the
+  `registrations` table that stores validated sign-up submissions.
+- [`frontend_logs.sql`](supabase/frontend_logs.sql) creates the
+  `frontend_logs` table for centralized logging.
+- [`profiles_policies.sql`](supabase/profiles_policies.sql) contains the
+  policies used by the existing Supabase profile features.
 
 ## Supabase Edge Functions
 

--- a/backend/lib/supabaseClient.js
+++ b/backend/lib/supabaseClient.js
@@ -1,0 +1,139 @@
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+const SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_KEY || '';
+
+const normalizeUrl = (url = '') => url.replace(/\/$/, '');
+
+const buildRestUrl = (baseUrl) => {
+  if (!baseUrl) return '';
+  return `${normalizeUrl(baseUrl)}/rest/v1`;
+};
+
+const config = {
+  baseUrl: normalizeUrl(SUPABASE_URL),
+  restUrl: buildRestUrl(SUPABASE_URL),
+  serviceKey: SUPABASE_SERVICE_ROLE_KEY,
+};
+
+const isSupabaseConfigured = () => Boolean(config.baseUrl && config.serviceKey);
+
+const parseJsonResponse = async (response) => {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    const parseError = new Error('Failed to parse Supabase response as JSON');
+    parseError.cause = error;
+    parseError.status = response.status;
+    throw parseError;
+  }
+};
+
+const createRequestUrl = (table, searchParams = {}) => {
+  if (!config.restUrl) {
+    throw new Error('Supabase is not configured');
+  }
+
+  const url = new URL(`${config.restUrl}/${table}`);
+
+  Object.entries(searchParams).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+    url.searchParams.set(key, String(value));
+  });
+
+  return url;
+};
+
+const supabaseRequest = async (table, { method = 'GET', searchParams, body, headers = {} } = {}) => {
+  if (!isSupabaseConfigured()) {
+    throw new Error('Supabase is not configured');
+  }
+
+  const url = createRequestUrl(table, searchParams);
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      apikey: config.serviceKey,
+      Authorization: `Bearer ${config.serviceKey}`,
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const data = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    const error = new Error(data?.message || 'Supabase request failed');
+    error.status = response.status;
+    error.code = data?.code;
+    error.details = data;
+    throw error;
+  }
+
+  return data;
+};
+
+const buildFilterValue = (value) => {
+  if (Array.isArray(value)) {
+    const formattedValues = value.map((item) => `"${item}"`).join(',');
+    return `in.(${formattedValues})`;
+  }
+
+  return `eq.${value}`;
+};
+
+const select = async (
+  table,
+  {
+    columns = '*',
+    filters = {},
+    limit,
+    single = false,
+  } = {},
+) => {
+  const searchParams = { select: columns };
+
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+    searchParams[key] = buildFilterValue(value);
+  });
+
+  if (limit) {
+    searchParams.limit = String(limit);
+  }
+
+  const data = await supabaseRequest(table, { searchParams });
+
+  if (single) {
+    return Array.isArray(data) && data.length > 0 ? data[0] : null;
+  }
+
+  return Array.isArray(data) ? data : [];
+};
+
+const insert = async (table, payload) => {
+  const body = Array.isArray(payload) ? payload : [payload];
+
+  const data = await supabaseRequest(table, {
+    method: 'POST',
+    headers: {
+      Prefer: 'return=representation',
+    },
+    body,
+  });
+
+  return Array.isArray(data) ? data : [];
+};
+
+module.exports = {
+  isSupabaseConfigured,
+  supabaseRequest,
+  select,
+  insert,
+};

--- a/backend/services/log-store.js
+++ b/backend/services/log-store.js
@@ -1,0 +1,37 @@
+const { randomUUID } = require('crypto');
+const { isSupabaseConfigured, insert } = require('../lib/supabaseClient');
+
+class LogStoreError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = 'LogStoreError';
+  }
+}
+
+const persistLog = async (log) => {
+  if (!isSupabaseConfigured()) {
+    return;
+  }
+
+  const payload = {
+    id: randomUUID(),
+    level: log.level,
+    message: log.message,
+    context: log.context ?? null,
+    stack: log.stack ?? null,
+    component_stack: log.componentStack ?? null,
+    received_at: log.receivedAt,
+    created_at: log.receivedAt,
+  };
+
+  try {
+    await insert('frontend_logs', payload);
+  } catch (error) {
+    throw new LogStoreError('Failed to persist log entry to Supabase', { cause: error });
+  }
+};
+
+module.exports = {
+  persistLog,
+  LogStoreError,
+};

--- a/backend/services/registration-store.js
+++ b/backend/services/registration-store.js
@@ -1,0 +1,125 @@
+const { randomUUID } = require('crypto');
+const sanitizeHtml = require('sanitize-html');
+const { isSupabaseConfigured, insert } = require('../lib/supabaseClient');
+
+class DuplicateRegistrationError extends Error {
+  constructor(message = 'User already registered') {
+    super(message);
+    this.name = 'DuplicateRegistrationError';
+    this.status = 409;
+  }
+}
+
+class RegistrationStoreError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = 'RegistrationStoreError';
+  }
+}
+
+const fallbackRegistrations = new Map();
+
+const sanitizeString = (value) => {
+  if (value === undefined || value === null) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+
+  const sanitized = sanitizeHtml(trimmed, {
+    allowedTags: [],
+    allowedAttributes: {},
+  });
+
+  return sanitized.replace(/\s+/g, ' ').trim();
+};
+
+const normalizeRegistrationPayload = (payload) => {
+  const firstName = sanitizeString(payload.firstName);
+  const lastName = sanitizeString(payload.lastName);
+  const email = sanitizeString(payload.email)?.toLowerCase();
+  const company = sanitizeString(payload.company);
+  const mobileNumber = sanitizeString(payload.mobileNumber);
+  const accountType = sanitizeString(payload.accountType);
+
+  return {
+    id: randomUUID(),
+    first_name: firstName,
+    last_name: lastName,
+    email,
+    account_type: accountType,
+    company,
+    mobile_number: mobileNumber,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+};
+
+const mapRecordToResponse = (record) => ({
+  id: record.id,
+  firstName: record.first_name,
+  lastName: record.last_name,
+  email: record.email,
+  accountType: record.account_type,
+  company: record.company ?? null,
+  mobileNumber: record.mobile_number ?? null,
+  registeredAt: record.created_at ?? record.registered_at ?? new Date().toISOString(),
+});
+
+const isDuplicateSupabaseError = (error) => {
+  if (!error) return false;
+  return error.code === '23505' || error.status === 409;
+};
+
+const storeInMemory = (record) => {
+  if (fallbackRegistrations.has(record.email)) {
+    throw new DuplicateRegistrationError();
+  }
+
+  fallbackRegistrations.set(record.email, record);
+  return mapRecordToResponse(record);
+};
+
+const storeInSupabase = async (record) => {
+  try {
+    const [inserted] = await insert('registrations', record);
+    return mapRecordToResponse(inserted || record);
+  } catch (error) {
+    if (isDuplicateSupabaseError(error)) {
+      throw new DuplicateRegistrationError();
+    }
+
+    throw new RegistrationStoreError('Failed to persist registration to Supabase', { cause: error });
+  }
+};
+
+const registerUser = async (payload) => {
+  const record = normalizeRegistrationPayload(payload);
+
+  if (!record.email) {
+    throw new RegistrationStoreError('Registration email is required after sanitization');
+  }
+
+  if (isSupabaseConfigured()) {
+    try {
+      return await storeInSupabase(record);
+    } catch (error) {
+      if (error instanceof DuplicateRegistrationError) {
+        throw error;
+      }
+
+      console.error('[registration-store] Supabase insert failed, falling back to in-memory storage', error);
+    }
+  }
+
+  return storeInMemory(record);
+};
+
+const getFallbackRegistrations = () => {
+  return Array.from(fallbackRegistrations.values()).map(mapRecordToResponse);
+};
+
+module.exports = {
+  registerUser,
+  DuplicateRegistrationError,
+  RegistrationStoreError,
+  getFallbackRegistrations,
+};

--- a/backend/supabase/frontend_logs.sql
+++ b/backend/supabase/frontend_logs.sql
@@ -1,0 +1,21 @@
+-- Stores sanitized client-side logs forwarded by the Express backend.
+create table if not exists public.frontend_logs (
+  id uuid primary key default gen_random_uuid(),
+  level text not null default 'info',
+  message text not null,
+  context jsonb,
+  stack text,
+  component_stack text,
+  received_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists frontend_logs_received_at_idx on public.frontend_logs (received_at desc);
+
+alter table public.frontend_logs enable row level security;
+
+create policy if not exists "frontend_logs_service_insert"
+  on public.frontend_logs
+  for insert
+  to service_role
+  with check (true);

--- a/backend/supabase/registrations.sql
+++ b/backend/supabase/registrations.sql
@@ -1,0 +1,31 @@
+-- Registrations table stores sign-up submissions received by the Express API.
+create table if not exists public.registrations (
+  id uuid primary key default gen_random_uuid(),
+  first_name text not null,
+  last_name text not null,
+  email text not null,
+  account_type text not null,
+  company text,
+  mobile_number text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Prevent duplicate registrations for the same email address.
+create unique index if not exists registrations_email_key on public.registrations (lower(email));
+
+-- Make the table available to authenticated clients if needed.
+alter table public.registrations enable row level security;
+
+-- Allow service role inserts by default (the backend uses the service key).
+create policy if not exists "registrations_service_insert"
+  on public.registrations
+  for insert
+  to service_role
+  with check (true);
+
+create policy if not exists "registrations_service_select"
+  on public.registrations
+  for select
+  to service_role
+  using (true);


### PR DESCRIPTION
## Summary
- add a lightweight Supabase REST client plus services so registrations and logs can be written to the database
- update the Express routes to persist data to Supabase when configured while keeping the in-memory fallback
- document the required backend tables and provide SQL for provisioning registrations and frontend log storage

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68f0d757fa308328b91ee0a677928a6b