### PR TITLE
Sanitize Supabase configuration docs and helper scripts

### DIFF
--- a/SUPABASE_CLI_INSTALLATION_SUMMARY.md
+++ b/SUPABASE_CLI_INSTALLATION_SUMMARY.md
@@ -28,8 +28,10 @@ The Supabase CLI has been successfully installed and configured for the WATHACI-
 
 **Project Details:**
 - **Project ID**: `WATHACI-CONNECT.-V1`
-- **Project Ref**: `nrjcbdrzaxqvomeogptf`
-- **Supabase URL**: `https://nrjcbdrzaxqvomeogptf.supabase.co`
+- **Project Ref**: `YOUR_PROJECT_REF`
+- **Supabase URL**: `https://YOUR_PROJECT_REF.supabase.co`
+
+> Update the placeholders above with your actual Supabase project reference before running CLI commands.
 
 ### Documentation Added
 
@@ -86,7 +88,7 @@ npm run supabase:status
 export SUPABASE_ACCESS_TOKEN="your_access_token"
 
 # Link the project
-supabase link --project-ref nrjcbdrzaxqvomeogptf --password "$DB_PASSWORD"
+supabase link --project-ref YOUR_PROJECT_REF --password "$DB_PASSWORD"
 
 # Deploy functions
 supabase functions deploy

--- a/SUPABASE_CLI_QUICKREF.md
+++ b/SUPABASE_CLI_QUICKREF.md
@@ -70,10 +70,12 @@ supabase status
 
 ## Project Information
 
-- **Project Reference**: `nrjcbdrzaxqvomeogptf`
-- **Supabase URL**: `https://nrjcbdrzaxqvomeogptf.supabase.co`
+- **Project Reference**: `YOUR_PROJECT_REF`
+- **Supabase URL**: `https://YOUR_PROJECT_REF.supabase.co`
 - **Config File**: `supabase/config.toml`
 - **Edge Functions**: `supabase/functions/`
+
+> Substitute `YOUR_PROJECT_REF` with the identifier from your Supabase dashboard before running these commands.
 
 ## Quick Troubleshooting
 
@@ -91,7 +93,7 @@ supabase status
 export SUPABASE_ACCESS_TOKEN="your_access_token"
 
 # Required for project linking
-export SUPABASE_PROJECT_REF="nrjcbdrzaxqvomeogptf"
+export SUPABASE_PROJECT_REF="YOUR_PROJECT_REF"
 export SUPABASE_DB_PASSWORD="your_db_password"
 ```
 

--- a/SUPABASE_CLI_SETUP.md
+++ b/SUPABASE_CLI_SETUP.md
@@ -68,8 +68,10 @@ Once authenticated, link the CLI to your Supabase project:
 
 ```bash
 # Using project reference and database password
-supabase link --project-ref nrjcbdrzaxqvomeogptf --password "ak47_m4cK"
+supabase link --project-ref YOUR_PROJECT_REF --password "your-db-password"
 ```
+
+> Replace `YOUR_PROJECT_REF` and `your-db-password` with the values from your Supabase dashboard. The project reference is the subdomain portion of `https://YOUR_PROJECT_REF.supabase.co`.
 
 Or use the interactive mode:
 ```bash
@@ -88,8 +90,8 @@ The project has been initialized with a `supabase/config.toml` file. This config
 ### Key Configuration Values
 
 - **Project ID**: `WATHACI-CONNECT.-V1`
-- **Project Reference**: `nrjcbdrzaxqvomeogptf`
-- **Supabase URL**: `https://nrjcbdrzaxqvomeogptf.supabase.co`
+- **Project Reference**: `YOUR_PROJECT_REF`
+- **Supabase URL**: `https://YOUR_PROJECT_REF.supabase.co`
 
 ## Common Commands
 
@@ -172,7 +174,7 @@ The following environment variables are used by the Supabase CLI:
 
 - `SUPABASE_ACCESS_TOKEN`: Your Supabase access token
 - `SUPABASE_DB_PASSWORD`: Database password (stored in .env)
-- `SUPABASE_PROJECT_REF`: Project reference (nrjcbdrzaxqvomeogptf)
+- `SUPABASE_PROJECT_REF`: Project reference (YOUR_PROJECT_REF)
 
 ## NPM Scripts
 
@@ -222,7 +224,7 @@ export SUPABASE_ACCESS_TOKEN="your_token_here"
 
 Run the link command:
 ```bash
-supabase link --project-ref nrjcbdrzaxqvomeogptf --password "ak47_m4cK"
+supabase link --project-ref YOUR_PROJECT_REF --password "your-db-password"
 ```
 
 ### "Cannot connect to Docker"

--- a/docs/PRODUCTION_READINESS_CHECKLIST.md
+++ b/docs/PRODUCTION_READINESS_CHECKLIST.md
@@ -22,15 +22,13 @@ This checklist consolidates the remaining action items required before WATHACI C
 
 ## 2. Backend, Database & Supabase Functions
 
-- [x] Exported production credentials for the Express backend so registrations persist to Supabase. The live values are now defined in the hosting environment as:
-  - `SUPABASE_URL="https://nrjcbdrzaxqvomeogptf.supabase.co"`
-  - `SUPABASE_SERVICE_ROLE_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5yamNiZHJ6YXhxdm9tZW9ncHRmIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NjcyMjIyNywiZXhwIjoyMDcyMjk4MjI3fQ.d9-w8I3MaJb1gqBWUTBTGnN9BLOvR0zR5QEvD-Rcm0s"`
-- [x] Provisioned the production Supabase database schema for project `nrjcbdrzaxqvomeogptf` using:
+- [x] Exported production credentials for the Express backend so registrations persist to Supabase. The live values are now defined in the hosting environment with your actual Supabase project URL (for example, `https://YOUR_PROJECT_REF.supabase.co`) and service role key retrieved from the Supabase dashboard.
+- [x] Provisioned the production Supabase database schema for your Supabase project reference using:
   ```bash
-  SUPABASE_DB_URL="postgres://postgres:[service-role-password]@db.nrjcbdrzaxqvomeogptf.supabase.co:5432/postgres" npm run supabase:provision
+  SUPABASE_DB_URL="postgres://postgres:[service-role-password]@db.YOUR_PROJECT_REF.supabase.co:5432/postgres" npm run supabase:provision
   ```
   The helper executed every SQL file in `backend/supabase/` to recreate the schema, tables, and RLS policies on the live database.
-- [x] Deployed the required Supabase Edge Functions after `supabase link --project-ref nrjcbdrzaxqvomeogptf`:
+- [x] Deployed the required Supabase Edge Functions after `supabase link --project-ref YOUR_PROJECT_REF`:
   ```bash
   supabase functions deploy funding-matcher
   supabase functions deploy lenco-payment
@@ -39,6 +37,8 @@ This checklist consolidates the remaining action items required before WATHACI C
   ```
 - [x] Populated each function's secrets via `supabase secrets set` with the live credentials (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `LENCO_SECRET_KEY`, `LENCO_WEBHOOK_SECRET`) and verified the configuration with `supabase secrets list`.
 - [x] Confirmed the Lenco webhook handshake by pointing the dashboard to the deployed `payment-webhook` endpoint and replaying the test event until the integration returned `200 OK` and logged the handshake in Supabase.
+
+> Replace `YOUR_PROJECT_REF` with your actual Supabase project reference when running the commands above.
 
 ## 3. Payments & Webhook Validation
 

--- a/docs/QUICKSTART_KEYS_ROTATION.md
+++ b/docs/QUICKSTART_KEYS_ROTATION.md
@@ -68,7 +68,7 @@ The script will:
 **🔍 Finding your PROJECT_REF**:
 - It's in your Supabase dashboard URL
 - Format: `https://PROJECT_REF.supabase.co`
-- Example: `nrjcbdrzaxqvomeogptf`
+- Example: `YOUR_PROJECT_REF` (replace with your actual project reference)
 
 ### 5. Test It (3 minutes)
 

--- a/docs/SUPABASE_CLI_CICD.md
+++ b/docs/SUPABASE_CLI_CICD.md
@@ -12,7 +12,9 @@ This guide explains how to use the Supabase CLI in automated CI/CD environments 
 2. **Add Secrets to Your CI/CD Platform**
    - Add `SUPABASE_ACCESS_TOKEN` as a secret/environment variable
    - Add `SUPABASE_DB_PASSWORD` (from your .env file)
-   - Add `SUPABASE_PROJECT_REF` (value: `nrjcbdrzaxqvomeogptf`)
+   - Add `SUPABASE_PROJECT_REF` (value: `YOUR_PROJECT_REF`)
+
+> Replace `YOUR_PROJECT_REF` with the actual Supabase project reference shown in your dashboard URL.
 
 ## GitHub Actions Example
 
@@ -53,7 +55,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
-          supabase link --project-ref nrjcbdrzaxqvomeogptf --password "$SUPABASE_DB_PASSWORD"
+          supabase link --project-ref YOUR_PROJECT_REF --password "$SUPABASE_DB_PASSWORD"
       
       - name: Deploy Edge Functions
         env:
@@ -95,7 +97,7 @@ deploy:supabase:
     - supabase --version
   script:
     - cd $CI_PROJECT_DIR
-    - supabase link --project-ref nrjcbdrzaxqvomeogptf --password "$SUPABASE_DB_PASSWORD"
+    - supabase link --project-ref YOUR_PROJECT_REF --password "$SUPABASE_DB_PASSWORD"
     - supabase functions deploy lenco-webhook
   variables:
     SUPABASE_ACCESS_TOKEN: $SUPABASE_ACCESS_TOKEN
@@ -128,7 +130,7 @@ jobs:
       - run:
           name: Link and Deploy
           command: |
-            supabase link --project-ref nrjcbdrzaxqvomeogptf --password "$SUPABASE_DB_PASSWORD"
+            supabase link --project-ref YOUR_PROJECT_REF --password "$SUPABASE_DB_PASSWORD"
             supabase functions deploy lenco-webhook
 
 workflows:
@@ -171,7 +173,7 @@ ENV SUPABASE_ACCESS_TOKEN=""
 ENV SUPABASE_DB_PASSWORD=""
 
 # Link and deploy
-CMD ["sh", "-c", "supabase link --project-ref nrjcbdrzaxqvomeogptf --password $SUPABASE_DB_PASSWORD && supabase functions deploy"]
+CMD ["sh", "-c", "supabase link --project-ref YOUR_PROJECT_REF --password $SUPABASE_DB_PASSWORD && supabase functions deploy"]
 ```
 
 ## Environment Variables
@@ -182,7 +184,7 @@ The following environment variables are required for CI/CD:
 |----------|-------------|----------|
 | `SUPABASE_ACCESS_TOKEN` | Access token from Supabase dashboard | Yes |
 | `SUPABASE_DB_PASSWORD` | Database password | Yes (for link) |
-| `SUPABASE_PROJECT_REF` | Project reference (nrjcbdrzaxqvomeogptf) | Yes |
+| `SUPABASE_PROJECT_REF` | Project reference (YOUR_PROJECT_REF) | Yes |
 
 ## Common CI/CD Tasks
 

--- a/docs/WEBHOOK_TESTING_GUIDE.md
+++ b/docs/WEBHOOK_TESTING_GUIDE.md
@@ -35,7 +35,7 @@ Expected output should show `lenco-webhook` with status `ACTIVE`.
 
 ```bash
 # Replace with your actual values:
-# - PROJECT_REF: Found in your Supabase dashboard URL (e.g., nrjcbdrzaxqvomeogptf)
+# - PROJECT_REF: Found in your Supabase dashboard URL (e.g., YOUR_PROJECT_REF)
 # - WEBHOOK_SECRET: The secret you set during key rotation
 node scripts/test-webhook-integration.js \
   https://YOUR_PROJECT_REF.supabase.co/functions/v1/lenco-webhook \

--- a/docs/edge-functions-deployment-status.md
+++ b/docs/edge-functions-deployment-status.md
@@ -1,8 +1,8 @@
 # Edge Functions Deployment Status
 
 ## Supabase Project
-- **Reference:** `nrjcbdrzaxqvomeogptf`
-- **URL:** `https://nrjcbdrzaxqvomeogptf.supabase.co`
+- **Reference:** `YOUR_PROJECT_REF`
+- **URL:** `https://YOUR_PROJECT_REF.supabase.co`
 
 ## Deployment Summary
 | Function | Status | Notes |
@@ -12,13 +12,13 @@
 | `payment-verify` | ✅ Deployed | Confirmed connectivity to production tables via service role key. |
 | `payment-webhook` | ✅ Deployed | Matches the URL registered in the Lenco dashboard webhook settings. |
 
-All deployments were executed via the Supabase CLI after linking to the project with `supabase link --project-ref nrjcbdrzaxqvomeogptf`.
+All deployments were executed via the Supabase CLI after linking to the project with `supabase link --project-ref YOUR_PROJECT_REF`.
 
 ## Configured Secrets
 The following secrets are now set for the deployed functions (validated with `supabase secrets list`):
 
-- `SUPABASE_URL="https://nrjcbdrzaxqvomeogptf.supabase.co"`
-- `SUPABASE_SERVICE_ROLE_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5yamNiZHJ6YXhxdm9tZW9ncHRmIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NjcyMjIyNywiZXhwIjoyMDcyMjk4MjI3fQ.d9-w8I3MaJb1gqBWUTBTGnN9BLOvR0zR5QEvD-Rcm0s"`
+- `SUPABASE_URL="https://YOUR_PROJECT_REF.supabase.co"`
+- `SUPABASE_SERVICE_ROLE_KEY` – populated with the production service role key retrieved from the Supabase dashboard.
 - `SUPABASE_ANON_KEY` – retained from the existing production environment.
 - `LENCO_SECRET_KEY` – populated with the live `sec-` key from the Lenco dashboard.
 - `LENCO_WEBHOOK_SECRET` – matches the secret configured on the Lenco webhook endpoint.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,7 +77,7 @@ node scripts/test-webhook-integration.js <webhook-url> <webhook-secret>
 **Example**:
 ```bash
 node scripts/test-webhook-integration.js \
-  https://nrjcbdrzaxqvomeogptf.supabase.co/functions/v1/lenco-webhook \
+  https://YOUR_PROJECT_REF.supabase.co/functions/v1/lenco-webhook \
   whsec_your_secret_key
 ```
 


### PR DESCRIPTION
## Summary
- replace real Supabase project reference and keys in documentation with safe placeholders and guidance for using actual values
- update Supabase CLI helper docs to clarify where YOUR_PROJECT_REF and passwords should be substituted
- enhance scripts/supabase-login.sh to derive project reference and database password from environment or .env files while warning when placeholders remain

## Testing
- bash -n scripts/supabase-login.sh

------
https://chatgpt.com/codex/tasks/task_e_68f78e3445a48328a959a925e642620f