### PR TITLE
Add production readiness checklist and environment audit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ Update the new `.env` file with production values:
 When deploying to Vercel (or another hosting provider), add **both** `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` to the project
 environment variables along with any server-side keys (such as `SUPABASE_SERVICE_ROLE_KEY` if you run edge functions). Use the
 [deployment checklist](docs/VERCEL_SUPABASE_DEPLOYMENT.md) to mirror the values from `.env` into the `Production`, `Preview`, and
-`Development` environments and verify them before triggering a build. Running `npm run env:check` or `./scripts/setup-payments.sh`
-locally is a quick way to confirm the `.env` file is complete.
-Double check that the variables are present in every environment (Preview, Development, and Production) so the application can connect
-to Supabase without runtime errors.
-See the [Vercel Supabase deployment checklist](docs/VERCEL_SUPABASE_DEPLOYMENT.md) for a full walkthrough of verifying project access,
-configuring variables, and troubleshooting integration issues.
+`Development` environments and verify them before triggering a build.
+
+Run `npm run env:check` (backed by `scripts/env-check.mjs`) or `./scripts/setup-payments.sh` locally to confirm the `.env` files in
+both the frontend and backend contain production values. The checker fails fast when required keys are missing or when placeholder/test
+credentials are still present.
+
+For a complete pre-launch overview—including database provisioning, Supabase Edge Function deployment, webhook validation, and
+regression testing—consult the [Production Readiness Checklist](docs/PRODUCTION_READINESS_CHECKLIST.md).
 
 ## Testing
 

--- a/docs/PRODUCTION_READINESS_CHECKLIST.md
+++ b/docs/PRODUCTION_READINESS_CHECKLIST.md
@@ -1,0 +1,70 @@
+# Production Readiness Checklist
+
+This checklist consolidates the remaining action items required before WATHACI CONNECT can ship to production. Use it alongside `docs/VERCEL_SUPABASE_DEPLOYMENT.md`, `docs/PAYMENT_INTEGRATION_GUIDE.md`, and `docs/DEPLOYMENT_SECURITY_CHECKLIST.md`.
+
+## 1. Environment & Configuration
+
+1. Copy `.env.example` to `.env` (and `.env.production` if you maintain a dedicated file for live builds).
+2. Populate every Supabase and Lenco credential with production values – replace all `your-…`, `test_`, or sandbox placeholders.
+3. Mirror the same values inside Vercel → **Settings → Environment Variables** for `Production`, `Preview`, and `Development` environments.
+4. Run the automated audit to confirm nothing is missing or placeholder values remain:
+   ```bash
+   npm run env:check
+   ```
+   The command inspects `.env*` files in the frontend root and backend directories, flagging missing values and non-live payment keys.
+
+## 2. Backend, Database & Supabase Functions
+
+1. Export `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` for the Express backend (or set them in the hosting provider) so registrations persist to Supabase.
+2. Provision the production Supabase database schema:
+   ```bash
+   SUPABASE_DB_URL="postgres://…" npm run supabase:provision
+   ```
+   Alternatively, execute the SQL files in `backend/supabase/` manually.
+3. Deploy the Supabase Edge Functions:
+   ```bash
+   supabase login
+   supabase link --project-ref <project-ref>
+   supabase functions deploy funding-matcher
+   supabase functions deploy lenco-payment
+   supabase functions deploy payment-verify
+   supabase functions deploy payment-webhook
+   ```
+4. Set each function's secrets using the Supabase CLI or dashboard (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `LENCO_SECRET_KEY`, `LENCO_WEBHOOK_SECRET`, etc.) and verify them via `supabase secrets list`.
+5. Update the Lenco dashboard webhook URL to the deployed `payment-webhook` endpoint and confirm the handshake using Lenco's webhook test utility.
+
+## 3. Payments & Webhook Validation
+
+1. Switch all payment credentials to production-mode keys (`pk_live_…`/`sk_live_…`).
+2. Confirm the configured transaction limits (`VITE_MIN_PAYMENT_AMOUNT`, `VITE_MAX_PAYMENT_AMOUNT`, `VITE_PLATFORM_FEE_PERCENTAGE`) match compliance requirements.
+3. Trigger a manual webhook event from the Lenco dashboard and ensure the Supabase Edge Function returns `200` while recording an entry in the `webhook_logs` table.
+
+## 4. Quality Gates & Regression Testing
+
+Run the release test suite locally (or in CI) after updating secrets:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+npm run test:jest
+npm run test:accessibility
+npm --prefix backend test
+```
+
+For Lighthouse, install a Chrome binary locally (or run the audit in CI where Chrome is available) before launching:
+
+```bash
+npm run test:lighthouse
+```
+
+Document any gaps (for example, missing Chrome in CI) in the release notes.
+
+## 5. Operational & Security Readiness
+
+1. Follow the detailed security review in `docs/DEPLOYMENT_SECURITY_CHECKLIST.md` (TLS validation, rate limiting, fraud monitoring).
+2. Confirm webhook secrets and Supabase credentials in each environment using your hosting provider's secret viewer or `supabase secrets list`.
+3. Keep Express rate limiting enabled in production and alert on sudden drops in the `X-RateLimit-Remaining` header.
+4. Wire payment-security alerts and webhook failures into your monitoring stack so on-call engineers are paged for anomalies.
+
+Once every item above is complete and green, you are ready to cut the production release.

--- a/docs/VERCEL_SUPABASE_DEPLOYMENT.md
+++ b/docs/VERCEL_SUPABASE_DEPLOYMENT.md
@@ -39,7 +39,7 @@ Before deploying, confirm the environment file is correctly populated:
 
 ```bash
 cp .env.example .env # if you have not created it yet
-npm run env:check    # custom script or use scripts/validate-database.ts
+npm run env:check    # validates required Supabase/Lenco variables across .env files
 ```
 
 For CI/CD, add a step that prints the variable names (not the values) to confirm they are present. Avoid logging secrets directly.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
+    "env:check": "node scripts/env-check.mjs",
     "test": "node --test",
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",

--- a/scripts/env-check.mjs
+++ b/scripts/env-check.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+
+const envFilenames = [
+  '.env.local',
+  '.env.production',
+  '.env',
+];
+
+const backendEnvFilenames = [
+  path.join('backend', '.env.local'),
+  path.join('backend', '.env.production'),
+  path.join('backend', '.env'),
+];
+
+const envFiles = [...envFilenames, ...backendEnvFilenames]
+  .map((relativePath) => ({
+    relativePath,
+    absolutePath: path.join(projectRoot, relativePath),
+  }))
+  .filter(({ absolutePath }) => fs.existsSync(absolutePath));
+
+const parseEnvLine = (line) => {
+  const trimmed = line.trim();
+
+  if (!trimmed || trimmed.startsWith('#')) {
+    return null;
+  }
+
+  const exportPrefix = 'export ';
+  const normalized = trimmed.startsWith(exportPrefix)
+    ? trimmed.slice(exportPrefix.length)
+    : trimmed;
+
+  const equalsIndex = normalized.indexOf('=');
+  if (equalsIndex === -1) {
+    return null;
+  }
+
+  const key = normalized.slice(0, equalsIndex).trim();
+  if (!key) {
+    return null;
+  }
+
+  let value = normalized.slice(equalsIndex + 1);
+
+  const stripInlineComment = (input) => {
+    let inSingleQuote = false;
+    let inDoubleQuote = false;
+
+    for (let index = 0; index < input.length; index += 1) {
+      const char = input[index];
+
+      if (char === "'" && !inDoubleQuote) {
+        inSingleQuote = !inSingleQuote;
+      } else if (char === '"' && !inSingleQuote) {
+        inDoubleQuote = !inDoubleQuote;
+      } else if (char === '#' && !inSingleQuote && !inDoubleQuote) {
+        return input.slice(0, index);
+      }
+    }
+
+    return input;
+  };
+
+  value = stripInlineComment(value).trim();
+  if (!value) {
+    return { key, value: '' };
+  }
+
+  const isQuoted =
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"));
+
+  if (isQuoted) {
+    value = value.slice(1, -1);
+  }
+
+  return { key, value };
+};
+
+const collectEnvFromFiles = () => {
+  const results = new Map();
+
+  envFiles.forEach(({ absolutePath, relativePath }) => {
+    const contents = fs.readFileSync(absolutePath, 'utf8');
+    contents.split(/\r?\n/).forEach((line) => {
+      const parsed = parseEnvLine(line);
+      if (!parsed) {
+        return;
+      }
+
+      if (!results.has(parsed.key)) {
+        results.set(parsed.key, {
+          value: parsed.value,
+          source: relativePath,
+        });
+      }
+    });
+  });
+
+  return results;
+};
+
+const envFromFiles = collectEnvFromFiles();
+
+const getEnvValue = (key) => {
+  if (process.env[key]) {
+    return { value: process.env[key], source: 'process.env' };
+  }
+
+  if (envFromFiles.has(key)) {
+    return envFromFiles.get(key);
+  }
+
+  return null;
+};
+
+const red = (text) => `\u001b[31m${text}\u001b[0m`;
+const green = (text) => `\u001b[32m${text}\u001b[0m`;
+const yellow = (text) => `\u001b[33m${text}\u001b[0m`;
+const cyan = (text) => `\u001b[36m${text}\u001b[0m`;
+
+const hasPlaceholder = (value = '') => {
+  const lowered = value.toLowerCase();
+  return (
+    lowered.includes('your-project') ||
+    lowered.includes('your-service-role') ||
+    lowered.includes('your-anon-key') ||
+    lowered.includes('example.com') ||
+    lowered.includes('dummy') ||
+    lowered.includes('test_') ||
+    lowered.includes('sandbox')
+  );
+};
+
+const looksLikeLiveLencoKey = (value = '') =>
+  /^pk_live_[a-z0-9]+$/i.test(value.trim()) || /^sk_live_[a-z0-9]+$/i.test(value.trim());
+
+const checks = [
+  {
+    heading: 'Supabase (Frontend)',
+    required: [
+      { key: 'VITE_SUPABASE_URL', description: 'Supabase project URL (https://<ref>.supabase.co)' },
+      { key: 'VITE_SUPABASE_KEY', description: 'Supabase anon/public key' },
+    ],
+  },
+  {
+    heading: 'Supabase (Backend)',
+    required: [
+      { key: 'SUPABASE_URL', description: 'Supabase project URL for server usage' },
+      { key: 'SUPABASE_SERVICE_ROLE_KEY', description: 'Supabase service role key' },
+    ],
+    optional: [
+      { key: 'SUPABASE_ANON_KEY', description: 'Supabase anon key (used by some edge functions)' },
+    ],
+  },
+  {
+    heading: 'Lenco Payments',
+    required: [
+      { key: 'VITE_LENCO_PUBLIC_KEY', description: 'Lenco publishable key (pk_live_...)' },
+      { key: 'LENCO_SECRET_KEY', description: 'Lenco secret key (sk_live_...)' },
+      { key: 'LENCO_WEBHOOK_SECRET', description: 'Webhook signing secret from Lenco dashboard' },
+      { key: 'VITE_LENCO_API_URL', description: 'Lenco API base URL' },
+    ],
+  },
+  {
+    heading: 'Payment Limits & Metadata',
+    required: [
+      { key: 'VITE_PAYMENT_CURRENCY', description: 'ISO currency code for payments' },
+      { key: 'VITE_PAYMENT_COUNTRY', description: 'ISO country code for payments' },
+      { key: 'VITE_PLATFORM_FEE_PERCENTAGE', description: 'Platform fee percentage' },
+      { key: 'VITE_MIN_PAYMENT_AMOUNT', description: 'Minimum payment amount' },
+      { key: 'VITE_MAX_PAYMENT_AMOUNT', description: 'Maximum payment amount' },
+    ],
+  },
+  {
+    heading: 'Runtime Environment Metadata',
+    required: [
+      { key: 'VITE_APP_ENV', description: 'Runtime environment label (development/production)' },
+      { key: 'VITE_APP_NAME', description: 'Application display name' },
+    ],
+    optional: [
+      { key: 'CORS_ALLOWED_ORIGINS', description: 'Comma-delimited list of origins for the Express backend' },
+    ],
+  },
+];
+
+let missingRequired = 0;
+let placeholderWarnings = 0;
+
+const formatEntry = ({ key, description }, required = true) => {
+  const result = getEnvValue(key);
+
+  if (!result || !result.value) {
+    if (required) {
+      missingRequired += 1;
+      console.log(`  ${red('✖')} ${key} ${cyan(`– ${description}`)}`);
+    } else {
+      console.log(`  ${yellow('!')} ${key} ${cyan(`– ${description} (optional)`)} `);
+    }
+    return;
+  }
+
+  const displaySource = result.source === 'process.env' ? 'process.env' : result.source;
+  const formattedSource = cyan(`(${displaySource})`);
+
+  let status = `${green('✔')} ${key} ${formattedSource}`;
+
+  if (hasPlaceholder(result.value)) {
+    placeholderWarnings += 1;
+    status = `${yellow('▲')} ${key} ${formattedSource} ${yellow('[placeholder detected]')}`;
+  }
+
+  if (key === 'VITE_LENCO_PUBLIC_KEY' || key === 'LENCO_SECRET_KEY') {
+    if (!looksLikeLiveLencoKey(result.value)) {
+      placeholderWarnings += 1;
+      status = `${yellow('▲')} ${key} ${formattedSource} ${yellow('[expected live Lenco key]')}`;
+    }
+  }
+
+  console.log(`  ${status}`);
+};
+
+console.log('\n🔍 WATHACI CONNECT environment audit');
+console.log('────────────────────────────────────');
+
+if (envFiles.length === 0) {
+  console.log(`  ${yellow('!')} No .env files found. The script will fall back to process.env only.`);
+} else {
+  envFiles.forEach(({ relativePath }) => {
+    console.log(`  ${cyan('•')} Loaded ${relativePath}`);
+  });
+}
+
+console.log('');
+
+checks.forEach((section) => {
+  console.log(`${section.heading}`);
+  console.log('────────────────');
+  section.required.forEach((entry) => formatEntry(entry, true));
+  if (section.optional) {
+    section.optional.forEach((entry) => formatEntry(entry, false));
+  }
+  console.log('');
+});
+
+if (missingRequired === 0 && placeholderWarnings === 0) {
+  console.log(`${green('🎉  All required environment variables are populated with non-placeholder values.')}`);
+} else {
+  if (missingRequired > 0) {
+    console.log(`${red('⛔  Missing required variables:')} ${missingRequired}`);
+  }
+  if (placeholderWarnings > 0) {
+    console.log(`${yellow('⚠️   Placeholder or non-production values detected:')} ${placeholderWarnings}`);
+  }
+}
+
+if (missingRequired > 0 || placeholderWarnings > 0) {
+  console.log('\nSee docs/PRODUCTION_READINESS_CHECKLIST.md for remediation steps.');
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a scripts/env-check.mjs utility and expose it via `npm run env:check`
- document the deployment tasks in a new production readiness checklist and refresh README guidance
- update the Supabase deployment notes to point at the automated environment audit

## Testing
- npm run env:check *(fails: placeholder/test keys in the sample .env)*

------
https://chatgpt.com/codex/tasks/task_e_68f1c0d3e16c83288aa51a9880d46361