### PR TITLE
Support Supabase anon key aliases for Vite builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ SUPABASE_URL="https://your-project.supabase.co"
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
 VITE_SUPABASE_URL="https://your-project.supabase.co"
 VITE_SUPABASE_KEY="your-anon-key"
+# The Supabase quickstart naming convention is also supported
+# VITE_SUPABASE_ANON_KEY="your-anon-key"
 
 # Lenco Payment Gateway Configuration
 # For PRODUCTION: Use live keys from Lenco Dashboard

--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -301,6 +301,8 @@ Required environment variables:
 ```env
 VITE_SUPABASE_URL="https://your-project.supabase.co"
 VITE_SUPABASE_KEY="your-anon-key"
+# Alternatively, you can provide the Supabase default name:
+# VITE_SUPABASE_ANON_KEY="your-anon-key"
 ```
 
 The enhanced client validates these on startup and provides clear error messages if missing or invalid.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cp backend/.env.example backend/.env.production
 After creating the files, update them with your actual credentials:
 
 - `VITE_SUPABASE_URL` / `SUPABASE_URL` – Supabase project URL (mirrored for the backend runtime).
-- `VITE_SUPABASE_KEY` – Supabase anon key for client access.
+- `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY` – Supabase anon key for client access.
 - `SUPABASE_SERVICE_ROLE_KEY` – Required for any server-side inserts, including the Express API and Supabase Edge Functions.
 - `VITE_LENCO_PUBLIC_KEY` – Lenco public API key (current dashboards issue `pub-…` keys; older projects may still use `pk_live_…`).
 - `LENCO_SECRET_KEY` – Lenco secret API key (accepts `sec-…`, `sk_live_…`, or legacy 64-character hex secrets).
@@ -108,7 +108,8 @@ npm run env:check
 
 This will scan all environment files and flag any missing or placeholder values.
 
-When deploying to Vercel (or another hosting provider), add **both** `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` to the project
+When deploying to Vercel (or another hosting provider), add **both** `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` (or the Supabase
+default `VITE_SUPABASE_ANON_KEY`) to the project
 environment variables along with any server-side keys (such as `SUPABASE_SERVICE_ROLE_KEY` if you run edge functions). Use the
 [deployment checklist](docs/VERCEL_SUPABASE_DEPLOYMENT.md) to mirror the values from `.env` into the `Production`, `Preview`, and
 `Development` environments and verify them before triggering a build.

--- a/TEST_SUITE_SUMMARY.md
+++ b/TEST_SUITE_SUMMARY.md
@@ -156,7 +156,7 @@ Lighthouse testing requires:
 1. Running dev/preview server
 2. Proper environment variables configured:
    - `VITE_SUPABASE_URL`
-   - `VITE_SUPABASE_KEY`
+   - `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY`
    - Other app-specific variables
 
 ### How to Run Lighthouse

--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -56,7 +56,7 @@ Located at `backend/.env`, this file contains:
 
 **Frontend Variables:**
 - `VITE_SUPABASE_URL` - Your Supabase project URL (e.g., `https://your-project.supabase.co`)
-- `VITE_SUPABASE_KEY` - Your Supabase anon/public key (JWT token)
+- `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY` - Your Supabase anon/public key (JWT token)
 
 **Backend Variables:**
 - `SUPABASE_URL` - Your Supabase project URL (same as frontend)

--- a/docs/ENVIRONMENT_VARIABLES_QUICK_REFERENCE.md
+++ b/docs/ENVIRONMENT_VARIABLES_QUICK_REFERENCE.md
@@ -25,7 +25,7 @@ npm run env:check
 | Variable | Description | Example | Environment |
 |----------|-------------|---------|-------------|
 | `VITE_SUPABASE_URL` | Supabase project URL | `https://xxx.supabase.co` | All |
-| `VITE_SUPABASE_KEY` | Supabase anon/public key | `eyJhbGci...` | All |
+| `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY` | Supabase anon/public key | `eyJhbGci...` | All |
 | `VITE_LENCO_PUBLIC_KEY` | Lenco publishable key (Production: `pub-...` or `pk_live_...`, Development: `pk_test_...`) | `pub-abc123...` or `pk_live_xyz789` | All |
 | `VITE_LENCO_API_URL` | Lenco API base URL | `https://api.lenco.co/access/v2` | All |
 | `VITE_PAYMENT_CURRENCY` | ISO currency code | `ZMW` | All |

--- a/docs/PAYMENT_INTEGRATION_GUIDE.md
+++ b/docs/PAYMENT_INTEGRATION_GUIDE.md
@@ -66,6 +66,8 @@ const paymentResponse = await lencoPaymentService.processMobileMoneyPayment({
 # Supabase Configuration
 VITE_SUPABASE_URL="https://your-project.supabase.co"
 VITE_SUPABASE_KEY="your-anon-key"
+# You may also set the default Supabase alias:
+# VITE_SUPABASE_ANON_KEY="your-anon-key"
 
 # Lenco Payment Gateway Configuration
 VITE_LENCO_PUBLIC_KEY="pub-dea560c94d379a23e7b85a265d7bb9acbd585481e6e1393e"

--- a/docs/VERCEL_SUPABASE_DEPLOYMENT.md
+++ b/docs/VERCEL_SUPABASE_DEPLOYMENT.md
@@ -29,7 +29,7 @@ In the Vercel dashboard:
 
 ### Supabase Variables (Required)
    - `VITE_SUPABASE_URL` – Supabase project URL (e.g., `https://abc123xyz789.supabase.co`)
-   - `VITE_SUPABASE_KEY` – Supabase anon/public key (JWT token)
+   - `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY` – Supabase anon/public key (JWT token)
    - `SUPABASE_URL` – Same as VITE_SUPABASE_URL (for backend/server usage)
    - `SUPABASE_SERVICE_ROLE_KEY` – Supabase service role key (required for server-side operations)
 

--- a/scripts/env-check.mjs
+++ b/scripts/env-check.mjs
@@ -170,8 +170,22 @@ const checks = [
   {
     heading: 'Supabase (Frontend)',
     required: [
-      { key: 'VITE_SUPABASE_URL', description: 'Supabase project URL (https://<ref>.supabase.co)' },
-      { key: 'VITE_SUPABASE_KEY', description: 'Supabase anon/public key' },
+      {
+        key: 'VITE_SUPABASE_URL',
+        description: 'Supabase project URL (https://<ref>.supabase.co)',
+        aliases: ['VITE_SUPABASE_PROJECT_URL', 'NEXT_PUBLIC_SUPABASE_URL', 'PUBLIC_SUPABASE_URL', 'SUPABASE_URL'],
+      },
+      {
+        key: 'VITE_SUPABASE_KEY',
+        description: 'Supabase anon/public key',
+        aliases: [
+          'VITE_SUPABASE_ANON_KEY',
+          'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+          'PUBLIC_SUPABASE_ANON_KEY',
+          'SUPABASE_KEY',
+          'SUPABASE_ANON_KEY',
+        ],
+      },
     ],
   },
   {
@@ -218,8 +232,19 @@ const checks = [
 let missingRequired = 0;
 let placeholderWarnings = 0;
 
-const formatEntry = ({ key, description }, required = true) => {
-  const result = getEnvValue(key);
+const getEnvValueFromKeys = (keys = []) => {
+  for (const key of keys) {
+    const result = getEnvValue(key);
+    if (result && result.value) {
+      return { ...result, key };
+    }
+  }
+  return null;
+};
+
+const formatEntry = ({ key, description, aliases = [] }, required = true) => {
+  const lookupKeys = [key, ...aliases];
+  const result = getEnvValueFromKeys(lookupKeys);
 
   if (!result || !result.value) {
     if (required) {
@@ -234,7 +259,9 @@ const formatEntry = ({ key, description }, required = true) => {
   const displaySource = result.source === 'process.env' ? 'process.env' : result.source;
   const formattedSource = cyan(`(${displaySource})`);
 
-  let status = `${green('✔')} ${key} ${formattedSource}`;
+  const resolvedKeyLabel = result.key === key ? key : `${key} ← ${result.key}`;
+
+  let status = `${green('✔')} ${resolvedKeyLabel} ${formattedSource}`;
 
   if (hasPlaceholder(result.value)) {
     placeholderWarnings += 1;

--- a/scripts/validate-database.ts
+++ b/scripts/validate-database.ts
@@ -30,19 +30,47 @@ const log = {
   info: (msg: string) => console.log(`${colors.blue}ℹ${colors.reset} ${msg}`),
 };
 
+const RUNTIME_ENV = {
+  ...(typeof process !== 'undefined' ? process.env : {}),
+  ...((import.meta as any)?.env ?? {}),
+} as Record<string, unknown>;
+
+const resolveRuntimeEnv = (...keys: string[]): string | undefined => {
+  for (const key of keys) {
+    const value = RUNTIME_ENV[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+};
+
 async function validateEnvironment() {
   log.info('Validating environment variables...');
-  
-  const url = import.meta.env.VITE_SUPABASE_URL;
-  const key = import.meta.env.VITE_SUPABASE_KEY;
-  
+
+  const url = resolveRuntimeEnv(
+    'VITE_SUPABASE_URL',
+    'VITE_SUPABASE_PROJECT_URL',
+    'NEXT_PUBLIC_SUPABASE_URL',
+    'PUBLIC_SUPABASE_URL',
+    'SUPABASE_URL'
+  );
+  const key = resolveRuntimeEnv(
+    'VITE_SUPABASE_KEY',
+    'VITE_SUPABASE_ANON_KEY',
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    'PUBLIC_SUPABASE_ANON_KEY',
+    'SUPABASE_KEY',
+    'SUPABASE_ANON_KEY'
+  );
+
   if (!url) {
     log.error('VITE_SUPABASE_URL is not set');
     return false;
   }
   
   if (!key) {
-    log.error('VITE_SUPABASE_KEY is not set');
+    log.error('Supabase anon key is not set (expected VITE_SUPABASE_KEY or VITE_SUPABASE_ANON_KEY)');
     return false;
   }
   

--- a/src/lib/__tests__/supabase-enhanced.test.ts
+++ b/src/lib/__tests__/supabase-enhanced.test.ts
@@ -17,7 +17,7 @@ describe('supabase-enhanced environment handling', () => {
 
   it('strips quotes and whitespace from environment variables before creating the client', async () => {
     process.env.VITE_SUPABASE_URL = '  "https://example.supabase.co"  ';
-    process.env.VITE_SUPABASE_KEY = "  'anon-test-key'  ";
+    process.env.VITE_SUPABASE_ANON_KEY = "  'anon-test-key'  ";
 
     const createClient = jest.fn(() => ({ auth: {} }));
 
@@ -36,7 +36,7 @@ describe('supabase-enhanced environment handling', () => {
 
   it('treats quoted "undefined" values as missing', async () => {
     process.env.VITE_SUPABASE_URL = '"undefined"';
-    process.env.VITE_SUPABASE_KEY = '"undefined"';
+    process.env.VITE_SUPABASE_ANON_KEY = '"undefined"';
 
     const createClient = jest.fn(() => ({ auth: {} }));
 
@@ -48,5 +48,24 @@ describe('supabase-enhanced environment handling', () => {
 
     expect(createClient).not.toHaveBeenCalled();
     expect(typeof supabase).toBe('object');
+  });
+
+  it('falls back to legacy VITE_SUPABASE_KEY configuration', async () => {
+    process.env.VITE_SUPABASE_URL = 'https://legacy.supabase.co';
+    process.env.VITE_SUPABASE_KEY = 'legacy-anon-key';
+
+    const createClient = jest.fn(() => ({ auth: {} }));
+
+    jest.doMock('@supabase/supabase-js', () => ({
+      createClient,
+    }));
+
+    await import('../supabase-enhanced');
+
+    expect(createClient).toHaveBeenCalledWith(
+      'https://legacy.supabase.co',
+      'legacy-anon-key',
+      expect.objectContaining({ auth: expect.any(Object) })
+    );
   });
 });

--- a/src/lib/services/__tests__/database-services.test.ts
+++ b/src/lib/services/__tests__/database-services.test.ts
@@ -7,7 +7,8 @@ import { describe, it, expect, jest } from '@jest/globals';
 // Mock the environment variables before importing services
 const mockEnv = {
   VITE_SUPABASE_URL: 'https://test.supabase.co',
-  VITE_SUPABASE_KEY: 'test-key'
+  VITE_SUPABASE_KEY: 'test-key',
+  VITE_SUPABASE_ANON_KEY: 'test-key',
 };
 
 // Mock import.meta.env

--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -26,6 +26,23 @@ const sanitizeEnvValue = (value: unknown): string | undefined => {
   return unquoted;
 };
 
+const SUPABASE_URL_ENV_KEYS = [
+  'VITE_SUPABASE_URL',
+  'VITE_SUPABASE_PROJECT_URL',
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'PUBLIC_SUPABASE_URL',
+  'SUPABASE_URL',
+];
+
+const SUPABASE_KEY_ENV_KEYS = [
+  'VITE_SUPABASE_KEY',
+  'VITE_SUPABASE_ANON_KEY',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  'PUBLIC_SUPABASE_ANON_KEY',
+  'SUPABASE_KEY',
+  'SUPABASE_ANON_KEY',
+];
+
 const getImportMetaEnv = (): any => {
   // This function isolates import.meta from Jest's parser
   // Jest will skip parsing this when it's not called in test environments
@@ -73,13 +90,25 @@ export const resolveEnvValue = (key: string): string | undefined => {
   return undefined;
 };
 
+const resolveFirstEnvValue = (keys: string[]): string | undefined => {
+  for (const key of keys) {
+    const value = resolveEnvValue(key);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
 const isTestEnvironment = typeof process !== 'undefined' && process.env?.NODE_ENV === 'test';
 
-const supabaseUrl = resolveEnvValue('VITE_SUPABASE_URL') || resolveEnvValue('SUPABASE_URL');
-const supabaseKey = resolveEnvValue('VITE_SUPABASE_KEY') || resolveEnvValue('SUPABASE_KEY');
+const supabaseUrl = resolveFirstEnvValue(SUPABASE_URL_ENV_KEYS);
+const supabaseKey = resolveFirstEnvValue(SUPABASE_KEY_ENV_KEYS);
 
 if ((!supabaseUrl || !supabaseKey) && !isTestEnvironment) {
-  throw new Error('Missing Supabase configuration. Please set VITE_SUPABASE_URL and VITE_SUPABASE_KEY environment variables.');
+  throw new Error(
+    'Missing Supabase configuration. Please set VITE_SUPABASE_URL and either VITE_SUPABASE_KEY or VITE_SUPABASE_ANON_KEY environment variables.'
+  );
 }
 
 type MockAuthUser = {

--- a/src/utils/validate-database-browser.ts
+++ b/src/utils/validate-database-browser.ts
@@ -59,9 +59,35 @@ async function validateDatabaseSetup() {
         return undefined;
       }
     };
-    const url = getEnvVar('VITE_SUPABASE_URL');
-    const key = getEnvVar('VITE_SUPABASE_KEY');
-    
+
+    const SUPABASE_URL_KEYS = [
+      'VITE_SUPABASE_URL',
+      'VITE_SUPABASE_PROJECT_URL',
+      'NEXT_PUBLIC_SUPABASE_URL',
+      'PUBLIC_SUPABASE_URL',
+      'SUPABASE_URL',
+    ];
+    const SUPABASE_KEY_KEYS = [
+      'VITE_SUPABASE_KEY',
+      'VITE_SUPABASE_ANON_KEY',
+      'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+      'PUBLIC_SUPABASE_ANON_KEY',
+      'SUPABASE_KEY',
+      'SUPABASE_ANON_KEY',
+    ];
+    const getFirstValue = (keys: string[]) => {
+      for (const key of keys) {
+        const value = getEnvVar(key);
+        if (value) {
+          return value as string;
+        }
+      }
+      return undefined;
+    };
+
+    const url = getFirstValue(SUPABASE_URL_KEYS);
+    const key = getFirstValue(SUPABASE_KEY_KEYS);
+
     if (url && key) {
       console.log('✅ Environment variables are set');
       console.log(`📍 Supabase URL: ${url.substring(0, 30)}...`);


### PR DESCRIPTION
## Summary
- allow the Supabase client to resolve VITE_SUPABASE_ANON_KEY and other common aliases during Vite builds
- update validation utilities, setup scripts, and integration tests to align with the new environment variable lookup
- document the supported Supabase key naming variants across examples and guides

## Testing
- npm run build
- npm run test:jest -- --runTestsByPath src/lib/__tests__/supabase-enhanced.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f773bd3f4c83289fb1a931a05309c8