### PR TITLE
Align homepage background with marketplace styling

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,20 +13,36 @@ const Index: React.FC = () => {
 
   return (
     <AppLayout>
-      <HeroSection />
-      {user && (
-        <div className="container mx-auto px-4 py-6">
-          <SubscriptionBanner 
-            userType={user.account_type} 
-            compact={true}
-            dismissible={true}
-          />
+      <div className="relative min-h-screen bg-gray-50">
+        <div
+          aria-hidden="true"
+          className="fixed inset-0 bg-center bg-cover"
+          style={{
+            backgroundImage:
+              "url('/images/ChatGPT%20Image%20Sep%2023%2C%202025%2C%2001_52_19%20PM.png')",
+          }}
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-gradient-to-r from-blue-600/70 to-emerald-600/70"
+        />
+        <div className="relative z-10">
+          <HeroSection />
+          {user && (
+            <div className="container mx-auto px-4 py-6">
+              <SubscriptionBanner
+                userType={user.account_type}
+                compact={true}
+                dismissible={true}
+              />
+            </div>
+          )}
+          <ServicesGrid />
+          <MarketplacePreview />
+          <StatsSection />
+          <TestimonialsSection />
         </div>
-      )}
-      <ServicesGrid />
-      <MarketplacePreview />
-      <StatsSection />
-      <TestimonialsSection />
+      </div>
     </AppLayout>
   );
 };


### PR DESCRIPTION
## Summary
- wrap the homepage content with a relative container that mirrors the marketplace background image configuration
- add fixed background image and gradient overlay layers so the hero section sits above the shared backdrop

## Testing
- npm run dev -- --host

------
https://chatgpt.com/codex/tasks/task_e_68f14d2264a88328a741cc03194f038c