### PR TITLE
Harden Lenco webhook handling

### DIFF
--- a/supabase/functions/_shared/lenco-webhook-handler.ts
+++ b/supabase/functions/_shared/lenco-webhook-handler.ts
@@ -8,19 +8,53 @@ import {
   LencoWebhookPayload,
 } from '../../../src/lib/server/lenco-webhook-utils.ts';
 
+const MAX_BODY_BYTES = 32 * 1024; // 32KB upper bound for webhook payloads
+const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000; // 5 minutes
+
 export const corsHeaders: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-lenco-signature',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type, x-lenco-signature, x-lenco-timestamp',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
-export async function handleLencoWebhookRequest(req: Request): Promise<Response> {
+type WaitUntil = (promise: Promise<unknown>) => void;
+
+interface WebhookContext {
+  requestId: string;
+  providerEventId: string;
+  paymentReference: string;
+  userId?: string;
+}
+
+export async function handleLencoWebhookRequest(
+  req: Request,
+  waitUntil?: WaitUntil,
+): Promise<Response> {
+  const fallbackSideEffects: Promise<unknown>[] = [];
+  const enqueueSideEffect = (promise: Promise<unknown>) => {
+    if (waitUntil) {
+      waitUntil(promise);
+    } else {
+      fallbackSideEffects.push(promise);
+    }
+  };
+  const finalizeResponse = async (response: Response): Promise<Response> => {
+    if (!waitUntil && fallbackSideEffects.length > 0) {
+      await Promise.allSettled(fallbackSideEffects);
+    }
+    return response;
+  };
+  const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' as const };
+
+  const requestId = crypto.randomUUID();
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
+    return finalizeResponse(new Response('ok', { headers: corsHeaders }));
   }
 
   if (req.method !== 'POST') {
-    return new Response('Method not allowed', { status: 405, headers: corsHeaders });
+    return finalizeResponse(new Response('Method not allowed', { status: 405, headers: corsHeaders }));
   }
 
   const signature = req.headers.get('x-lenco-signature');
@@ -29,79 +63,250 @@ export async function handleLencoWebhookRequest(req: Request): Promise<Response>
   const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 
   if (!signature || !webhookSecret) {
-    logger.error('Missing Lenco webhook signature or secret');
-    return new Response(JSON.stringify({ success: false, error: 'Missing webhook authentication' }), {
-      status: 401,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    logger.warn('Missing Lenco webhook signature or secret', { requestId });
+    return finalizeResponse(
+      new Response(JSON.stringify({ success: false, error: 'Missing webhook authentication' }), {
+        status: 401,
+        headers: jsonHeaders,
+      }),
+    );
   }
 
   if (!supabaseUrl || !supabaseServiceRoleKey) {
-    logger.error('Supabase environment variables are not configured for webhook processing');
-    return new Response(JSON.stringify({ success: false, error: 'Server configuration incomplete' }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    logger.error('Supabase environment variables are not configured for webhook processing', undefined, {
+      requestId,
     });
+    return finalizeResponse(
+      new Response(JSON.stringify({ success: false, error: 'Server configuration incomplete' }), {
+        status: 500,
+        headers: jsonHeaders,
+      }),
+    );
+  }
+
+  const contentLengthHeader = req.headers.get('content-length');
+  if (contentLengthHeader) {
+    const contentLength = Number(contentLengthHeader);
+    if (!Number.isFinite(contentLength) || contentLength > MAX_BODY_BYTES) {
+      logger.warn('Webhook payload rejected due to content-length limit', { requestId, contentLength });
+      return finalizeResponse(
+        new Response(JSON.stringify({ success: false, error: 'Payload too large' }), {
+          status: 413,
+          headers: jsonHeaders,
+        }),
+      );
+    }
   }
 
   const rawBody = await req.text();
-  let payload: LencoWebhookPayload | undefined;
+  const payloadSize = new TextEncoder().encode(rawBody).byteLength;
+  if (payloadSize > MAX_BODY_BYTES) {
+    logger.warn('Webhook payload exceeded size limit', { requestId, payloadSize });
+    return finalizeResponse(
+      new Response(JSON.stringify({ success: false, error: 'Payload too large' }), {
+        status: 413,
+        headers: jsonHeaders,
+      }),
+    );
+  }
+
+  let payload: LencoWebhookPayload;
 
   try {
     const isSignatureValid = await verifyLencoSignature(signature, rawBody, webhookSecret);
     if (!isSignatureValid) {
-      logger.warn('Lenco webhook signature validation failed');
-      return new Response(JSON.stringify({ success: false, error: 'Invalid webhook signature' }), {
-        status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      logger.warn('Lenco webhook signature validation failed', { requestId });
+      return finalizeResponse(
+        new Response(JSON.stringify({ success: false, error: 'Invalid webhook signature' }), {
+          status: 401,
+          headers: jsonHeaders,
+        }),
+      );
     }
 
     payload = JSON.parse(rawBody) as LencoWebhookPayload;
   } catch (error) {
-    logger.error('Failed to parse or validate webhook payload', error);
-    return new Response(JSON.stringify({ success: false, error: 'Invalid payload' }), {
-      status: 400,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    logger.error('Failed to parse or validate webhook payload', error, { requestId });
+    return finalizeResponse(
+      new Response(JSON.stringify({ success: false, error: 'Invalid payload' }), {
+        status: 400,
+        headers: jsonHeaders,
+      }),
+    );
   }
+
+  const validationErrors = validatePayload(payload);
+  if (validationErrors.length > 0) {
+    logger.warn('Rejected Lenco webhook due to validation errors', { requestId, validationErrors });
+    return finalizeResponse(
+      new Response(JSON.stringify({ success: false, error: 'Invalid payload structure' }), {
+        status: 400,
+        headers: jsonHeaders,
+      }),
+    );
+  }
+
+  const eventTimestamp = Date.parse(payload.created_at);
+  if (Number.isNaN(eventTimestamp) || Math.abs(Date.now() - eventTimestamp) > TIMESTAMP_TOLERANCE_MS) {
+    logger.warn('Lenco webhook timestamp outside accepted window', {
+      requestId,
+      createdAt: payload.created_at,
+    });
+    return finalizeResponse(
+      new Response(JSON.stringify({ success: false, error: 'Stale webhook event' }), {
+        status: 400,
+        headers: jsonHeaders,
+      }),
+    );
+  }
+
+  const providerEventId = payload.data.id;
+  const paymentReference = payload.data.reference;
+  const userId = payload.data.metadata?.user_id;
+  const context: WebhookContext = { requestId, providerEventId, paymentReference, userId };
 
   const supabaseClient = createClient(supabaseUrl, supabaseServiceRoleKey);
 
-  try {
-    await updatePaymentRecord(supabaseClient, payload);
-    await handleSubscriptionPaymentUpdate(supabaseClient, payload);
-    await handleServicePaymentUpdate(supabaseClient, payload);
-    await sendRealTimeNotification(supabaseClient, payload);
-    await logWebhookEvent(supabaseClient, payload, 'processed');
+  logger.info('Processing Lenco webhook event', {
+    requestId,
+    providerEventId,
+    event: payload.event,
+    paymentReference,
+  });
 
-    return new Response(JSON.stringify({ success: true }), {
-      status: 200,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
-  } catch (error) {
-    logger.error('Webhook processing error', error, {
-      paymentReference: payload?.data?.reference,
-      userId: payload?.data?.metadata?.user_id,
-    });
+  const receivedAt = new Date().toISOString();
+  const { error: recordEventError } = await supabaseClient.from('payment_events').insert({
+    provider_event_id: providerEventId,
+    payment_reference: paymentReference,
+    event_type: payload.event,
+    provider_status: payload.data.status,
+    payload,
+    received_at: receivedAt,
+  });
 
-    try {
-      await logWebhookEvent(supabaseClient, payload, 'failed', (error as Error).message);
-    } catch (logError) {
-      logger.error('Failed to log webhook error', logError);
+  if (recordEventError) {
+    if (
+      recordEventError.code === '23505' ||
+      (typeof recordEventError.message === 'string' &&
+        recordEventError.message.toLowerCase().includes('duplicate key'))
+    ) {
+      logger.info('Duplicate Lenco payment event received', { requestId, providerEventId, paymentReference });
+
+      enqueueSideEffect(
+        logWebhookEvent(supabaseClient, payload, 'duplicate', undefined, context).catch((error) => {
+          logger.error('Failed to record duplicate webhook event log', error, context);
+        }),
+      );
+
+      return finalizeResponse(
+        new Response(JSON.stringify({ success: true, duplicate: true }), {
+          status: 200,
+          headers: jsonHeaders,
+        }),
+      );
     }
 
-    return new Response(JSON.stringify({
-      success: false,
-      error: (error as Error).message ?? 'Webhook processing failed',
-    }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    logger.error('Failed to persist payment event', recordEventError, context);
+    return finalizeResponse(
+      new Response(JSON.stringify({ success: false, error: 'Unable to persist payment event' }), {
+        status: 500,
+        headers: jsonHeaders,
+      }),
+    );
+  }
+
+  try {
+    await updatePaymentRecord(supabaseClient, payload, context);
+    await handleSubscriptionPaymentUpdate(supabaseClient, payload, context);
+    await handleServicePaymentUpdate(supabaseClient, payload, context);
+
+    enqueueSideEffect(
+      sendRealTimeNotification(supabaseClient, payload, context).catch((error) => {
+        logger.error('Error sending payment realtime notification', error, context);
+      }),
+    );
+
+    enqueueSideEffect(
+      logWebhookEvent(supabaseClient, payload, 'processed', undefined, context).catch((error) => {
+        logger.error('Failed to log processed webhook event', error, context);
+      }),
+    );
+
+    return finalizeResponse(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: jsonHeaders,
+      }),
+    );
+  } catch (error) {
+    logger.error('Webhook processing error', error, context);
+
+    enqueueSideEffect(
+      logWebhookEvent(supabaseClient, payload, 'failed', (error as Error).message, context).catch((logError) => {
+        logger.error('Failed to log webhook error', logError, context);
+      }),
+    );
+
+    return finalizeResponse(
+      new Response(JSON.stringify({ success: false, error: 'Webhook processing failed' }), {
+        status: 500,
+        headers: jsonHeaders,
+      }),
+    );
   }
 }
 
-async function updatePaymentRecord(supabaseClient: any, payload: LencoWebhookPayload) {
+function validatePayload(payload: LencoWebhookPayload): string[] {
+  const errors: string[] = [];
+
+  const allowedEvents: Array<LencoWebhookPayload['event']> = [
+    'payment.success',
+    'payment.failed',
+    'payment.pending',
+    'payment.cancelled',
+  ];
+
+  if (!allowedEvents.includes(payload.event)) {
+    errors.push('event');
+  }
+
+  if (!payload.data || typeof payload.data !== 'object') {
+    errors.push('data');
+    return errors;
+  }
+
+  if (!payload.data.id || typeof payload.data.id !== 'string') {
+    errors.push('data.id');
+  }
+
+  if (!payload.data.reference || typeof payload.data.reference !== 'string') {
+    errors.push('data.reference');
+  }
+
+  if (typeof payload.data.amount !== 'number' || !Number.isFinite(payload.data.amount) || payload.data.amount < 0) {
+    errors.push('data.amount');
+  }
+
+  if (!payload.data.currency || typeof payload.data.currency !== 'string') {
+    errors.push('data.currency');
+  }
+
+  if (!payload.data.status || typeof payload.data.status !== 'string') {
+    errors.push('data.status');
+  }
+
+  if (!payload.created_at || Number.isNaN(Date.parse(payload.created_at))) {
+    errors.push('created_at');
+  }
+
+  return errors;
+}
+
+async function updatePaymentRecord(
+  supabaseClient: any,
+  payload: LencoWebhookPayload,
+  context: WebhookContext,
+) {
   const { data } = payload;
 
   const { error } = await supabaseClient
@@ -116,11 +321,16 @@ async function updatePaymentRecord(supabaseClient: any, payload: LencoWebhookPay
     .eq('reference', data.reference);
 
   if (error) {
-    logger.error('Failed to update payment record', error, { paymentReference: data.reference });
+    logger.error('Failed to update payment record', error, context);
+    throw new Error(error.message || 'Failed to update payment record');
   }
 }
 
-async function handleSubscriptionPaymentUpdate(supabaseClient: any, payload: LencoWebhookPayload) {
+async function handleSubscriptionPaymentUpdate(
+  supabaseClient: any,
+  payload: LencoWebhookPayload,
+  context: WebhookContext,
+) {
   const subscriptionId = payload.data.metadata?.subscription_id;
   if (!subscriptionId) {
     return;
@@ -140,22 +350,39 @@ async function handleSubscriptionPaymentUpdate(supabaseClient: any, payload: Len
       .eq('id', subscriptionId);
 
     if (error) {
-      logger.error('Failed to update subscription payment state', error, { paymentReference: payload.data.reference });
+      logger.error('Failed to update subscription payment state', error, {
+        ...context,
+        subscriptionId,
+      });
     }
 
-    await supabaseClient
+    const { error: transactionError } = await supabaseClient
       .from('transactions')
       .update({
         status: payload.data.status === 'success' ? 'completed' : 'failed',
         updated_at: new Date().toISOString(),
       })
       .eq('reference_number', payload.data.reference);
+
+    if (transactionError) {
+      logger.error('Failed to update related transaction status', transactionError, {
+        ...context,
+        subscriptionId,
+      });
+    }
   } catch (error) {
-    logger.error('Error handling subscription payment update', error, { paymentReference: payload.data.reference });
+    logger.error('Error handling subscription payment update', error, {
+      ...context,
+      subscriptionId,
+    });
   }
 }
 
-async function handleServicePaymentUpdate(supabaseClient: any, payload: LencoWebhookPayload) {
+async function handleServicePaymentUpdate(
+  supabaseClient: any,
+  payload: LencoWebhookPayload,
+  context: WebhookContext,
+) {
   const serviceId = payload.data.metadata?.service_id;
   if (!serviceId) {
     return;
@@ -172,14 +399,24 @@ async function handleServicePaymentUpdate(supabaseClient: any, payload: LencoWeb
       .eq('id', serviceId);
 
     if (error) {
-      logger.error('Failed to update service booking payment state', error, { paymentReference: payload.data.reference });
+      logger.error('Failed to update service booking payment state', error, {
+        ...context,
+        serviceId,
+      });
     }
   } catch (error) {
-    logger.error('Error handling service payment update', error, { paymentReference: payload.data.reference });
+    logger.error('Error handling service payment update', error, {
+      ...context,
+      serviceId,
+    });
   }
 }
 
-async function sendRealTimeNotification(supabaseClient: any, payload: LencoWebhookPayload) {
+async function sendRealTimeNotification(
+  supabaseClient: any,
+  payload: LencoWebhookPayload,
+  context: WebhookContext,
+) {
   const userId = payload.data.metadata?.user_id;
   if (!userId) {
     return;
@@ -201,15 +438,14 @@ async function sendRealTimeNotification(supabaseClient: any, payload: LencoWebho
       created_at: new Date().toISOString(),
     };
 
-    const { error } = await supabaseClient
-      .from('notifications')
-      .insert(notification);
+    const { error } = await supabaseClient.from('notifications').insert(notification);
 
     if (error) {
       logger.error('Failed to create payment notification', error, {
+        ...context,
         userId,
-        paymentReference: payload.data.reference,
       });
+      return;
     }
 
     await supabaseClient
@@ -221,8 +457,8 @@ async function sendRealTimeNotification(supabaseClient: any, payload: LencoWebho
       });
   } catch (error) {
     logger.error('Error sending payment realtime notification', error, {
+      ...context,
       userId,
-      paymentReference: payload.data.reference,
     });
   }
 }
@@ -230,12 +466,13 @@ async function sendRealTimeNotification(supabaseClient: any, payload: LencoWebho
 async function logWebhookEvent(
   supabaseClient: any,
   payload: LencoWebhookPayload | undefined,
-  status: 'processed' | 'failed',
-  errorMessage?: string,
+  status: 'processed' | 'failed' | 'duplicate',
+  errorMessage: string | undefined,
+  context: WebhookContext,
 ) {
   const logEntry = {
     event_type: payload?.event ?? 'unknown',
-    reference: payload?.data?.reference ?? 'unknown',
+    reference: payload?.data?.reference ?? context.paymentReference ?? 'unknown',
     status,
     error_message: errorMessage ?? null,
     payload,

--- a/supabase/functions/lenco-webhook/index.ts
+++ b/supabase/functions/lenco-webhook/index.ts
@@ -1,4 +1,32 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { handleLencoWebhookRequest } from '../_shared/lenco-webhook-handler.ts';
 
-serve(handleLencoWebhookRequest);
+type WaitUntil = (promise: Promise<unknown>) => void;
+
+serve(async (req) => {
+  const fallbackPromises: Promise<unknown>[] = [];
+  const waitUntil = resolveWaitUntil(fallbackPromises);
+
+  const response = await handleLencoWebhookRequest(req, waitUntil);
+
+  if (fallbackPromises.length > 0) {
+    await Promise.allSettled(fallbackPromises);
+  }
+
+  return response;
+});
+
+function resolveWaitUntil(pending: Promise<unknown>[]): WaitUntil {
+  const edgeRuntime = (globalThis as { EdgeRuntime?: { waitUntil?: WaitUntil } }).EdgeRuntime;
+  if (edgeRuntime?.waitUntil) {
+    return edgeRuntime.waitUntil.bind(edgeRuntime);
+  }
+
+  return (promise: Promise<unknown>) => {
+    pending.push(promise);
+  };
+}
+
+export const config = {
+  verifyJWT: false,
+};


### PR DESCRIPTION
## Summary
- disable JWT verification for the Lenco webhook edge function and ensure background tasks use waitUntil when available
- validate incoming payloads with size, signature, and timestamp checks while logging structured context
- persist payment events idempotently before processing and queue notification/logging side effects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5b2d2abf08328820b57a6af07e04b