### PR TITLE
Resolve Supabase edge function runtime errors

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -6,7 +6,16 @@ export interface LogContext {
 
 function sendToMonitoringService(log: any) {
   try {
-    fetch('/api/logs', {
+    const isBrowserEnvironment =
+      typeof window !== 'undefined' && typeof document !== 'undefined';
+
+    if (!isBrowserEnvironment || typeof fetch !== 'function') {
+      return;
+    }
+
+    const endpoint = new URL('/api/logs', window.location.origin);
+
+    fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(log),


### PR DESCRIPTION
## Summary
- guard the logger's monitoring calls so they only run in browser contexts and avoid invalid edge fetches
- rework the Lenco webhook utilities to use Web Crypto APIs exclusively and drop Node-specific imports

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f6c736f8308328b336aed7e29fccee