### PR TITLE
Fix Vite base path for static deployments

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,14 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
+export default defineConfig(({ command }) => ({
+  // Use relative paths for built assets so that deployments served from
+  // subdirectories (for example via object storage buckets) can resolve the
+  // CSS/JS bundles correctly without falling back to a blank page.  This
+  // matches the structure of the previously working build where
+  // dist/assets/index-BfhehJjT.css and dist/assets/index-CtanDc5o.js were
+  // referenced with relative URLs.
+  base: command === "serve" ? "/" : "./",
   server: {
     host: "::",
     port: 8080,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,14 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
+export default defineConfig(({ command }) => ({
+  // Use relative paths for built assets so that deployments served from
+  // subdirectories (for example via object storage buckets) can resolve the
+  // CSS/JS bundles correctly without falling back to a blank page.  This
+  // matches the structure of the previously working build where
+  // dist/assets/index-BfhehJjT.css and dist/assets/index-CtanDc5o.js were
+  // referenced with relative URLs.
+  base: command === "serve" ? "/" : "./",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure the Vite base path to use relative asset URLs when building so static deployments resolve the bundles correctly
- document the reason for the change in the Vite config files used across the project

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8a1d2cfb883289b9414d27ecf5a30