### PR TITLE
Align Supabase anon key configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 SUPABASE_URL="https://your-project.supabase.co"
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+SUPABASE_ANON_KEY="your-anon-key"
 VITE_SUPABASE_URL="https://your-project.supabase.co"
-VITE_SUPABASE_KEY="your-anon-key"
+VITE_SUPABASE_ANON_KEY="your-anon-key"
 
 # Lenco Payment Gateway Configuration
 # For PRODUCTION: Use live keys from Lenco Dashboard

--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -300,7 +300,7 @@ Required environment variables:
 
 ```env
 VITE_SUPABASE_URL="https://your-project.supabase.co"
-VITE_SUPABASE_KEY="your-anon-key"
+VITE_SUPABASE_ANON_KEY="your-anon-key"
 ```
 
 The enhanced client validates these on startup and provides clear error messages if missing or invalid.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cp backend/.env.example backend/.env.production
 After creating the files, update them with your actual credentials:
 
 - `VITE_SUPABASE_URL` / `SUPABASE_URL` – Supabase project URL (mirrored for the backend runtime).
-- `VITE_SUPABASE_KEY` – Supabase anon key for client access.
+- `VITE_SUPABASE_ANON_KEY` – Supabase anon key for client access.
 - `SUPABASE_SERVICE_ROLE_KEY` – Required for any server-side inserts, including the Express API and Supabase Edge Functions.
 - `VITE_LENCO_PUBLIC_KEY` – Lenco public API key (current dashboards issue `pub-…` keys; older projects may still use `pk_live_…`).
 - `LENCO_SECRET_KEY` – Lenco secret API key (accepts `sec-…`, `sk_live_…`, or legacy 64-character hex secrets).
@@ -108,8 +108,9 @@ npm run env:check
 
 This will scan all environment files and flag any missing or placeholder values.
 
-When deploying to Vercel (or another hosting provider), add **both** `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` to the project
-environment variables along with any server-side keys (such as `SUPABASE_SERVICE_ROLE_KEY` if you run edge functions). Use the
+When deploying to Vercel (or another hosting provider), add **both** `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to the
+project environment variables along with any server-side keys (such as `SUPABASE_SERVICE_ROLE_KEY` if you run edge functions).
+Rename any legacy `VITE_SUPABASE_KEY` entries to `VITE_SUPABASE_ANON_KEY` to keep configuration consistent. Use the
 [deployment checklist](docs/VERCEL_SUPABASE_DEPLOYMENT.md) to mirror the values from `.env` into the `Production`, `Preview`, and
 `Development` environments and verify them before triggering a build.
 

--- a/TEST_SUITE_SUMMARY.md
+++ b/TEST_SUITE_SUMMARY.md
@@ -156,7 +156,7 @@ Lighthouse testing requires:
 1. Running dev/preview server
 2. Proper environment variables configured:
    - `VITE_SUPABASE_URL`
-   - `VITE_SUPABASE_KEY`
+   - `VITE_SUPABASE_ANON_KEY`
    - Other app-specific variables
 
 ### How to Run Lighthouse

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 SUPABASE_URL="https://your-project.supabase.co"
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+SUPABASE_ANON_KEY="your-anon-key"
 
 # Lenco Payment Gateway (replace with live keys before production)
 LENCO_SECRET_KEY="your-lenco-secret-key"

--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -56,7 +56,7 @@ Located at `backend/.env`, this file contains:
 
 **Frontend Variables:**
 - `VITE_SUPABASE_URL` - Your Supabase project URL (e.g., `https://your-project.supabase.co`)
-- `VITE_SUPABASE_KEY` - Your Supabase anon/public key (JWT token)
+- `VITE_SUPABASE_ANON_KEY` - Your Supabase anon/public key (JWT token)
 
 **Backend Variables:**
 - `SUPABASE_URL` - Your Supabase project URL (same as frontend)

--- a/docs/ENVIRONMENT_VARIABLES_QUICK_REFERENCE.md
+++ b/docs/ENVIRONMENT_VARIABLES_QUICK_REFERENCE.md
@@ -25,7 +25,7 @@ npm run env:check
 | Variable | Description | Example | Environment |
 |----------|-------------|---------|-------------|
 | `VITE_SUPABASE_URL` | Supabase project URL | `https://xxx.supabase.co` | All |
-| `VITE_SUPABASE_KEY` | Supabase anon/public key | `eyJhbGci...` | All |
+| `VITE_SUPABASE_ANON_KEY` | Supabase anon/public key | `eyJhbGci...` | All |
 | `VITE_LENCO_PUBLIC_KEY` | Lenco publishable key (Production: `pub-...` or `pk_live_...`, Development: `pk_test_...`) | `pub-abc123...` or `pk_live_xyz789` | All |
 | `VITE_LENCO_API_URL` | Lenco API base URL | `https://api.lenco.co/access/v2` | All |
 | `VITE_PAYMENT_CURRENCY` | ISO currency code | `ZMW` | All |

--- a/docs/PAYMENT_INTEGRATION_GUIDE.md
+++ b/docs/PAYMENT_INTEGRATION_GUIDE.md
@@ -65,7 +65,7 @@ const paymentResponse = await lencoPaymentService.processMobileMoneyPayment({
 ```bash
 # Supabase Configuration
 VITE_SUPABASE_URL="https://your-project.supabase.co"
-VITE_SUPABASE_KEY="your-anon-key"
+VITE_SUPABASE_ANON_KEY="your-anon-key"
 
 # Lenco Payment Gateway Configuration
 VITE_LENCO_PUBLIC_KEY="pub-dea560c94d379a23e7b85a265d7bb9acbd585481e6e1393e"

--- a/docs/VERCEL_SUPABASE_DEPLOYMENT.md
+++ b/docs/VERCEL_SUPABASE_DEPLOYMENT.md
@@ -29,7 +29,7 @@ In the Vercel dashboard:
 
 ### Supabase Variables (Required)
    - `VITE_SUPABASE_URL` – Supabase project URL (e.g., `https://abc123xyz789.supabase.co`)
-   - `VITE_SUPABASE_KEY` – Supabase anon/public key (JWT token)
+   - `VITE_SUPABASE_ANON_KEY` – Supabase anon/public key (JWT token)
    - `SUPABASE_URL` – Same as VITE_SUPABASE_URL (for backend/server usage)
    - `SUPABASE_SERVICE_ROLE_KEY` – Supabase service role key (required for server-side operations)
 

--- a/scripts/setup-payments.sh
+++ b/scripts/setup-payments.sh
@@ -55,7 +55,7 @@ config_errors=0
 echo ""
 echo -e "${BLUE}🗄️  Supabase Configuration${NC}"
 check_env_var "VITE_SUPABASE_URL" "Supabase project URL" || ((config_errors++))
-check_env_var "VITE_SUPABASE_KEY" "Supabase anon key" || ((config_errors++))
+check_env_var "VITE_SUPABASE_ANON_KEY" "Supabase anon key" || ((config_errors++))
 
 # Check Lenco configuration
 echo ""

--- a/scripts/validate-database.ts
+++ b/scripts/validate-database.ts
@@ -34,7 +34,9 @@ async function validateEnvironment() {
   log.info('Validating environment variables...');
   
   const url = import.meta.env.VITE_SUPABASE_URL;
-  const key = import.meta.env.VITE_SUPABASE_KEY;
+  const key =
+    import.meta.env.VITE_SUPABASE_ANON_KEY ??
+    import.meta.env.VITE_SUPABASE_KEY;
   
   if (!url) {
     log.error('VITE_SUPABASE_URL is not set');
@@ -42,7 +44,10 @@ async function validateEnvironment() {
   }
   
   if (!key) {
-    log.error('VITE_SUPABASE_KEY is not set');
+    log.error('VITE_SUPABASE_ANON_KEY is not set');
+    if (import.meta.env.VITE_SUPABASE_KEY) {
+      log.warning('Detected legacy VITE_SUPABASE_KEY. Rename it to VITE_SUPABASE_ANON_KEY.');
+    }
     return false;
   }
   

--- a/src/components/__tests__/LencoPayment.realIntegration.test.ts
+++ b/src/components/__tests__/LencoPayment.realIntegration.test.ts
@@ -14,14 +14,17 @@ const testSuite = ENABLE_REAL_TESTS ? describe : describe.skip;
 testSuite('Lenco Payment Real Integration Tests', () => {
   // These would be used in a real test environment with proper secrets management
   const SUPABASE_URL = process.env.VITE_SUPABASE_URL || 'https://wfqsmvkzkxdasbhpugdc.supabase.co';
-  const SUPABASE_KEY = process.env.VITE_SUPABASE_KEY || 'sb_publishable_8rLYlRkT8hNwBs-T7jsOAQ_pJq9gtfB';
+  const SUPABASE_ANON_KEY =
+    process.env.VITE_SUPABASE_ANON_KEY ||
+    process.env.VITE_SUPABASE_KEY ||
+    'sb_publishable_8rLYlRkT8hNwBs-T7jsOAQ_pJq9gtfB';
 
   describe('Supabase Configuration', () => {
     it('should have valid Supabase configuration', () => {
       expect(SUPABASE_URL).toBeDefined();
-      expect(SUPABASE_KEY).toBeDefined();
+      expect(SUPABASE_ANON_KEY).toBeDefined();
       expect(SUPABASE_URL).toMatch(/^https:\/\/.*\.supabase\.co$/);
-      expect(SUPABASE_KEY).toMatch(/^eyJ|^sb_/); // JWT tokens start with eyJ or sb_ keys
+      expect(SUPABASE_ANON_KEY).toMatch(/^eyJ|^sb_/); // JWT tokens start with eyJ or sb_ keys
     });
 
     it('should construct proper API endpoints', () => {
@@ -33,19 +36,20 @@ testSuite('Lenco Payment Real Integration Tests', () => {
     it('should have proper environment variable access', () => {
       // In Jest environment, env variables might not be loaded from .env file
       // This is expected behavior - we test with fallback values
-      const hasEnvVars = process.env.VITE_SUPABASE_URL && process.env.VITE_SUPABASE_KEY;
-      
+      const envAnonKey = process.env.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_KEY;
+      const hasEnvVars = process.env.VITE_SUPABASE_URL && envAnonKey;
+
       if (hasEnvVars) {
         expect(process.env.VITE_SUPABASE_URL).toBeDefined();
-        expect(process.env.VITE_SUPABASE_KEY).toBeDefined();
-        
+        expect(envAnonKey).toBeDefined();
+
         // Ensure they match our constants
         expect(SUPABASE_URL).toBe(process.env.VITE_SUPABASE_URL);
-        expect(SUPABASE_KEY).toBe(process.env.VITE_SUPABASE_KEY);
+        expect(SUPABASE_ANON_KEY).toBe(envAnonKey);
       } else {
         // Using fallback values - this is acceptable for testing
         expect(SUPABASE_URL).toBe('https://wfqsmvkzkxdasbhpugdc.supabase.co');
-        expect(SUPABASE_KEY).toBe('sb_publishable_8rLYlRkT8hNwBs-T7jsOAQ_pJq9gtfB');
+        expect(SUPABASE_ANON_KEY).toBe('sb_publishable_8rLYlRkT8hNwBs-T7jsOAQ_pJq9gtfB');
       }
     });
   });
@@ -64,14 +68,14 @@ testSuite('Lenco Payment Real Integration Tests', () => {
       const requestOptions = {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${SUPABASE_KEY}`,
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
           'Content-Type': 'application/json'
         },
         body: JSON.stringify(paymentData)
       };
 
       expect(requestOptions.method).toBe('POST');
-      expect(requestOptions.headers['Authorization']).toBe(`Bearer ${SUPABASE_KEY}`);
+      expect(requestOptions.headers['Authorization']).toBe(`Bearer ${SUPABASE_ANON_KEY}`);
       expect(requestOptions.headers['Content-Type']).toBe('application/json');
       expect(JSON.parse(requestOptions.body)).toEqual(paymentData);
     });
@@ -228,15 +232,15 @@ testSuite('Lenco Payment Real Integration Tests', () => {
   describe('Security Considerations', () => {
     it('should not expose sensitive information in logs', () => {
       // Mask the API key for logging
-      const maskedKey = SUPABASE_KEY.substring(0, 10) + '***';
-      
+      const maskedKey = SUPABASE_ANON_KEY.substring(0, 10) + '***';
+
       expect(maskedKey).toMatch(/^.{10}\*\*\*$/);
-      expect(maskedKey).not.toContain(SUPABASE_KEY.substring(10));
+      expect(maskedKey).not.toContain(SUPABASE_ANON_KEY.substring(10));
     });
 
     it('should validate request headers', () => {
       const headers = {
-        'Authorization': `Bearer ${SUPABASE_KEY}`,
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
         'Content-Type': 'application/json',
         'Accept': 'application/json'
       };
@@ -307,6 +311,6 @@ testSuite('Lenco Payment Real Integration Tests', () => {
 export const testConfig = {
   ENABLE_REAL_TESTS,
   SUPABASE_URL: process.env.VITE_SUPABASE_URL,
-  SUPABASE_KEY: process.env.VITE_SUPABASE_KEY ? 
-    process.env.VITE_SUPABASE_KEY.substring(0, 10) + '***' : undefined // Masked for security
+  SUPABASE_ANON_KEY: (process.env.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_KEY) ?
+    (process.env.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_KEY)!.substring(0, 10) + '***' : undefined // Masked for security
 };

--- a/src/lib/__tests__/supabase-enhanced.test.ts
+++ b/src/lib/__tests__/supabase-enhanced.test.ts
@@ -17,7 +17,7 @@ describe('supabase-enhanced environment handling', () => {
 
   it('strips quotes and whitespace from environment variables before creating the client', async () => {
     process.env.VITE_SUPABASE_URL = '  "https://example.supabase.co"  ';
-    process.env.VITE_SUPABASE_KEY = "  'anon-test-key'  ";
+    process.env.VITE_SUPABASE_ANON_KEY = "  'anon-test-key'  ";
 
     const createClient = jest.fn(() => ({ auth: {} }));
 
@@ -34,9 +34,28 @@ describe('supabase-enhanced environment handling', () => {
     );
   });
 
+  it('supports the legacy VITE_SUPABASE_KEY variable for backward compatibility', async () => {
+    process.env.VITE_SUPABASE_URL = 'https://legacy.supabase.co';
+    process.env.VITE_SUPABASE_KEY = 'legacy-anon-key';
+
+    const createClient = jest.fn(() => ({ auth: {} }));
+
+    jest.doMock('@supabase/supabase-js', () => ({
+      createClient,
+    }));
+
+    await import('../supabase-enhanced');
+
+    expect(createClient).toHaveBeenCalledWith(
+      'https://legacy.supabase.co',
+      'legacy-anon-key',
+      expect.objectContaining({ auth: expect.any(Object) })
+    );
+  });
+
   it('treats quoted "undefined" values as missing', async () => {
     process.env.VITE_SUPABASE_URL = '"undefined"';
-    process.env.VITE_SUPABASE_KEY = '"undefined"';
+    process.env.VITE_SUPABASE_ANON_KEY = '"undefined"';
 
     const createClient = jest.fn(() => ({ auth: {} }));
 

--- a/src/lib/services/__tests__/database-services.test.ts
+++ b/src/lib/services/__tests__/database-services.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, jest } from '@jest/globals';
 // Mock the environment variables before importing services
 const mockEnv = {
   VITE_SUPABASE_URL: 'https://test.supabase.co',
-  VITE_SUPABASE_KEY: 'test-key'
+  VITE_SUPABASE_ANON_KEY: 'test-key'
 };
 
 // Mock import.meta.env

--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -76,10 +76,16 @@ export const resolveEnvValue = (key: string): string | undefined => {
 const isTestEnvironment = typeof process !== 'undefined' && process.env?.NODE_ENV === 'test';
 
 const supabaseUrl = resolveEnvValue('VITE_SUPABASE_URL') || resolveEnvValue('SUPABASE_URL');
-const supabaseKey = resolveEnvValue('VITE_SUPABASE_KEY') || resolveEnvValue('SUPABASE_KEY');
+const supabaseKey =
+  resolveEnvValue('VITE_SUPABASE_ANON_KEY') ||
+  resolveEnvValue('VITE_SUPABASE_KEY') ||
+  resolveEnvValue('SUPABASE_ANON_KEY') ||
+  resolveEnvValue('SUPABASE_KEY');
 
 if ((!supabaseUrl || !supabaseKey) && !isTestEnvironment) {
-  throw new Error('Missing Supabase configuration. Please set VITE_SUPABASE_URL and VITE_SUPABASE_KEY environment variables.');
+  throw new Error(
+    'Missing Supabase configuration. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY environment variables.'
+  );
 }
 
 type MockAuthUser = {

--- a/src/utils/validate-database-browser.ts
+++ b/src/utils/validate-database-browser.ts
@@ -60,13 +60,16 @@ async function validateDatabaseSetup() {
       }
     };
     const url = getEnvVar('VITE_SUPABASE_URL');
-    const key = getEnvVar('VITE_SUPABASE_KEY');
+    const key = getEnvVar('VITE_SUPABASE_ANON_KEY') || getEnvVar('VITE_SUPABASE_KEY');
     
     if (url && key) {
       console.log('✅ Environment variables are set');
       console.log(`📍 Supabase URL: ${url.substring(0, 30)}...`);
     } else {
       console.warn('⚠️ Environment variables not fully set');
+      if (!getEnvVar('VITE_SUPABASE_ANON_KEY') && getEnvVar('VITE_SUPABASE_KEY')) {
+        console.warn('⚠️ Detected legacy VITE_SUPABASE_KEY. Rename it to VITE_SUPABASE_ANON_KEY.');
+      }
     }
     
     // Test 4: Test types


### PR DESCRIPTION
## Summary
- rename the Supabase anon key environment variable to `VITE_SUPABASE_ANON_KEY` across docs and sample env files
- update the Supabase client and validation tooling to prefer the new variable name while warning when legacy names are used
- refresh the Supabase client tests to cover the new naming and legacy fallback behaviour

## Testing
- npm run test:jest -- supabase-enhanced

------
https://chatgpt.com/codex/tasks/task_e_68f775f995dc8328bb47fec0050c5742