### PR TITLE
Add mobile money resolution support

### DIFF
--- a/docs/PAYMENT_INTEGRATION_GUIDE.md
+++ b/docs/PAYMENT_INTEGRATION_GUIDE.md
@@ -311,6 +311,17 @@ Process a mobile money payment.
 
 **Returns:** `Promise<LencoPaymentResponse>`
 
+##### `resolveMobileMoneyAccount(request)`
+
+Resolve mobile money account information before triggering a charge.
+
+**Parameters:**
+- `phone` (string): Mobile number to resolve. Supports `0` prefixed or `+260` formats
+- `operator` (string): `mtn`, `airtel`, or `zamtel`
+- `country` (string, optional): Defaults to configured payment country (`zm`)
+
+**Returns:** `Promise<MobileMoneyResolutionResponse>` containing `accountName`, `phone`, `operator`, and `country` when successful.
+
 ##### `processCardPayment(request)`
 
 Process a card payment.

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -7,6 +7,17 @@
 // Base service class
 export { BaseService } from './base-service';
 
+// Lenco payment service
+export {
+  LencoPaymentService,
+  lencoPaymentService
+} from './lenco-payment-service';
+
+export type {
+  MobileMoneyResolutionData,
+  MobileMoneyResolutionResponse
+} from './lenco-payment-service';
+
 // User and Profile services
 import {
   UserService,


### PR DESCRIPTION
## Summary
- add mobile money resolution helper to the Lenco payment service and expose its response types through the service index
- extend the Supabase lenco-payment edge function to call the `/resolve/mobile-money` endpoint and normalise operator input
- document the new `resolveMobileMoneyAccount` workflow in the payment integration guide for implementers

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f6a7a52f308328b54ec6374bcd0155