### PR TITLE
Ensure Supabase profile JSON columns and card capture

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -131,6 +131,12 @@ Manages payment transactions:
 - updated_at: TIMESTAMP
 ```
 
+> **Note:** Run [`backend/supabase/profiles_schema.sql`](backend/supabase/profiles_schema.sql)
+> after provisioning the base table to guarantee the `qualifications`,
+> `coordinates`, and `card_details` columns are JSONB. The script safely converts
+> existing data where possible so the nested payloads emitted by the frontend
+> profile forms can be stored without Supabase returning 400-level errors.
+
 #### `subscription_plans` Table
 ```sql
 - id: UUID (Primary Key)

--- a/backend/README.md
+++ b/backend/README.md
@@ -51,6 +51,9 @@ tables and policies:
   `frontend_logs` table for centralized logging.
 - [`profiles_policies.sql`](supabase/profiles_policies.sql) contains the
   policies used by the existing Supabase profile features.
+- [`profiles_schema.sql`](supabase/profiles_schema.sql) normalizes the
+  `profiles` table so nested JSON payloads (`qualifications`, `coordinates`,
+  `card_details`) emitted by the frontend can be stored without casting errors.
 
 ## Supabase Edge Functions
 

--- a/backend/supabase/profiles_schema.sql
+++ b/backend/supabase/profiles_schema.sql
@@ -1,0 +1,96 @@
+-- Ensure the profiles table supports nested JSON payloads used by the frontend
+-- forms. This script can be executed from the Supabase SQL editor or via the
+-- Supabase CLI (e.g. `supabase db query < backend/supabase/profiles_schema.sql`).
+
+begin;
+
+-- Ensure the qualifications column exists and uses JSONB so arrays of nested
+-- qualification objects can be persisted without 400-level validation errors.
+do $$
+declare
+  col_type text;
+begin
+  select data_type
+    into col_type
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'profiles'
+    and column_name = 'qualifications';
+
+  if col_type is null then
+    alter table public.profiles
+      add column qualifications jsonb default '[]'::jsonb;
+  elsif col_type <> 'jsonb' then
+    alter table public.profiles
+      alter column qualifications type jsonb using (
+        case
+          when qualifications is null then '[]'::jsonb
+          when trim(qualifications::text) = '' then '[]'::jsonb
+          when left(trim(qualifications::text), 1) in ('{', '[') then qualifications::jsonb
+          else '[]'::jsonb
+        end
+      );
+  end if;
+
+  -- drop the default once the column exists to avoid unexpected implicit values
+  alter table public.profiles
+    alter column qualifications drop default;
+end $$;
+
+-- Ensure the coordinates column exists and is JSONB so the geocoded
+-- latitude/longitude pair from the address autocomplete widget can be stored.
+do $$
+declare
+  col_type text;
+begin
+  select data_type
+    into col_type
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'profiles'
+    and column_name = 'coordinates';
+
+  if col_type is null then
+    alter table public.profiles add column coordinates jsonb;
+  elsif col_type <> 'jsonb' then
+    alter table public.profiles
+      alter column coordinates type jsonb using (
+        case
+          when coordinates is null then null
+          when trim(coordinates::text) = '' then null
+          when left(trim(coordinates::text), 1) in ('{', '[') then coordinates::jsonb
+          else null
+        end
+      );
+  end if;
+end $$;
+
+-- Ensure the card_details column exists and is JSONB so masked card metadata
+-- can be stored while keeping sensitive fields off the database.
+do $$
+declare
+  col_type text;
+begin
+  select data_type
+    into col_type
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'profiles'
+    and column_name = 'card_details';
+
+  if col_type is null then
+    alter table public.profiles add column card_details jsonb;
+  elsif col_type <> 'jsonb' then
+    alter table public.profiles
+      alter column card_details type jsonb using (
+        case
+          when card_details is null then null
+          when trim(card_details::text) = '' then null
+          when left(trim(card_details::text), 1) in ('{', '[') then card_details::jsonb
+          else null
+        end
+      );
+  end if;
+end $$;
+
+commit;

--- a/docs/frontend-diagnostics.md
+++ b/docs/frontend-diagnostics.md
@@ -43,13 +43,15 @@ paths, expected payloads, and potential sources of client-side errors.
    failures into user-friendly error messages, but network outages will still be
    surfaced as exceptions in the console.
 2. **Profile upsert validation** – The profile `upsert` sends nested JSON
-   structures (e.g. `qualifications`, `coordinates`, `card_details`). Supabase
-   columns must be declared with compatible JSONB types; otherwise, the insert
-   will fail with a 400 response logged in the console.
-3. **Missing card inputs** – When `payment_method` is `card`, the form does not
-   currently collect card number/expiry fields, so the `card_details` object is
-   sent with undefined values. Supabase schemas that expect concrete strings may
-   reject the payload, generating client-side errors.
+   structures (e.g. `qualifications`, `coordinates`, `card_details`). Run
+   [`backend/supabase/profiles_schema.sql`](../backend/supabase/profiles_schema.sql)
+   so the Supabase columns are JSONB; otherwise, the insert will fail with a 400
+   response logged in the console.
+3. **Complete card capture** – When `payment_method` is `card`, the form now
+   collects the cardholder name, card number, and expiry. The submission logic
+   stores only masked metadata (`last4`, `expiry_month`, `expiry_year`,
+   `cardholder_name`) to keep sensitive fields off Supabase while satisfying the
+   validation rules required for card-based sign-ups.
 4. **Existing row conflicts** – The initial account type `upsert` includes a
    `created_at` timestamp each time. If the column is configured as
    non-updatable or expects server defaults, Supabase will respond with an

--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -70,17 +70,21 @@ export interface PaymentInfo {
   payment_method: 'phone' | 'card';
   payment_phone?: string;
   card_details?: {
-    number: string;
-    expiry: string;
+    last4: string;
+    expiry_month: number;
+    expiry_year: number;
+    cardholder_name?: string | null;
   };
   use_same_phone?: boolean;
 }
 
 export interface ProfessionalInfo {
-  qualifications: Array<{
-    name: string;
-    institution: string;
-    year: number;
+  qualifications?: Array<{
+    institution?: string | null;
+    degree?: string | null;
+    name?: string | null;
+    field?: string | null;
+    year?: string | null;
   }>;
   experience_years?: number;
   specialization?: string;

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -32,6 +32,7 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
     payment_phone: '',
     card_number: '',
     card_expiry: '',
+    cardholder_name: initialData?.card_details?.cardholder_name || '',
     profile_image_url: null,
     linkedin_url: '',
     ...initialData
@@ -42,6 +43,7 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
     initialData?.card_details?.expiry_month && initialData?.card_details?.expiry_year
       ? `${String(initialData.card_details.expiry_month).padStart(2, '0')}/${String(initialData.card_details.expiry_year).slice(-2)}`
       : undefined;
+  const savedCardholderName = initialData?.card_details?.cardholder_name;
 
   useEffect(() => {
     if (!initialData) {
@@ -57,6 +59,7 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
         payment_method: initialData.payment_method || prev.payment_method,
         use_same_phone: shouldUseCard ? false : initialData.use_same_phone ?? prev.use_same_phone,
         payment_phone: initialData.payment_phone ?? prev.payment_phone,
+        cardholder_name: initialData.card_details?.cardholder_name ?? prev.cardholder_name,
         card_number: shouldUseCard ? '' : prev.card_number,
         card_expiry: shouldUseCard ? '' : prev.card_expiry,
       };
@@ -121,6 +124,7 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
       payment_phone: isChecked ? '' : prev.payment_phone,
       card_number: isChecked ? '' : prev.card_number,
       card_expiry: isChecked ? '' : prev.card_expiry,
+      cardholder_name: isChecked ? '' : prev.cardholder_name,
     }));
   };
 
@@ -385,6 +389,15 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
                 {formData.payment_method === 'card' && (
                   <div className="space-y-4">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <div className="md:col-span-2">
+                        <Label>Cardholder Name</Label>
+                        <Input
+                          value={formData.cardholder_name}
+                          onChange={(e) => handleInputChange('cardholder_name', e.target.value)}
+                          autoComplete="cc-name"
+                          placeholder={savedCardholderName || 'Jane Doe'}
+                        />
+                      </div>
                       <div>
                         <Label>Card Number</Label>
                         <Input

--- a/src/components/ProfileReview.tsx
+++ b/src/components/ProfileReview.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
-import { Edit, MapPin, Phone, Mail, Building, Calendar, Users, DollarSign } from 'lucide-react';
+import { Edit, MapPin, Phone, Mail, Building, Calendar, Users, DollarSign, CreditCard } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
 export const ProfileReview = () => {
@@ -87,6 +87,48 @@ export const ProfileReview = () => {
       'government': 'Government Institution'
     };
     return labels[type as keyof typeof labels] || type;
+  };
+
+  const formatQualification = (qualification: unknown) => {
+    if (!qualification) {
+      return null;
+    }
+
+    if (typeof qualification === 'string') {
+      return qualification;
+    }
+
+    if (typeof qualification === 'object') {
+      const qual = qualification as {
+        degree?: string | null;
+        name?: string | null;
+        institution?: string | null;
+        year?: string | null;
+        field?: string | null;
+      };
+
+      const title = qual.degree || qual.name || qual.field;
+      const institution = qual.institution ? ` – ${qual.institution}` : '';
+      const year = qual.year ? ` (${qual.year})` : '';
+
+      if (!title && !institution && !year) {
+        return null;
+      }
+
+      return `${title ?? 'Qualification'}${institution}${year}`;
+    }
+
+    return null;
+  };
+
+  const formatCardExpiry = (card: any) => {
+    if (!card?.expiry_month || !card?.expiry_year) {
+      return null;
+    }
+
+    const month = String(card.expiry_month).padStart(2, '0');
+    const year = card.expiry_year.toString().slice(-2);
+    return `${month}/${year}`;
   };
 
   return (
@@ -210,9 +252,16 @@ export const ProfileReview = () => {
                   <div>
                     <h4 className="font-medium mb-2">Qualifications</h4>
                     <div className="flex flex-wrap gap-2">
-                      {profile.qualifications.map((qual: string, index: number) => (
-                        <Badge key={index} variant="outline">{qual}</Badge>
-                      ))}
+                      {profile.qualifications.map((qualification: unknown, index: number) => {
+                        const formatted = formatQualification(qualification);
+                        if (!formatted) {
+                          return null;
+                        }
+
+                        return (
+                          <Badge key={index} variant="outline">{formatted}</Badge>
+                        );
+                      })}
                     </div>
                   </div>
                 )}
@@ -260,6 +309,16 @@ export const ProfileReview = () => {
               <div className="flex items-center gap-3 mt-2">
                 <span className="text-muted-foreground">Payment Phone:</span>
                 <span>{profile.payment_phone}</span>
+              </div>
+            )}
+            {profile.payment_method === 'card' && profile.card_details?.last4 && (
+              <div className="flex items-center gap-3 mt-2">
+                <CreditCard className="h-5 w-5 text-muted-foreground" />
+                <span>
+                  Card ending in {profile.card_details.last4}
+                  {formatCardExpiry(profile.card_details) ? ` (expires ${formatCardExpiry(profile.card_details)})` : ''}
+                  {profile.card_details.cardholder_name ? ` • ${profile.card_details.cardholder_name}` : ''}
+                </span>
               </div>
             )}
           </CardContent>

--- a/src/components/QualificationsInput.tsx
+++ b/src/components/QualificationsInput.tsx
@@ -6,10 +6,11 @@ import { Card, CardContent } from './ui/card';
 import { X, Plus } from 'lucide-react';
 
 interface Qualification {
-  institution: string;
-  degree: string;
-  year: string;
-  field: string;
+  institution?: string;
+  degree?: string;
+  name?: string;
+  year?: string;
+  field?: string;
 }
 
 interface QualificationsInputProps {
@@ -17,21 +18,27 @@ interface QualificationsInputProps {
   onChange: (qualifications: Qualification[]) => void;
 }
 
-export const QualificationsInput: React.FC<QualificationsInputProps> = ({
-  qualifications,
-  onChange
-}) => {
-  const [newQualification, setNewQualification] = useState<Qualification>({
+export const QualificationsInput: React.FC<QualificationsInputProps> = ({ qualifications, onChange }) => {
+  const [newQualification, setNewQualification] = useState<Required<Qualification>>({
     institution: '',
     degree: '',
+    name: '',
     year: '',
     field: ''
   });
 
   const addQualification = () => {
     if (qualifications.length < 5 && newQualification.institution && newQualification.degree) {
-      onChange([...qualifications, newQualification]);
-      setNewQualification({ institution: '', degree: '', year: '', field: '' });
+      const normalizedQualification: Qualification = {
+        institution: newQualification.institution,
+        degree: newQualification.degree,
+        name: newQualification.degree,
+        year: newQualification.year,
+        field: newQualification.field,
+      };
+
+      onChange([...qualifications, normalizedQualification]);
+      setNewQualification({ institution: '', degree: '', name: '', year: '', field: '' });
     }
   };
 
@@ -43,39 +50,43 @@ export const QualificationsInput: React.FC<QualificationsInputProps> = ({
     <div className="space-y-4">
       <Label>Professional Qualifications (up to 5)</Label>
       
-      {qualifications.map((qual, index) => (
-        <Card key={index} className="relative">
-          <CardContent className="p-4">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="absolute top-2 right-2"
-              onClick={() => removeQualification(index)}
-            >
-              <X className="h-4 w-4" />
-            </Button>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <Label className="text-sm">Institution</Label>
-                <p className="text-sm text-gray-700">{qual.institution}</p>
+      {qualifications.map((qual, index) => {
+        const degree = qual.degree || qual.name || '';
+
+        return (
+          <Card key={index} className="relative">
+            <CardContent className="p-4">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute top-2 right-2"
+                onClick={() => removeQualification(index)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label className="text-sm">Institution</Label>
+                  <p className="text-sm text-gray-700">{qual.institution}</p>
+                </div>
+                <div>
+                  <Label className="text-sm">Degree/Certificate</Label>
+                  <p className="text-sm text-gray-700">{degree}</p>
+                </div>
+                <div>
+                  <Label className="text-sm">Year</Label>
+                  <p className="text-sm text-gray-700">{qual.year}</p>
+                </div>
+                <div>
+                  <Label className="text-sm">Field of Study</Label>
+                  <p className="text-sm text-gray-700">{qual.field}</p>
+                </div>
               </div>
-              <div>
-                <Label className="text-sm">Degree/Certificate</Label>
-                <p className="text-sm text-gray-700">{qual.degree}</p>
-              </div>
-              <div>
-                <Label className="text-sm">Year</Label>
-                <p className="text-sm text-gray-700">{qual.year}</p>
-              </div>
-              <div>
-                <Label className="text-sm">Field of Study</Label>
-                <p className="text-sm text-gray-700">{qual.field}</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
+            </CardContent>
+          </Card>
+        );
+      })}
 
       {qualifications.length < 5 && (
         <Card>
@@ -100,7 +111,8 @@ export const QualificationsInput: React.FC<QualificationsInputProps> = ({
                   value={newQualification.degree}
                   onChange={(e) => setNewQualification({
                     ...newQualification,
-                    degree: e.target.value
+                    degree: e.target.value,
+                    name: e.target.value
                   })}
                   placeholder="Bachelor's, Master's, etc."
                 />

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -445,7 +445,12 @@ export class ProfileService extends BaseService<Profile> {
     paymentData: {
       payment_method: 'phone' | 'card';
       payment_phone?: string;
-      card_details?: { number: string; expiry: string };
+      card_details?: {
+        last4: string;
+        expiry_month: number;
+        expiry_year: number;
+        cardholder_name?: string | null;
+      };
       use_same_phone?: boolean;
     }
   ): Promise<DatabaseResponse<Profile>> {


### PR DESCRIPTION
## Summary
- add a Supabase schema script and docs updates so profile JSON payloads persist without casting errors
- normalize profile setup submission data, including geocoordinates, qualifications, and masked card metadata
- capture cardholder details in the profile form, refresh typings, and surface saved card info in the review UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f14386f01c8328b8ccb25a12696056