### PR TITLE
Ensure Supabase confirmation emails redirect to live site

### DIFF
--- a/src/contexts/__tests__/AppContext.test.tsx
+++ b/src/contexts/__tests__/AppContext.test.tsx
@@ -163,10 +163,15 @@ describe('AppContext auth actions', () => {
     const ctx = await renderWithContext();
     const result = await ctx.signUp('test@example.com', 'pass', { foo: 'bar' });
 
+    const expectedRedirect = new URL('/signin', window.location.origin).toString();
+
     expect(mockSupabase.auth.signUp).toHaveBeenCalledWith(expect.objectContaining({
       email: 'test@example.com',
       password: 'pass',
-      options: { data: { foo: 'bar' } },
+      options: expect.objectContaining({
+        data: { foo: 'bar' },
+        emailRedirectTo: expectedRedirect,
+      }),
     }));
     expect(profileChain.insert).toHaveBeenCalledWith(expect.objectContaining({ id: '1', email: 'test@example.com', foo: 'bar' }));
     expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Account created!' }));

--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -40,7 +40,7 @@ const getImportMetaEnv = (): any => {
   }
 };
 
-const resolveEnvValue = (key: string): string | undefined => {
+export const resolveEnvValue = (key: string): string | undefined => {
   // Check process.env first for test/Node.js environments
   if (typeof process !== 'undefined') {
     const processValue = sanitizeEnvValue(process.env?.[key]);


### PR DESCRIPTION
## Summary
- derive a deployment-aware base URL for Supabase auth email redirects and attach it to sign-up requests
- expose the existing environment resolver so other modules can reuse the logic
- update auth context tests to assert the confirmation email redirect that will be sent to Supabase

## Testing
- npm run typecheck
- npm run test:jest -- AppContext *(fails: ts-jest reports an unrelated Profile type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68f670037a9c83288b1069c5ee031e28