### PR TITLE
Align Supabase URL aliases across docs and tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 SUPABASE_URL="https://your-project.supabase.co"
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
 VITE_SUPABASE_URL="https://your-project.supabase.co"
+# The Supabase quickstart naming convention is also supported
+# VITE_SUPABASE_PROJECT_URL="https://your-project.supabase.co"
 VITE_SUPABASE_KEY="your-anon-key"
 # The Supabase quickstart naming convention is also supported
 # VITE_SUPABASE_ANON_KEY="your-anon-key"

--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -299,6 +299,7 @@ if (user) {
 Required environment variables:
 
 ```env
+# VITE_SUPABASE_PROJECT_URL="https://your-project.supabase.co" # optional alias
 VITE_SUPABASE_URL="https://your-project.supabase.co"
 VITE_SUPABASE_KEY="your-anon-key"
 # Alternatively, you can provide the Supabase default name:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cp backend/.env.example backend/.env.production
 
 After creating the files, update them with your actual credentials:
 
-- `VITE_SUPABASE_URL` / `SUPABASE_URL` – Supabase project URL (mirrored for the backend runtime).
+- `VITE_SUPABASE_URL` / `VITE_SUPABASE_PROJECT_URL` / `SUPABASE_URL` – Supabase project URL (mirrored for the backend runtime).
 - `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY` – Supabase anon key for client access.
 - `SUPABASE_SERVICE_ROLE_KEY` – Required for any server-side inserts, including the Express API and Supabase Edge Functions.
 - `VITE_LENCO_PUBLIC_KEY` – Lenco public API key (current dashboards issue `pub-…` keys; older projects may still use `pk_live_…`).

--- a/TEST_SUITE_SUMMARY.md
+++ b/TEST_SUITE_SUMMARY.md
@@ -155,7 +155,7 @@ The **functionality they test works correctly in production** - these are primar
 Lighthouse testing requires:
 1. Running dev/preview server
 2. Proper environment variables configured:
-   - `VITE_SUPABASE_URL`
+   - `VITE_SUPABASE_URL` / `VITE_SUPABASE_PROJECT_URL`
    - `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY`
    - Other app-specific variables
 

--- a/backend/lib/supabaseClient.js
+++ b/backend/lib/supabaseClient.js
@@ -1,4 +1,10 @@
-const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+const SUPABASE_URL =
+  process.env.SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  process.env.VITE_SUPABASE_PROJECT_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.PUBLIC_SUPABASE_URL ||
+  '';
 const SUPABASE_SERVICE_ROLE_KEY =
   process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_KEY || '';
 

--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -55,7 +55,7 @@ Located at `backend/.env`, this file contains:
 ### Supabase Configuration
 
 **Frontend Variables:**
-- `VITE_SUPABASE_URL` - Your Supabase project URL (e.g., `https://your-project.supabase.co`)
+- `VITE_SUPABASE_URL` / `VITE_SUPABASE_PROJECT_URL` - Your Supabase project URL (e.g., `https://your-project.supabase.co`)
 - `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY` - Your Supabase anon/public key (JWT token)
 - `VITE_API_BASE_URL` - Base URL for the Express onboarding API (`http://localhost:3000` for local development, or your hosted backend URL in production)
 

--- a/docs/ENVIRONMENT_VARIABLES_QUICK_REFERENCE.md
+++ b/docs/ENVIRONMENT_VARIABLES_QUICK_REFERENCE.md
@@ -24,7 +24,7 @@ npm run env:check
 
 | Variable | Description | Example | Environment |
 |----------|-------------|---------|-------------|
-| `VITE_SUPABASE_URL` | Supabase project URL | `https://xxx.supabase.co` | All |
+| `VITE_SUPABASE_URL` / `VITE_SUPABASE_PROJECT_URL` | Supabase project URL | `https://xxx.supabase.co` | All |
 | `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY` | Supabase anon/public key | `eyJhbGci...` | All |
 | `VITE_API_BASE_URL` | Express backend base URL for onboarding API | `http://localhost:3000` or `https://api.example.com` | All |
 | `VITE_LENCO_PUBLIC_KEY` | Lenco publishable key (Production: `pub-...` or `pk_live_...`, Development: `pk_test_...`) | `pub-abc123...` or `pk_live_xyz789` | All |

--- a/docs/PAYMENT_INTEGRATION_GUIDE.md
+++ b/docs/PAYMENT_INTEGRATION_GUIDE.md
@@ -64,6 +64,7 @@ const paymentResponse = await lencoPaymentService.processMobileMoneyPayment({
 
 ```bash
 # Supabase Configuration
+# VITE_SUPABASE_PROJECT_URL="https://your-project.supabase.co" # optional alias
 VITE_SUPABASE_URL="https://your-project.supabase.co"
 VITE_SUPABASE_KEY="your-anon-key"
 # You may also set the default Supabase alias:

--- a/docs/PRODUCTION_READINESS_CHECKLIST.md
+++ b/docs/PRODUCTION_READINESS_CHECKLIST.md
@@ -12,6 +12,7 @@ This checklist consolidates the remaining action items required before WATHACI C
    cp backend/.env.example backend/.env.production
    ```
 2. Populate every Supabase and Lenco credential with production values in `.env.production` – replace all `your-…`, `test_`, or sandbox placeholders.
+   - Ensure the Supabase URL is defined via `VITE_SUPABASE_URL` or the alias `VITE_SUPABASE_PROJECT_URL`.
 3. Ensure `VITE_APP_ENV="production"` is set in `.env.production`.
 4. Point `VITE_API_BASE_URL` at the deployed Express onboarding backend (for example, `https://api.wathaci.com`).
 5. Mirror the same values inside Vercel → **Settings → Environment Variables** for `Production`, `Preview`, and `Development` environments.

--- a/docs/VERCEL_SUPABASE_DEPLOYMENT.md
+++ b/docs/VERCEL_SUPABASE_DEPLOYMENT.md
@@ -28,7 +28,7 @@ In the Vercel dashboard:
 2. Add the following variables for **each environment** (`Production`, `Preview`, and `Development`):
 
 ### Supabase Variables (Required)
-   - `VITE_SUPABASE_URL` – Supabase project URL (e.g., `https://abc123xyz789.supabase.co`)
+   - `VITE_SUPABASE_URL` / `VITE_SUPABASE_PROJECT_URL` – Supabase project URL (e.g., `https://abc123xyz789.supabase.co`)
    - `VITE_SUPABASE_KEY` / `VITE_SUPABASE_ANON_KEY` – Supabase anon/public key (JWT token)
    - `SUPABASE_URL` – Same as VITE_SUPABASE_URL (for backend/server usage)
    - `SUPABASE_SERVICE_ROLE_KEY` – Supabase service role key (required for server-side operations)

--- a/scripts/env-check.mjs
+++ b/scripts/env-check.mjs
@@ -172,7 +172,7 @@ const checks = [
     required: [
       {
         key: 'VITE_SUPABASE_URL',
-        description: 'Supabase project URL (https://<ref>.supabase.co)',
+        description: 'Supabase project URL (https://<ref>.supabase.co) — alias VITE_SUPABASE_PROJECT_URL supported',
         aliases: ['VITE_SUPABASE_PROJECT_URL', 'NEXT_PUBLIC_SUPABASE_URL', 'PUBLIC_SUPABASE_URL', 'SUPABASE_URL'],
       },
       {

--- a/scripts/setup-payments.sh
+++ b/scripts/setup-payments.sh
@@ -86,7 +86,7 @@ config_errors=0
 # Check Supabase configuration
 echo ""
 echo -e "${BLUE}🗄️  Supabase Configuration${NC}"
-check_env_var "VITE_SUPABASE_URL" "Supabase project URL" || ((config_errors++))
+check_env_var_any "Supabase project URL" "VITE_SUPABASE_URL" "VITE_SUPABASE_PROJECT_URL" || ((config_errors++))
 check_env_var_any "Supabase anon key" "VITE_SUPABASE_KEY" "VITE_SUPABASE_ANON_KEY" || ((config_errors++))
 
 # Check Lenco configuration

--- a/scripts/supabase-login.sh
+++ b/scripts/supabase-login.sh
@@ -26,7 +26,7 @@ infer_project_ref() {
             return
         fi
 
-        candidate=$(grep -E '^(SUPABASE_URL|VITE_SUPABASE_URL)=' "$PROJECT_DIR/.env" | tail -n1 | cut -d'=' -f2-)
+        candidate=$(grep -E '^(SUPABASE_URL|VITE_SUPABASE_URL|VITE_SUPABASE_PROJECT_URL)=' "$PROJECT_DIR/.env" | tail -n1 | cut -d'=' -f2-)
         candidate=${candidate//$double_quote/}
         candidate=${candidate//$single_quote/}
         if [[ -n "$candidate" ]]; then

--- a/scripts/validate-database.ts
+++ b/scripts/validate-database.ts
@@ -65,7 +65,9 @@ async function validateEnvironment() {
   );
 
   if (!url) {
-    log.error('VITE_SUPABASE_URL is not set');
+    log.error(
+      'Supabase URL is not set (expected VITE_SUPABASE_URL, VITE_SUPABASE_PROJECT_URL, NEXT_PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_URL, or SUPABASE_URL)',
+    );
     return false;
   }
   
@@ -79,7 +81,7 @@ async function validateEnvironment() {
     log.success('Environment variables are valid');
     return true;
   } catch {
-    log.error('VITE_SUPABASE_URL is not a valid URL');
+    log.error('Supabase URL is not a valid URL (checked VITE_SUPABASE_URL and its aliases)');
     return false;
   }
 }

--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -107,7 +107,7 @@ const supabaseKey = resolveFirstEnvValue(SUPABASE_KEY_ENV_KEYS);
 
 if ((!supabaseUrl || !supabaseKey) && !isTestEnvironment) {
   throw new Error(
-    'Missing Supabase configuration. Please set VITE_SUPABASE_URL and either VITE_SUPABASE_KEY or VITE_SUPABASE_ANON_KEY environment variables.'
+    'Missing Supabase configuration. Please set VITE_SUPABASE_URL (or its aliases) and either VITE_SUPABASE_KEY or VITE_SUPABASE_ANON_KEY environment variables.'
   );
 }
 


### PR DESCRIPTION
## Summary
- document the supported VITE_SUPABASE_PROJECT_URL alias in environment templates and guides
- accept the Supabase URL alias in helper scripts, backend Supabase client, and diagnostics messaging
- clarify production checklist and test suite notes around configuring either VITE_SUPABASE_URL or its alias

## Testing
- npm run test:jest -- --testPathPatterns=supabase-enhanced.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f7a18d5fa08328b2e798a7926fc15e