### PR TITLE
Handle missing Supabase configuration gracefully

### DIFF
--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -106,8 +106,11 @@ const supabaseUrl = resolveFirstEnvValue(SUPABASE_URL_ENV_KEYS);
 const supabaseKey = resolveFirstEnvValue(SUPABASE_KEY_ENV_KEYS);
 
 if ((!supabaseUrl || !supabaseKey) && !isTestEnvironment) {
-  throw new Error(
-    'Missing Supabase configuration. Please set VITE_SUPABASE_URL (or its aliases) and either VITE_SUPABASE_KEY or VITE_SUPABASE_ANON_KEY environment variables.'
+  console.warn(
+    [
+      'Missing Supabase configuration detected. Falling back to the mock Supabase client so the UI can still render.',
+      'Set VITE_SUPABASE_URL (or its aliases) and either VITE_SUPABASE_KEY or VITE_SUPABASE_ANON_KEY environment variables to enable full functionality.',
+    ].join(' ')
   );
 }
 


### PR DESCRIPTION
## Summary
- log a warning when Supabase environment variables are missing instead of throwing
- allow the application to fall back to the mock Supabase client so the UI can render in production without configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8af329e588328bb3e825b36269ef8