### PR TITLE
Enforce payment readiness checks and stabilize onboarding

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { logPaymentReadiness } = require('./lib/payment-readiness');
 
 let helmet;
 try {
@@ -15,6 +16,8 @@ try {
 }
 
 const app = express();
+
+logPaymentReadiness();
 
 app.use(express.json());
 
@@ -56,8 +59,10 @@ app.use((req, res, next) => {
 
 const userRoutes = require('./routes/users');
 const logRoutes = require('./routes/logs');
+const paymentRoutes = require('./routes/payment');
 app.use('/users', userRoutes);
 app.use('/api/logs', logRoutes);
+app.use('/api/payment', paymentRoutes);
 
 const PORT = process.env.PORT || 3000;
 if (require.main === module) {

--- a/backend/lib/payment-readiness.js
+++ b/backend/lib/payment-readiness.js
@@ -1,0 +1,145 @@
+const LIVE_PUBLIC_KEY_PREFIX = 'pk_live_';
+const TEST_PUBLIC_KEY_PREFIX = 'pk_test_';
+const LIVE_SECRET_KEY_PREFIX = 'sk_live_';
+const TEST_SECRET_KEY_PREFIX = 'sk_test_';
+
+const ENV_KEYS = {
+  publicKey: ['VITE_LENCO_PUBLIC_KEY', 'LENCO_PUBLIC_KEY'],
+  secretKey: ['LENCO_SECRET_KEY', 'VITE_LENCO_SECRET_KEY'],
+  webhookUrl: ['LENCO_WEBHOOK_URL', 'PAYMENT_WEBHOOK_URL', 'VITE_LENCO_WEBHOOK_URL'],
+  webhookSecret: ['LENCO_WEBHOOK_SECRET'],
+  supabaseUrl: ['SUPABASE_URL', 'VITE_SUPABASE_URL'],
+  serviceRoleKey: ['SUPABASE_SERVICE_ROLE_KEY', 'SUPABASE_SERVICE_KEY', 'SUPABASE_KEY'],
+  environment: ['APP_ENV', 'NODE_ENV', 'VITE_APP_ENV'],
+};
+
+const normalizeEnvValue = (value) => {
+  if (!value) return '';
+  return String(value).trim();
+};
+
+const readEnvValue = (keys) => {
+  for (const key of keys) {
+    const value = normalizeEnvValue(process.env[key]);
+    if (value) {
+      return { key, value };
+    }
+  }
+  return { key: keys[0], value: '' };
+};
+
+const interpretEnvironment = () => {
+  const envValue = readEnvValue(ENV_KEYS.environment).value.toLowerCase();
+  if (envValue === 'prod' || envValue === 'production') {
+    return 'production';
+  }
+  return envValue || 'development';
+};
+
+const buildIssue = (severity, message) => ({ severity, message });
+
+const cached = { logged: false };
+
+const getPaymentReadiness = () => {
+  const errors = [];
+  const warnings = [];
+
+  const publicKeyEntry = readEnvValue(ENV_KEYS.publicKey);
+  const secretKeyEntry = readEnvValue(ENV_KEYS.secretKey);
+  const webhookUrlEntry = readEnvValue(ENV_KEYS.webhookUrl);
+  const webhookSecretEntry = readEnvValue(ENV_KEYS.webhookSecret);
+  const supabaseUrlEntry = readEnvValue(ENV_KEYS.supabaseUrl);
+  const serviceRoleEntry = readEnvValue(ENV_KEYS.serviceRoleKey);
+
+  const environment = interpretEnvironment();
+  const isProduction = environment === 'production';
+
+  const details = {
+    environment,
+    publicKeySource: publicKeyEntry.key,
+    webhookUrlSource: webhookUrlEntry.key,
+    supabaseConfigured: Boolean(supabaseUrlEntry.value),
+    serviceRoleConfigured: Boolean(serviceRoleEntry.value),
+  };
+
+  if (!supabaseUrlEntry.value) {
+    errors.push(buildIssue('error', 'SUPABASE_URL is not configured. Set SUPABASE_URL for backend persistence.'));
+  }
+
+  if (!serviceRoleEntry.value) {
+    errors.push(buildIssue('error', 'SUPABASE_SERVICE_ROLE_KEY is missing. Configure the service role key to enable persistence.'));
+  }
+
+  if (!publicKeyEntry.value) {
+    errors.push(buildIssue('error', 'Lenco public key is not configured. Set VITE_LENCO_PUBLIC_KEY with your live key.'));
+  } else if (isProduction && publicKeyEntry.value.startsWith(TEST_PUBLIC_KEY_PREFIX)) {
+    errors.push(
+      buildIssue(
+        'error',
+        'Lenco public key is using a test key (pk_test_). Replace it with the live pk_live_ key before going live.'
+      )
+    );
+  } else if (!publicKeyEntry.value.startsWith(LIVE_PUBLIC_KEY_PREFIX)) {
+    warnings.push(
+      buildIssue(
+        'warning',
+        'Lenco public key does not use the expected live prefix (pk_live_). Double-check that production keys are configured.'
+      )
+    );
+  }
+
+  if (!secretKeyEntry.value) {
+    errors.push(buildIssue('error', 'LENCO_SECRET_KEY is missing. Configure the live sk_live_ secret key for server-side calls.'));
+  } else if (isProduction && secretKeyEntry.value.startsWith(TEST_SECRET_KEY_PREFIX)) {
+    errors.push(
+      buildIssue(
+        'error',
+        'LENCO_SECRET_KEY is using a test key (sk_test_). Replace it with the live sk_live_ key for production payments.'
+      )
+    );
+  }
+
+  if (!webhookSecretEntry.value) {
+    errors.push(buildIssue('error', 'LENCO_WEBHOOK_SECRET is not set. Configure the webhook secret from the Lenco dashboard.'));
+  }
+
+  if (!webhookUrlEntry.value) {
+    errors.push(buildIssue('error', 'LENCO_WEBHOOK_URL is not configured. Provide the deployed webhook endpoint URL.'));
+  } else if (!/^https:\/\//i.test(webhookUrlEntry.value)) {
+    errors.push(buildIssue('error', 'LENCO_WEBHOOK_URL must be an HTTPS URL.'));
+  }
+
+  const status = errors.length > 0 ? 'error' : warnings.length > 0 ? 'warning' : 'ready';
+
+  return {
+    status,
+    environment,
+    errors,
+    warnings,
+    details,
+  };
+};
+
+const logPaymentReadiness = () => {
+  if (cached.logged) {
+    return;
+  }
+  cached.logged = true;
+
+  const readiness = getPaymentReadiness();
+
+  if (readiness.errors.length > 0) {
+    console.error('[payment-readiness] Configuration errors detected:',
+      readiness.errors.map((issue) => issue.message));
+  } else if (readiness.warnings.length > 0) {
+    console.warn('[payment-readiness] Configuration warnings:',
+      readiness.warnings.map((issue) => issue.message));
+  } else {
+    console.log('[payment-readiness] Lenco payment integration verified for', readiness.environment, 'environment.');
+  }
+};
+
+module.exports = {
+  getPaymentReadiness,
+  logPaymentReadiness,
+};

--- a/backend/routes/payment.js
+++ b/backend/routes/payment.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { getPaymentReadiness } = require('../lib/payment-readiness');
+
+const router = express.Router();
+
+router.get('/readiness', (req, res) => {
+  const readiness = getPaymentReadiness();
+  const hasErrors = readiness.errors.length > 0;
+  res.status(hasErrors ? 503 : 200).json(readiness);
+});
+
+module.exports = router;

--- a/docs/PAYMENT_INTEGRATION_GUIDE.md
+++ b/docs/PAYMENT_INTEGRATION_GUIDE.md
@@ -66,6 +66,7 @@ VITE_SUPABASE_KEY="your-anon-key"
 VITE_LENCO_PUBLIC_KEY="pub-dea560c94d379a23e7b85a265d7bb9acbd585481e6e1393e"
 LENCO_SECRET_KEY="843a2b242591e9a58370da44e11bb2575b20780f27c8efe39a6ed24ecba0b668"
 LENCO_WEBHOOK_SECRET="bc09f682f3bbbf3d851b125b9914984c272471e16cd2a4f14f9406706f7c98cd293bf0d"
+LENCO_WEBHOOK_URL="https://your-project.functions.supabase.co/payment-webhook"
 VITE_LENCO_API_URL="https://api.lenco.co/access/v2"
 
 # Payment Configuration
@@ -123,7 +124,8 @@ VITE_APP_NAME="WATHACI CONNECT"
    ```bash
    supabase secrets set \
      LENCO_SECRET_KEY="843a2b242591e9a58370da44e11bb2575b20780f27c8efe39a6ed24ecba0b668" \
-     LENCO_WEBHOOK_SECRET="bc09f682f3bbbf3d851b125b9914984c272471e16cd2a4f14f9406706f7c98cd293bf0d"
+     LENCO_WEBHOOK_SECRET="bc09f682f3bbbf3d851b125b9914984c272471e16cd2a4f14f9406706f7c98cd293bf0d" \
+     LENCO_WEBHOOK_URL="https://<project-ref>.functions.supabase.co/payment-webhook"
    ```
 5. **Verify deployment** – note the generated URL:
    `https://<project-ref>.functions.supabase.co/lenco-webhook`
@@ -134,6 +136,7 @@ VITE_APP_NAME="WATHACI CONNECT"
 2. In the Lenco dashboard, open **Developer > Webhooks**.
 3. Add the function URL as your webhook endpoint.
 4. Use the same `LENCO_WEBHOOK_SECRET` value to validate incoming requests.
+5. Set `LENCO_WEBHOOK_URL` in your environment (backend and frontend) so readiness checks can validate the deployed endpoint.
 
 ### Environment Variables
 
@@ -344,6 +347,16 @@ const sanitizedData = paymentSecurityService.sanitizePaymentData(paymentData);
 - Set daily/monthly transaction limits
 
 ## Testing
+
+### 0. Configuration Readiness
+
+Before initiating payments, verify the environment with the readiness endpoint:
+
+```bash
+curl -s https://your-backend.example.com/api/payment/readiness | jq
+```
+
+The response should report a `ready` status with no errors. Address any warnings before processing live transactions.
 
 ### 1. Payment Test Suite
 

--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -68,11 +68,16 @@ export interface BusinessInfo {
 
 export interface PaymentInfo {
   payment_method: 'phone' | 'card';
-  payment_phone?: string;
+  payment_phone?: string | null;
   card_details?: {
-    number: string;
-    expiry: string;
-  };
+    provider: 'lenco';
+    status?: 'external_gateway' | 'tokenized' | 'pending_verification';
+    setup_required?: boolean;
+    last4?: string;
+    exp_month?: string;
+    exp_year?: string;
+    expiry?: string;
+  } | null;
   use_same_phone?: boolean;
 }
 

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Checkbox } from '@/components/ui/checkbox';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { CountrySelect } from '@/components/CountrySelect';
@@ -320,12 +321,21 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
                 {formData.payment_method === 'phone' && (
                   <div>
                     <Label>Payment Phone Number</Label>
-                    <Input 
+                    <Input
                       value={formData.payment_phone}
                       onChange={(e) => handleInputChange('payment_phone', e.target.value)}
                       placeholder="Country code will be auto-filled"
                     />
                   </div>
+                )}
+
+                {formData.payment_method === 'card' && (
+                  <Alert>
+                    <AlertDescription>
+                      Card payments are processed securely by Lenco. We will record that you prefer card billing, but card numbers
+                      are collected on the Lenco checkout and never stored in this form.
+                    </AlertDescription>
+                  </Alert>
                 )}
               </div>
             )}

--- a/src/lib/payment-readiness.ts
+++ b/src/lib/payment-readiness.ts
@@ -1,0 +1,67 @@
+import { getPaymentConfig, getPaymentEnvValue, PaymentConfig } from './payment-config';
+
+export type PaymentIssueSeverity = 'error' | 'warning';
+
+export interface PaymentReadinessIssue {
+  severity: PaymentIssueSeverity;
+  message: string;
+}
+
+export interface PaymentReadiness {
+  status: 'ready' | 'warning' | 'error';
+  issues: PaymentReadinessIssue[];
+  config: PaymentConfig;
+}
+
+const LIVE_PUBLIC_KEY_PREFIX = 'pk_live_';
+const TEST_PUBLIC_KEY_PREFIX = 'pk_test_';
+
+const resolveWebhookUrl = (): string | undefined => {
+  return getPaymentEnvValue('VITE_LENCO_WEBHOOK_URL') || getPaymentEnvValue('LENCO_WEBHOOK_URL');
+};
+
+export const evaluatePaymentReadiness = (): PaymentReadiness => {
+  const config = getPaymentConfig();
+  const issues: PaymentReadinessIssue[] = [];
+
+  if (!config.publicKey) {
+    issues.push({ severity: 'error', message: 'Lenco public key is not configured.' });
+  } else if (config.environment === 'production' && config.publicKey.startsWith(TEST_PUBLIC_KEY_PREFIX)) {
+    issues.push({
+      severity: 'error',
+      message: 'Production environment is using a test public key (pk_test_). Switch to your live pk_live_ key.',
+    });
+  } else if (!config.publicKey.startsWith(LIVE_PUBLIC_KEY_PREFIX)) {
+    issues.push({
+      severity: 'warning',
+      message: 'Lenco public key does not start with pk_live_. Ensure the correct key is provided before going live.',
+    });
+  }
+
+  if (!config.webhookUrl) {
+    const configuredWebhook = resolveWebhookUrl();
+    if (!configuredWebhook) {
+      issues.push({
+        severity: config.environment === 'production' ? 'error' : 'warning',
+        message: 'Lenco webhook URL is not configured. Configure LENCO_WEBHOOK_URL to receive payment events.',
+      });
+    }
+  } else if (!/^https:\/\//i.test(config.webhookUrl)) {
+    issues.push({
+      severity: 'error',
+      message: 'Lenco webhook URL must be an HTTPS endpoint.',
+    });
+  }
+
+  const status = issues.some(issue => issue.severity === 'error')
+    ? 'error'
+    : issues.length > 0
+      ? 'warning'
+      : 'ready';
+
+  return {
+    status,
+    issues,
+    config,
+  };
+};

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -441,11 +441,19 @@ export class ProfileService extends BaseService<Profile> {
    * Update payment information
    */
   async updatePaymentInfo(
-    userId: string, 
+    userId: string,
     paymentData: {
       payment_method: 'phone' | 'card';
-      payment_phone?: string;
-      card_details?: { number: string; expiry: string };
+      payment_phone?: string | null;
+      card_details?: {
+        provider: 'lenco';
+        status?: 'external_gateway' | 'tokenized' | 'pending_verification';
+        setup_required?: boolean;
+        last4?: string;
+        exp_month?: string;
+        exp_year?: string;
+        expiry?: string;
+      } | null;
       use_same_phone?: boolean;
     }
   ): Promise<DatabaseResponse<Profile>> {


### PR DESCRIPTION
## Summary
- add backend payment readiness validation with an API endpoint and integrate it into server startup logging
- require Supabase persistence for registrations unless an opt-in fallback is enabled and surface readiness status in the payment test UI
- sanitize card onboarding data so Supabase receives stable metadata and document the new webhook URL and readiness workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f129e24e4c832883ffc490b6fb902f