### PR TITLE
Add Supabase provisioning script

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -370,6 +370,20 @@ To guarantee that every authenticated user can manage only their own profile, ru
 > ℹ️ The function performs an `ON CONFLICT` upsert to avoid duplicate-key errors if retries occur. You can safely re-run the
 > script whenever policies or trigger logic need to be refreshed.
 
+### Automated schema provisioning
+
+To apply the latest schema and RLS automation in one pass, export your Supabase connection string and run the provisioning script:
+
+```bash
+export SUPABASE_DB_URL="postgres://postgres:[service-role-password]@[host]:6543/postgres"
+npm run supabase:provision
+```
+
+The script sequentially executes all SQL files in [`backend/supabase/`](backend/supabase) (core schema, profile enhancements,
+registrations, frontend logs, and profile policies). It uses the `psql` CLI, so make sure PostgreSQL client tools are installed
+locally or available in your CI environment. Re-running the script is safe; every SQL file is idempotent and designed for repeat
+execution without raising errors.
+
 After executing the script, confirm that:
 
 - Anonymous clients can only select/update the profile whose `id` matches their authenticated user.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",
     "test:accessibility": "jest --testPathPatterns=\"accessibility\"",
-    "test:lighthouse": "lighthouse http://localhost:5173 --quiet --no-update-notifier --chrome-flags='--headless'"
+    "test:lighthouse": "lighthouse http://localhost:5173 --quiet --no-update-notifier --chrome-flags='--headless'",
+    "supabase:provision": "bash ./scripts/provision-supabase.sh"
   },
   "dependencies": {
     "@eslint/js": "^9.9.0",

--- a/scripts/provision-supabase.sh
+++ b/scripts/provision-supabase.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SQL_DIR="${SCRIPT_DIR}/../backend/supabase"
+
+if [[ ! -d "${SQL_DIR}" ]]; then
+  echo "Error: Unable to locate Supabase SQL directory at ${SQL_DIR}" >&2
+  exit 1
+fi
+
+if [[ -z "${SUPABASE_DB_URL:-}" && -z "${DATABASE_URL:-}" ]]; then
+  cat <<'MSG' >&2
+Error: Please export a Supabase connection string before running this script.
+Set either SUPABASE_DB_URL or DATABASE_URL, for example:
+
+  export SUPABASE_DB_URL="postgres://postgres:[password]@[host]:5432/postgres"
+
+You can copy the connection string from the Supabase project settings (Project Settings → Database → Connection string → URI).
+MSG
+  exit 1
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  cat <<'MSG' >&2
+Error: psql command not found.
+Install PostgreSQL client tools or run this script from an environment where the `psql` CLI is available.
+MSG
+  exit 1
+fi
+
+CONNECTION_STRING="${SUPABASE_DB_URL:-${DATABASE_URL}}"
+
+SQL_FILES=(
+  "core_schema.sql"
+  "profiles_schema.sql"
+  "registrations.sql"
+  "frontend_logs.sql"
+  "profiles_policies.sql"
+)
+
+for file in "${SQL_FILES[@]}"; do
+  SQL_PATH="${SQL_DIR}/${file}"
+  if [[ ! -f "${SQL_PATH}" ]]; then
+    echo "Warning: Skipping missing SQL file ${SQL_PATH}" >&2
+    continue
+  fi
+
+  echo "\n➡️  Executing ${file}"
+  psql "${CONNECTION_STRING}" --file "${SQL_PATH}"
+  echo "✅  Completed ${file}"
+
+done
+
+echo "\n🎉 Supabase schema provisioning complete."


### PR DESCRIPTION
## Summary
- add a provisioning helper script that executes the Supabase SQL files through psql
- expose an npm script for running the provisioning helper
- document how to run the provisioning script in the database setup guide

## Testing
- not run (requires external Supabase connection and psql CLI)

------
https://chatgpt.com/codex/tasks/task_e_68f1b3cb4e088328ab75079e90196e01