### PR TITLE
Add backend proxy for Lenco Money wallet resolution

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,6 +25,9 @@ npm --prefix backend test
   to the server console for monitoring, and forwards them to the `frontend_logs`
   Supabase table when configured.
 - `GET /api/logs` – Returns the most recent 50 log entries for operational diagnostics.
+- `POST /resolve/lenco-money` – Validates a wallet number and proxies the request to Lenco's
+  `/resolve/lenco-money` endpoint using the configured `LENCO_SECRET_KEY`, returning the gateway
+  response for clients that need to confirm wallet ownership.
 
 ## Supabase integration
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -60,9 +60,11 @@ app.use((req, res, next) => {
 const userRoutes = require('./routes/users');
 const logRoutes = require('./routes/logs');
 const paymentRoutes = require('./routes/payment');
+const resolveRoutes = require('./routes/resolve');
 app.use('/users', userRoutes);
 app.use('/api/logs', logRoutes);
 app.use('/api/payment', paymentRoutes);
+app.use('/resolve', resolveRoutes);
 
 const PORT = process.env.PORT || 3000;
 if (require.main === module) {

--- a/backend/routes/resolve.js
+++ b/backend/routes/resolve.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const Joi = require('joi');
+const validate = require('../middleware/validate');
+const { resolveLencoMoneyWallet } = require('../services/lenco-money-resolver');
+
+const router = express.Router();
+
+const resolveSchema = Joi.object({
+  walletNumber: Joi.string().trim().min(1).required(),
+});
+
+router.post('/lenco-money', validate(resolveSchema), async (req, res) => {
+  const { walletNumber } = req.body;
+
+  try {
+    const result = await resolveLencoMoneyWallet(walletNumber);
+    return res.status(200).json(result);
+  } catch (error) {
+    const status = error.status || 500;
+
+    if (status >= 500) {
+      console.error('[routes/resolve] Failed to resolve Lenco Money wallet', error);
+    }
+
+    const responseBody =
+      (error.details && typeof error.details === 'object' ? error.details : null) || {
+        status: false,
+        message: error.message || 'Unable to resolve Lenco Money wallet',
+      };
+
+    return res.status(status).json(responseBody);
+  }
+});
+
+module.exports = router;

--- a/backend/services/lenco-money-resolver.js
+++ b/backend/services/lenco-money-resolver.js
@@ -1,0 +1,70 @@
+const DEFAULT_API_BASE_URL = 'https://api.lenco.co/access/v2';
+const RESOLVE_PATH = '/resolve/lenco-money';
+
+const getApiBaseUrl = () => {
+  const envUrl = process.env.LENCO_API_URL || process.env.VITE_LENCO_API_URL || DEFAULT_API_BASE_URL;
+  return String(envUrl).replace(/\/$/, '');
+};
+
+const getResolveUrl = () => `${getApiBaseUrl()}${RESOLVE_PATH}`;
+
+const getSecretKey = () => process.env.LENCO_SECRET_KEY || process.env.VITE_LENCO_SECRET_KEY || '';
+
+const parseJsonResponse = async (response) => {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    const parseError = new Error('Failed to parse Lenco response as JSON');
+    parseError.status = response.status;
+    parseError.cause = error;
+    throw parseError;
+  }
+};
+
+const resolveLencoMoneyWallet = async (walletNumber, { fetchImpl = global.fetch } = {}) => {
+  if (!fetchImpl || typeof fetchImpl !== 'function') {
+    throw new Error('A fetch implementation is required to resolve wallet numbers');
+  }
+
+  const secretKey = getSecretKey();
+  if (!secretKey) {
+    const error = new Error('LENCO_SECRET_KEY is not configured. Set the live secret key before resolving wallets.');
+    error.status = 503;
+    error.code = 'LENCO_SECRET_KEY_MISSING';
+    throw error;
+  }
+
+  const response = await fetchImpl(getResolveUrl(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${secretKey}`,
+    },
+    body: JSON.stringify({ walletNumber }),
+  });
+
+  const data = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    const error = new Error(data?.message || 'Failed to resolve Lenco Money wallet');
+    error.status = response.status;
+    error.details = data;
+    throw error;
+  }
+
+  return data;
+};
+
+module.exports = {
+  resolveLencoMoneyWallet,
+  __internal: {
+    getResolveUrl,
+    getSecretKey,
+    getApiBaseUrl,
+  },
+};

--- a/test/backend-response.test.js
+++ b/test/backend-response.test.js
@@ -88,3 +88,124 @@ test('POST /api/logs stores sanitized log entries', async () => {
   await new Promise((resolve) => server.close(resolve));
 });
 
+test('POST /resolve/lenco-money proxies successful Lenco wallet lookups', async () => {
+  const server = app.listen(0);
+  const { port } = server.address();
+
+  const originalFetch = global.fetch;
+  const originalSecret = process.env.LENCO_SECRET_KEY;
+  process.env.LENCO_SECRET_KEY = 'sk_live_example';
+
+  const lencoResponse = {
+    status: true,
+    message: 'Wallet resolved',
+    data: {
+      type: 'lenco-money',
+      accountName: 'Alice Banda',
+      walletNumber: '1234567890',
+    },
+  };
+
+  global.fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url === 'https://api.lenco.co/access/v2/resolve/lenco-money') {
+      assert.strictEqual(init?.method, 'POST');
+      assert.strictEqual(init?.headers?.Authorization, 'Bearer sk_live_example');
+      assert.strictEqual(init?.headers?.['Content-Type'], 'application/json');
+      const body = JSON.parse(init?.body);
+      assert.deepStrictEqual(body, { walletNumber: '1234567890' });
+
+      return new Response(JSON.stringify(lencoResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return originalFetch(input, init);
+  };
+
+  try {
+    const res = await fetch(`http://localhost:${port}/resolve/lenco-money`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ walletNumber: '1234567890' }),
+    });
+
+    assert.strictEqual(res.status, 200);
+    const data = await res.json();
+    assert.deepStrictEqual(data, lencoResponse);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.LENCO_SECRET_KEY = originalSecret;
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('POST /resolve/lenco-money forwards Lenco validation errors', async () => {
+  const server = app.listen(0);
+  const { port } = server.address();
+
+  const originalFetch = global.fetch;
+  const originalSecret = process.env.LENCO_SECRET_KEY;
+  process.env.LENCO_SECRET_KEY = 'sk_live_example';
+
+  const lencoError = {
+    status: false,
+    message: 'Wallet not found',
+  };
+
+  global.fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url === 'https://api.lenco.co/access/v2/resolve/lenco-money') {
+      return new Response(JSON.stringify(lencoError), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return originalFetch(input, init);
+  };
+
+  try {
+    const res = await fetch(`http://localhost:${port}/resolve/lenco-money`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ walletNumber: '9999999999' }),
+    });
+
+    assert.strictEqual(res.status, 400);
+    const data = await res.json();
+    assert.deepStrictEqual(data, lencoError);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.LENCO_SECRET_KEY = originalSecret;
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('POST /resolve/lenco-money requires a configured secret key', async () => {
+  const server = app.listen(0);
+  const { port } = server.address();
+
+  const originalSecret = process.env.LENCO_SECRET_KEY;
+  delete process.env.LENCO_SECRET_KEY;
+
+  try {
+    const res = await fetch(`http://localhost:${port}/resolve/lenco-money`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ walletNumber: '1234567890' }),
+    });
+
+    assert.strictEqual(res.status, 503);
+    const data = await res.json();
+    assert.deepStrictEqual(data, {
+      status: false,
+      message: 'LENCO_SECRET_KEY is not configured. Set the live secret key before resolving wallets.',
+    });
+  } finally {
+    process.env.LENCO_SECRET_KEY = originalSecret;
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+


### PR DESCRIPTION
## Summary
- add an Express route for POST /resolve/lenco-money that validates input and forwards requests to Lenco
- implement a reusable service that signs Lenco resolve requests with the configured secret key and surfaces gateway errors
- expand backend tests and documentation to cover the new wallet resolution endpoint

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68f6a7d2a0748328abc887311e7b7272