### PR TITLE
Add profile support for all account types

### DIFF
--- a/backend/supabase/core_schema.sql
+++ b/backend/supabase/core_schema.sql
@@ -37,6 +37,23 @@ create table if not exists public.profiles (
   payment_phone text,
   use_same_phone boolean default false,
   card_details jsonb,
+  investment_focus text,
+  investment_ticket_min numeric,
+  investment_ticket_max numeric,
+  investment_stage text,
+  investment_regions text,
+  impact_focus text,
+  support_services text,
+  support_preferences text,
+  partnership_preferences text,
+  donor_type text,
+  funding_focus text,
+  annual_funding_budget numeric,
+  institution_type text,
+  department text,
+  government_focus text,
+  programs text,
+  partnership_needs text,
   qualifications jsonb,
   experience_years integer,
   specialization text,
@@ -47,6 +64,25 @@ create table if not exists public.profiles (
 
 create index if not exists profiles_account_type_idx on public.profiles (account_type);
 create index if not exists profiles_country_idx on public.profiles (country);
+
+alter table public.profiles
+  add column if not exists investment_focus text,
+  add column if not exists investment_ticket_min numeric,
+  add column if not exists investment_ticket_max numeric,
+  add column if not exists investment_stage text,
+  add column if not exists investment_regions text,
+  add column if not exists impact_focus text,
+  add column if not exists support_services text,
+  add column if not exists support_preferences text,
+  add column if not exists partnership_preferences text,
+  add column if not exists donor_type text,
+  add column if not exists funding_focus text,
+  add column if not exists annual_funding_budget numeric,
+  add column if not exists institution_type text,
+  add column if not exists department text,
+  add column if not exists government_focus text,
+  add column if not exists programs text,
+  add column if not exists partnership_needs text;
 
 -- Automatically maintain updated_at
 create or replace function public.set_updated_at()
@@ -62,6 +98,474 @@ create trigger set_timestamp
   before update on public.profiles
   for each row
   execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- Needs assessment tables for each profile type
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.sme_needs_assessments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  monthly_revenue numeric not null,
+  monthly_expenses numeric not null,
+  cash_flow_positive boolean not null,
+  debt_obligations numeric not null,
+  financial_records_organized boolean not null,
+  key_operational_challenges text[] not null,
+  technology_gaps text[] not null,
+  automation_level text not null,
+  target_market_clarity integer not null,
+  customer_acquisition_challenges text[] not null,
+  competitive_position text not null,
+  regulatory_compliance_status text not null,
+  legal_structure_optimized boolean not null,
+  intellectual_property_protected boolean not null,
+  growth_strategy_defined boolean not null,
+  funding_requirements jsonb not null,
+  key_performance_metrics_tracked boolean not null,
+  immediate_support_areas text[] not null,
+  budget_for_professional_services numeric not null,
+  overall_score integer not null,
+  identified_gaps text[] not null,
+  priority_areas text[] not null,
+  completed_at timestamptz not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists sme_needs_assessments_user_id_idx on public.sme_needs_assessments (user_id);
+
+alter table public.sme_needs_assessments enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'sme_needs_assessments'
+      and polname = 'SME assessments are viewable by owners'
+  ) then
+    create policy "SME assessments are viewable by owners"
+      on public.sme_needs_assessments
+      for select
+      using (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'sme_needs_assessments'
+      and polname = 'SME assessments are manageable by owners'
+  ) then
+    create policy "SME assessments are manageable by owners"
+      on public.sme_needs_assessments
+      for all
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'sme_needs_assessments'
+      and polname = 'SME assessments managed by service role'
+  ) then
+    create policy "SME assessments managed by service role"
+      on public.sme_needs_assessments
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end
+$$;
+
+drop trigger if exists set_timestamp on public.sme_needs_assessments;
+create trigger set_timestamp
+  before update on public.sme_needs_assessments
+  for each row execute function public.set_updated_at();
+
+create table if not exists public.professional_needs_assessments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  primary_profession text not null,
+  years_of_experience integer not null,
+  specialization_areas text[] not null,
+  current_employment_status text not null,
+  services_offered text[] not null,
+  service_delivery_modes text[] not null,
+  hourly_rate_min numeric not null,
+  hourly_rate_max numeric not null,
+  target_client_types text[] not null,
+  client_size_preference text[] not null,
+  industry_focus text[] not null,
+  availability_hours_per_week integer not null,
+  project_duration_preference text not null,
+  travel_willingness text not null,
+  remote_work_capability boolean not null,
+  key_skills text[] not null,
+  certification_status text[] not null,
+  continuous_learning_interest boolean not null,
+  mentorship_interest text not null,
+  client_acquisition_challenges text[] not null,
+  marketing_channels text[] not null,
+  business_development_support_needed text[] not null,
+  networking_preferences text[] not null,
+  collaboration_interest boolean not null,
+  partnership_types text[] not null,
+  referral_system_interest boolean not null,
+  professional_profile jsonb not null,
+  professional_strategy text[] not null,
+  completed_at timestamptz not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists professional_needs_assessments_user_id_idx on public.professional_needs_assessments (user_id);
+
+alter table public.professional_needs_assessments enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'professional_needs_assessments'
+      and polname = 'Professional assessments are viewable by owners'
+  ) then
+    create policy "Professional assessments are viewable by owners"
+      on public.professional_needs_assessments
+      for select
+      using (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'professional_needs_assessments'
+      and polname = 'Professional assessments are manageable by owners'
+  ) then
+    create policy "Professional assessments are manageable by owners"
+      on public.professional_needs_assessments
+      for all
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'professional_needs_assessments'
+      and polname = 'Professional assessments managed by service role'
+  ) then
+    create policy "Professional assessments managed by service role"
+      on public.professional_needs_assessments
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end
+$$;
+
+drop trigger if exists set_timestamp on public.professional_needs_assessments;
+create trigger set_timestamp
+  before update on public.professional_needs_assessments
+  for each row execute function public.set_updated_at();
+
+create table if not exists public.investor_needs_assessments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  investment_amount_min numeric not null,
+  investment_amount_max numeric not null,
+  investment_horizon text not null,
+  risk_tolerance text not null,
+  support_types text[] not null,
+  technical_assistance_areas text[] not null,
+  mentorship_availability boolean not null,
+  preferred_industries text[] not null,
+  business_stages text[] not null,
+  geographic_focus text[] not null,
+  equity_percentage_min numeric not null,
+  equity_percentage_max numeric not null,
+  board_participation boolean not null,
+  follow_on_investment boolean not null,
+  due_diligence_requirements text[] not null,
+  decision_timeline text not null,
+  investment_committee boolean not null,
+  impact_focus boolean not null,
+  esg_criteria text[] not null,
+  social_impact_importance integer not null,
+  co_investment_interest boolean not null,
+  lead_investor_preference text not null,
+  syndicate_participation boolean not null,
+  investor_profile jsonb not null,
+  investment_strategy text[] not null,
+  completed_at timestamptz not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists investor_needs_assessments_user_id_idx on public.investor_needs_assessments (user_id);
+
+alter table public.investor_needs_assessments enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'investor_needs_assessments'
+      and polname = 'Investor assessments are viewable by owners'
+  ) then
+    create policy "Investor assessments are viewable by owners"
+      on public.investor_needs_assessments
+      for select
+      using (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'investor_needs_assessments'
+      and polname = 'Investor assessments are manageable by owners'
+  ) then
+    create policy "Investor assessments are manageable by owners"
+      on public.investor_needs_assessments
+      for all
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'investor_needs_assessments'
+      and polname = 'Investor assessments managed by service role'
+  ) then
+    create policy "Investor assessments managed by service role"
+      on public.investor_needs_assessments
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end
+$$;
+
+drop trigger if exists set_timestamp on public.investor_needs_assessments;
+create trigger set_timestamp
+  before update on public.investor_needs_assessments
+  for each row execute function public.set_updated_at();
+
+create table if not exists public.donor_needs_assessments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  annual_donation_budget numeric not null,
+  donation_frequency text not null,
+  donation_amount_per_recipient numeric not null,
+  focus_areas text[] not null,
+  target_beneficiaries text[] not null,
+  geographic_focus text[] not null,
+  support_types text[] not null,
+  capacity_building_interest boolean not null,
+  mentorship_availability boolean not null,
+  impact_measurement_importance integer not null,
+  reporting_requirements text[] not null,
+  follow_up_engagement boolean not null,
+  organization_size_preference text[] not null,
+  organization_stage_preference text[] not null,
+  religious_affiliation_preference text not null,
+  selection_criteria text[] not null,
+  application_process text not null,
+  decision_timeline text not null,
+  collaborative_funding boolean not null,
+  partner_organizations text[] not null,
+  volunteer_opportunities boolean not null,
+  donor_profile jsonb not null,
+  donor_strategy text[] not null,
+  completed_at timestamptz not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists donor_needs_assessments_user_id_idx on public.donor_needs_assessments (user_id);
+
+alter table public.donor_needs_assessments enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'donor_needs_assessments'
+      and polname = 'Donor assessments are viewable by owners'
+  ) then
+    create policy "Donor assessments are viewable by owners"
+      on public.donor_needs_assessments
+      for select
+      using (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'donor_needs_assessments'
+      and polname = 'Donor assessments are manageable by owners'
+  ) then
+    create policy "Donor assessments are manageable by owners"
+      on public.donor_needs_assessments
+      for all
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'donor_needs_assessments'
+      and polname = 'Donor assessments managed by service role'
+  ) then
+    create policy "Donor assessments managed by service role"
+      on public.donor_needs_assessments
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end
+$$;
+
+drop trigger if exists set_timestamp on public.donor_needs_assessments;
+create trigger set_timestamp
+  before update on public.donor_needs_assessments
+  for each row execute function public.set_updated_at();
+
+create table if not exists public.government_needs_assessments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  institution_name text not null,
+  institution_type text not null,
+  department_division text not null,
+  geographic_jurisdiction text[] not null,
+  current_programs text[] not null,
+  target_beneficiaries text[] not null,
+  annual_budget_allocation numeric not null,
+  program_reach text not null,
+  partnership_interests text[] not null,
+  collaboration_types text[] not null,
+  preferred_partners text[] not null,
+  capacity_building_areas text[] not null,
+  staff_development_priorities text[] not null,
+  technical_assistance_needs text[] not null,
+  policy_development_focus text[] not null,
+  regulatory_challenges text[] not null,
+  stakeholder_engagement_priorities text[] not null,
+  digitalization_priorities text[] not null,
+  innovation_focus_areas text[] not null,
+  technology_adoption_challenges text[] not null,
+  monitoring_systems boolean not null,
+  evaluation_frequency text not null,
+  impact_measurement_priorities text[] not null,
+  reporting_requirements text[] not null,
+  government_profile jsonb not null,
+  government_strategy text[] not null,
+  completed_at timestamptz not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists government_needs_assessments_user_id_idx on public.government_needs_assessments (user_id);
+
+alter table public.government_needs_assessments enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'government_needs_assessments'
+      and polname = 'Government assessments are viewable by owners'
+  ) then
+    create policy "Government assessments are viewable by owners"
+      on public.government_needs_assessments
+      for select
+      using (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'government_needs_assessments'
+      and polname = 'Government assessments are manageable by owners'
+  ) then
+    create policy "Government assessments are manageable by owners"
+      on public.government_needs_assessments
+      for all
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'government_needs_assessments'
+      and polname = 'Government assessments managed by service role'
+  ) then
+    create policy "Government assessments managed by service role"
+      on public.government_needs_assessments
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end
+$$;
+
+drop trigger if exists set_timestamp on public.government_needs_assessments;
+create trigger set_timestamp
+  before update on public.government_needs_assessments
+  for each row execute function public.set_updated_at();
 
 -- ---------------------------------------------------------------------------
 -- Subscription plans available to end users

--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -64,6 +64,23 @@ export interface BusinessInfo {
   employee_count?: number;
   annual_revenue?: number;
   funding_stage?: string;
+  investment_focus?: string;
+  investment_ticket_min?: number;
+  investment_ticket_max?: number;
+  investment_stage?: string;
+  investment_regions?: string;
+  impact_focus?: string;
+  support_services?: string;
+  support_preferences?: string;
+  partnership_preferences?: string;
+  donor_type?: string;
+  funding_focus?: string;
+  annual_funding_budget?: number;
+  institution_type?: string;
+  department?: string;
+  government_focus?: string;
+  programs?: string;
+  partnership_needs?: string;
 }
 
 export interface PaymentInfo {
@@ -242,6 +259,140 @@ export interface SMENeedsAssessment {
   identified_gaps: string[];
   priority_areas: string[];
   
+  completed_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProfessionalNeedsAssessment {
+  id: string;
+  user_id: string;
+  primary_profession: string;
+  years_of_experience: number;
+  specialization_areas: string[];
+  current_employment_status: 'employed' | 'self_employed' | 'consultant' | 'unemployed' | 'retired';
+  services_offered: string[];
+  service_delivery_modes: string[];
+  hourly_rate_min: number;
+  hourly_rate_max: number;
+  target_client_types: string[];
+  client_size_preference: string[];
+  industry_focus: string[];
+  availability_hours_per_week: number;
+  project_duration_preference: 'short_term' | 'medium_term' | 'long_term' | 'flexible';
+  travel_willingness: 'local_only' | 'regional' | 'national' | 'international';
+  remote_work_capability: boolean;
+  key_skills: string[];
+  certification_status: string[];
+  continuous_learning_interest: boolean;
+  mentorship_interest: 'provide' | 'receive' | 'both' | 'none';
+  client_acquisition_challenges: string[];
+  marketing_channels: string[];
+  business_development_support_needed: string[];
+  networking_preferences: string[];
+  collaboration_interest: boolean;
+  partnership_types: string[];
+  referral_system_interest: boolean;
+  professional_profile: Record<string, any>;
+  professional_strategy: string[];
+  completed_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InvestorNeedsAssessment {
+  id: string;
+  user_id: string;
+  investment_amount_min: number;
+  investment_amount_max: number;
+  investment_horizon: 'short_term' | 'medium_term' | 'long_term';
+  risk_tolerance: 'low' | 'moderate' | 'high';
+  support_types: string[];
+  technical_assistance_areas: string[];
+  mentorship_availability: boolean;
+  preferred_industries: string[];
+  business_stages: string[];
+  geographic_focus: string[];
+  equity_percentage_min: number;
+  equity_percentage_max: number;
+  board_participation: boolean;
+  follow_on_investment: boolean;
+  due_diligence_requirements: string[];
+  decision_timeline: string;
+  investment_committee: boolean;
+  impact_focus: boolean;
+  esg_criteria: string[];
+  social_impact_importance: number;
+  co_investment_interest: boolean;
+  lead_investor_preference: 'lead' | 'follow' | 'either';
+  syndicate_participation: boolean;
+  investor_profile: Record<string, any>;
+  investment_strategy: string[];
+  completed_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DonorNeedsAssessment {
+  id: string;
+  user_id: string;
+  annual_donation_budget: number;
+  donation_frequency: 'one_time' | 'monthly' | 'quarterly' | 'annually';
+  donation_amount_per_recipient: number;
+  focus_areas: string[];
+  target_beneficiaries: string[];
+  geographic_focus: string[];
+  support_types: string[];
+  capacity_building_interest: boolean;
+  mentorship_availability: boolean;
+  impact_measurement_importance: number;
+  reporting_requirements: string[];
+  follow_up_engagement: boolean;
+  organization_size_preference: string[];
+  organization_stage_preference: string[];
+  religious_affiliation_preference: 'any' | 'christian' | 'muslim' | 'other' | 'secular_only';
+  selection_criteria: string[];
+  application_process: string;
+  decision_timeline: string;
+  collaborative_funding: boolean;
+  partner_organizations: string[];
+  volunteer_opportunities: boolean;
+  donor_profile: Record<string, any>;
+  donor_strategy: string[];
+  completed_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GovernmentNeedsAssessment {
+  id: string;
+  user_id: string;
+  institution_name: string;
+  institution_type: 'ministry' | 'agency' | 'council' | 'commission' | 'parastate' | 'other';
+  department_division: string;
+  geographic_jurisdiction: string[];
+  current_programs: string[];
+  target_beneficiaries: string[];
+  annual_budget_allocation: number;
+  program_reach: 'local' | 'provincial' | 'national' | 'regional';
+  partnership_interests: string[];
+  collaboration_types: string[];
+  preferred_partners: string[];
+  capacity_building_areas: string[];
+  staff_development_priorities: string[];
+  technical_assistance_needs: string[];
+  policy_development_focus: string[];
+  regulatory_challenges: string[];
+  stakeholder_engagement_priorities: string[];
+  digitalization_priorities: string[];
+  innovation_focus_areas: string[];
+  technology_adoption_challenges: string[];
+  monitoring_systems: boolean;
+  evaluation_frequency: 'monthly' | 'quarterly' | 'annually' | 'project_based';
+  impact_measurement_priorities: string[];
+  reporting_requirements: string[];
+  government_profile: Record<string, any>;
+  government_strategy: string[];
   completed_at: string;
   created_at: string;
   updated_at: string;

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -14,6 +14,32 @@ import { ImageUpload } from '@/components/ImageUpload';
 import { ArrowLeft } from 'lucide-react';
 import { sectors, countries } from '../data/countries';
 
+const investmentStageOptions = [
+  { value: 'pre_seed', label: 'Pre-seed & Seed' },
+  { value: 'series_a', label: 'Series A' },
+  { value: 'series_b_plus', label: 'Series B and Beyond' },
+  { value: 'growth', label: 'Growth & Expansion' },
+  { value: 'infrastructure', label: 'Infrastructure Projects' },
+];
+
+const donorTypeOptions = [
+  { value: 'individual', label: 'Individual Donor' },
+  { value: 'corporate', label: 'Corporate Foundation' },
+  { value: 'family_foundation', label: 'Family Foundation' },
+  { value: 'international', label: 'International Organization' },
+  { value: 'government', label: 'Government Agency' },
+  { value: 'faith_based', label: 'Faith-based Organization' },
+];
+
+const institutionTypeOptions = [
+  { value: 'ministry', label: 'Ministry' },
+  { value: 'agency', label: 'Agency' },
+  { value: 'council', label: 'Council' },
+  { value: 'commission', label: 'Commission' },
+  { value: 'parastate', label: 'Parastatal' },
+  { value: 'other', label: 'Other Government Institution' },
+];
+
 interface ProfileFormProps {
   accountType: string;
   onSubmit: (data: any) => void;
@@ -35,6 +61,24 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
     cardholder_name: initialData?.card_details?.cardholder_name || '',
     profile_image_url: null,
     linkedin_url: '',
+    annual_revenue: initialData?.annual_revenue ?? '',
+    investment_focus: initialData?.investment_focus || '',
+    investment_ticket_min: initialData?.investment_ticket_min ?? '',
+    investment_ticket_max: initialData?.investment_ticket_max ?? '',
+    investment_stage: initialData?.investment_stage || '',
+    investment_regions: initialData?.investment_regions || '',
+    impact_focus: initialData?.impact_focus || '',
+    support_services: initialData?.support_services || '',
+    support_preferences: initialData?.support_preferences || '',
+    partnership_preferences: initialData?.partnership_preferences || '',
+    donor_type: initialData?.donor_type || '',
+    funding_focus: initialData?.funding_focus || '',
+    annual_funding_budget: initialData?.annual_funding_budget ?? '',
+    institution_type: initialData?.institution_type || '',
+    department: initialData?.department || '',
+    government_focus: initialData?.government_focus || '',
+    programs: initialData?.programs || '',
+    partnership_needs: initialData?.partnership_needs || '',
     ...initialData
   });
 
@@ -262,10 +306,326 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
       </div>
       <div>
         <Label>LinkedIn Profile URL</Label>
-        <Input 
+        <Input
           value={formData.linkedin_url || ''}
           onChange={(e) => handleInputChange('linkedin_url', e.target.value)}
           placeholder="https://linkedin.com/company/your-company"
+        />
+      </div>
+    </>
+  );
+
+  const renderInvestorFields = () => (
+    <>
+      <ImageUpload
+        currentImage={formData.profile_image_url}
+        onImageChange={(url) => handleInputChange('profile_image_url', url)}
+        label="Organization Logo"
+        type="logo"
+      />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <Label>Organization Name</Label>
+          <Input
+            value={formData.business_name || ''}
+            onChange={(e) => handleInputChange('business_name', e.target.value)}
+          />
+        </div>
+        <div>
+          <Label>Registration Number</Label>
+          <Input
+            value={formData.registration_number || ''}
+            onChange={(e) => handleInputChange('registration_number', e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+          <Label>Annual Investment Capacity (USD)</Label>
+          <Input
+            type="number"
+            value={formData.annual_revenue ?? ''}
+            onChange={(e) => handleInputChange('annual_revenue', e.target.value)}
+          />
+        </div>
+        <div>
+          <Label>Typical Ticket Size (Min)</Label>
+          <Input
+            type="number"
+            value={formData.investment_ticket_min ?? ''}
+            onChange={(e) => handleInputChange('investment_ticket_min', e.target.value)}
+          />
+        </div>
+        <div>
+          <Label>Typical Ticket Size (Max)</Label>
+          <Input
+            type="number"
+            value={formData.investment_ticket_max ?? ''}
+            onChange={(e) => handleInputChange('investment_ticket_max', e.target.value)}
+          />
+        </div>
+      </div>
+      <div>
+        <Label>Preferred Investment Stage</Label>
+        <Select
+          value={formData.investment_stage || ''}
+          onValueChange={(value) => handleInputChange('investment_stage', value)}
+        >
+          <SelectTrigger><SelectValue placeholder="Select stage" /></SelectTrigger>
+          <SelectContent>
+            {investmentStageOptions.map((stage) => (
+              <SelectItem key={stage.value} value={stage.value}>
+                {stage.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div>
+        <Label>Investment Focus Areas</Label>
+        <Textarea
+          value={formData.investment_focus || ''}
+          onChange={(e) => handleInputChange('investment_focus', e.target.value)}
+          placeholder="e.g. Agriculture, Renewable Energy, Financial Inclusion"
+          rows={3}
+        />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <Label>Geographic Focus</Label>
+          <Textarea
+            value={formData.investment_regions || ''}
+            onChange={(e) => handleInputChange('investment_regions', e.target.value)}
+            placeholder="Regions or countries you focus on"
+            rows={3}
+          />
+        </div>
+        <div>
+          <Label>Impact Priorities</Label>
+          <Textarea
+            value={formData.impact_focus || ''}
+            onChange={(e) => handleInputChange('impact_focus', e.target.value)}
+            placeholder="Impact themes such as climate resilience, women's economic empowerment, etc."
+            rows={3}
+          />
+        </div>
+      </div>
+      <div>
+        <Label>Support Provided Beyond Capital</Label>
+        <Textarea
+          value={formData.support_services || ''}
+          onChange={(e) => handleInputChange('support_services', e.target.value)}
+          placeholder="Describe advisory, mentorship, or technical support offered to portfolio companies"
+          rows={3}
+        />
+      </div>
+      <div>
+        <Label>LinkedIn Profile URL</Label>
+        <Input
+          value={formData.linkedin_url || ''}
+          onChange={(e) => handleInputChange('linkedin_url', e.target.value)}
+          placeholder="https://linkedin.com/company/your-organization"
+        />
+      </div>
+    </>
+  );
+
+  const renderDonorFields = () => (
+    <>
+      <ImageUpload
+        currentImage={formData.profile_image_url}
+        onImageChange={(url) => handleInputChange('profile_image_url', url)}
+        label="Organization Logo"
+        type="logo"
+      />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <Label>Organization Name</Label>
+          <Input
+            value={formData.business_name || ''}
+            onChange={(e) => handleInputChange('business_name', e.target.value)}
+          />
+        </div>
+        <div>
+          <Label>Registration Number</Label>
+          <Input
+            value={formData.registration_number || ''}
+            onChange={(e) => handleInputChange('registration_number', e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <Label>Donor Type</Label>
+          <Select
+            value={formData.donor_type || ''}
+            onValueChange={(value) => handleInputChange('donor_type', value)}
+          >
+            <SelectTrigger><SelectValue placeholder="Select donor type" /></SelectTrigger>
+            <SelectContent>
+              {donorTypeOptions.map((type) => (
+                <SelectItem key={type.value} value={type.value}>
+                  {type.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label>Annual Funding Budget (USD)</Label>
+          <Input
+            type="number"
+            value={formData.annual_funding_budget ?? ''}
+            onChange={(e) => handleInputChange('annual_funding_budget', e.target.value)}
+          />
+        </div>
+      </div>
+      <div>
+        <Label>Funding Focus Areas</Label>
+        <Textarea
+          value={formData.funding_focus || ''}
+          onChange={(e) => handleInputChange('funding_focus', e.target.value)}
+          placeholder="e.g. Education, Healthcare, Women-led Enterprises"
+          rows={3}
+        />
+      </div>
+      <div>
+        <Label>Support Offered</Label>
+        <Textarea
+          value={formData.support_preferences || ''}
+          onChange={(e) => handleInputChange('support_preferences', e.target.value)}
+          placeholder="Describe non-financial support such as mentorship, capacity building, or volunteer programs"
+          rows={3}
+        />
+      </div>
+      <div>
+        <Label>Impact Priorities</Label>
+        <Textarea
+          value={formData.impact_focus || ''}
+          onChange={(e) => handleInputChange('impact_focus', e.target.value)}
+          placeholder="Impact outcomes you prioritize in your funding"
+          rows={3}
+        />
+      </div>
+      <div>
+        <Label>Partnership Preferences</Label>
+        <Textarea
+          value={formData.partnership_preferences || ''}
+          onChange={(e) => handleInputChange('partnership_preferences', e.target.value)}
+          placeholder="Preferred partners, collaboration models, or grant structures"
+          rows={3}
+        />
+      </div>
+      <div>
+        <Label>LinkedIn Profile URL</Label>
+        <Input
+          value={formData.linkedin_url || ''}
+          onChange={(e) => handleInputChange('linkedin_url', e.target.value)}
+          placeholder="https://linkedin.com/company/your-organization"
+        />
+      </div>
+    </>
+  );
+
+  const renderGovernmentFields = () => (
+    <>
+      <ImageUpload
+        currentImage={formData.profile_image_url}
+        onImageChange={(url) => handleInputChange('profile_image_url', url)}
+        label="Institution Emblem"
+        type="logo"
+      />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <Label>Institution Name</Label>
+          <Input
+            value={formData.business_name || ''}
+            onChange={(e) => handleInputChange('business_name', e.target.value)}
+          />
+        </div>
+        <div>
+          <Label>Registration Number</Label>
+          <Input
+            value={formData.registration_number || ''}
+            onChange={(e) => handleInputChange('registration_number', e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+          <Label>Institution Type</Label>
+          <Select
+            value={formData.institution_type || ''}
+            onValueChange={(value) => handleInputChange('institution_type', value)}
+          >
+            <SelectTrigger><SelectValue placeholder="Select institution type" /></SelectTrigger>
+            <SelectContent>
+              {institutionTypeOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label>Department / Division</Label>
+          <Input
+            value={formData.department || ''}
+            onChange={(e) => handleInputChange('department', e.target.value)}
+          />
+        </div>
+        <div>
+          <Label>Annual Program Budget (USD)</Label>
+          <Input
+            type="number"
+            value={formData.annual_revenue ?? ''}
+            onChange={(e) => handleInputChange('annual_revenue', e.target.value)}
+          />
+        </div>
+      </div>
+      <div>
+        <Label>Primary Focus Areas</Label>
+        <Textarea
+          value={formData.government_focus || ''}
+          onChange={(e) => handleInputChange('government_focus', e.target.value)}
+          placeholder="e.g. SME development, skills training, infrastructure"
+          rows={3}
+        />
+      </div>
+      <div>
+        <Label>Key Programs & Initiatives</Label>
+        <Textarea
+          value={formData.programs || ''}
+          onChange={(e) => handleInputChange('programs', e.target.value)}
+          placeholder="List major programs, priority sectors, or flagship initiatives"
+          rows={3}
+        />
+      </div>
+      <div>
+        <Label>Partnership Needs</Label>
+        <Textarea
+          value={formData.partnership_needs || ''}
+          onChange={(e) => handleInputChange('partnership_needs', e.target.value)}
+          placeholder="Describe collaboration needs with SMEs, investors, donors, or other partners"
+          rows={3}
+        />
+      </div>
+      <div>
+        <Label>Impact Priorities</Label>
+        <Textarea
+          value={formData.impact_focus || ''}
+          onChange={(e) => handleInputChange('impact_focus', e.target.value)}
+          placeholder="Outcomes you aim to achieve (e.g. job creation, export growth)"
+          rows={3}
+        />
+      </div>
+      <div>
+        <Label>LinkedIn Profile URL</Label>
+        <Input
+          value={formData.linkedin_url || ''}
+          onChange={(e) => handleInputChange('linkedin_url', e.target.value)}
+          placeholder="https://linkedin.com/company/your-institution"
         />
       </div>
     </>
@@ -346,6 +706,9 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
           {accountType === 'sole_proprietor' && renderSoleProprietorFields()}
           {accountType === 'professional' && renderProfessionalFields()}
           {accountType === 'sme' && renderSMEFields()}
+          {accountType === 'investor' && renderInvestorFields()}
+          {accountType === 'donor' && renderDonorFields()}
+          {accountType === 'government' && renderGovernmentFields()}
 
           {/* Payment Method Section */}
           <div className="border-t pt-6">

--- a/src/components/ProfileReview.tsx
+++ b/src/components/ProfileReview.tsx
@@ -7,7 +7,20 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
-import { Edit, MapPin, Phone, Mail, Building, Calendar, Users, DollarSign, CreditCard } from 'lucide-react';
+import {
+  Edit,
+  MapPin,
+  Phone,
+  Mail,
+  Building,
+  Calendar,
+  Users,
+  DollarSign,
+  CreditCard,
+  Globe,
+  Target,
+  Handshake
+} from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
 export const ProfileReview = () => {
@@ -87,6 +100,39 @@ export const ProfileReview = () => {
       'government': 'Government Institution'
     };
     return labels[type as keyof typeof labels] || type;
+  };
+
+  const formatInvestmentStage = (stage: string) => {
+    const stages: Record<string, string> = {
+      pre_seed: 'Pre-seed & Seed',
+      series_a: 'Series A',
+      series_b_plus: 'Series B and Beyond',
+      growth: 'Growth & Expansion',
+      infrastructure: 'Infrastructure Projects'
+    };
+
+    return stages[stage] ?? stage;
+  };
+
+  const formatAmount = (value: unknown) => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    const numericValue =
+      typeof value === 'number'
+        ? value
+        : Number(String(value).replace(/[^0-9.-]/g, ''));
+
+    if (!Number.isFinite(numericValue)) {
+      return String(value);
+    }
+
+    return numericValue.toLocaleString(undefined, {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0
+    });
   };
 
   const formatQualification = (qualification: unknown) => {
@@ -286,6 +332,192 @@ export const ProfileReview = () => {
                   <div className="flex items-center gap-3">
                     <DollarSign className="h-5 w-5 text-muted-foreground" />
                     <span>Funding requirement: ${profile.funding_requirements}</span>
+                  </div>
+                )}
+              </>
+            )}
+            {profile.account_type === 'investor' && (
+              <>
+                {profile.business_name && (
+                  <div>
+                    <h4 className="font-medium">Organization Name</h4>
+                    <p className="text-muted-foreground">{profile.business_name}</p>
+                  </div>
+                )}
+                {profile.annual_revenue && (
+                  <div className="flex items-center gap-3">
+                    <DollarSign className="h-5 w-5 text-muted-foreground" />
+                    <span>
+                      Annual investment capacity: {formatAmount(profile.annual_revenue)}
+                    </span>
+                  </div>
+                )}
+                {(profile.investment_ticket_min || profile.investment_ticket_max) && (
+                  <div className="flex items-center gap-3">
+                    <DollarSign className="h-5 w-5 text-muted-foreground" />
+                    <span>
+                      Ticket size:
+                      {profile.investment_ticket_min
+                        ? ` ${formatAmount(profile.investment_ticket_min)}`
+                        : ''}
+                      {profile.investment_ticket_max
+                        ? ` - ${formatAmount(profile.investment_ticket_max)}`
+                        : ''}
+                    </span>
+                  </div>
+                )}
+                {profile.investment_stage && (
+                  <div className="flex items-center gap-3">
+                    <Target className="h-5 w-5 text-muted-foreground" />
+                    <span>Preferred stage: {formatInvestmentStage(profile.investment_stage)}</span>
+                  </div>
+                )}
+                {profile.investment_focus && (
+                  <div>
+                    <h4 className="font-medium">Investment Focus Areas</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.investment_focus}
+                    </p>
+                  </div>
+                )}
+                {profile.investment_regions && (
+                  <div className="flex items-center gap-3">
+                    <Globe className="h-5 w-5 text-muted-foreground" />
+                    <span>{profile.investment_regions}</span>
+                  </div>
+                )}
+                {profile.impact_focus && (
+                  <div>
+                    <h4 className="font-medium">Impact Priorities</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.impact_focus}
+                    </p>
+                  </div>
+                )}
+                {profile.support_services && (
+                  <div>
+                    <h4 className="font-medium">Support Beyond Capital</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.support_services}
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
+            {profile.account_type === 'donor' && (
+              <>
+                {profile.business_name && (
+                  <div>
+                    <h4 className="font-medium">Organization Name</h4>
+                    <p className="text-muted-foreground">{profile.business_name}</p>
+                  </div>
+                )}
+                {profile.donor_type && (
+                  <div className="flex items-center gap-3">
+                    <Building className="h-5 w-5 text-muted-foreground" />
+                    <span>{profile.donor_type.replace(/_/g, ' ')}</span>
+                  </div>
+                )}
+                {profile.annual_funding_budget && (
+                  <div className="flex items-center gap-3">
+                    <DollarSign className="h-5 w-5 text-muted-foreground" />
+                    <span>
+                      Annual funding budget: {formatAmount(profile.annual_funding_budget)}
+                    </span>
+                  </div>
+                )}
+                {profile.funding_focus && (
+                  <div>
+                    <h4 className="font-medium">Funding Focus Areas</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.funding_focus}
+                    </p>
+                  </div>
+                )}
+                {profile.support_preferences && (
+                  <div>
+                    <h4 className="font-medium">Support Offered</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.support_preferences}
+                    </p>
+                  </div>
+                )}
+                {profile.impact_focus && (
+                  <div>
+                    <h4 className="font-medium">Impact Priorities</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.impact_focus}
+                    </p>
+                  </div>
+                )}
+                {profile.partnership_preferences && (
+                  <div>
+                    <h4 className="font-medium">Partnership Preferences</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.partnership_preferences}
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
+            {profile.account_type === 'government' && (
+              <>
+                {profile.business_name && (
+                  <div>
+                    <h4 className="font-medium">Institution Name</h4>
+                    <p className="text-muted-foreground">{profile.business_name}</p>
+                  </div>
+                )}
+                {profile.institution_type && (
+                  <div className="flex items-center gap-3">
+                    <Building className="h-5 w-5 text-muted-foreground" />
+                    <span>{profile.institution_type.replace(/_/g, ' ')}</span>
+                  </div>
+                )}
+                {profile.department && (
+                  <div className="flex items-center gap-3">
+                    <Users className="h-5 w-5 text-muted-foreground" />
+                    <span>Department: {profile.department}</span>
+                  </div>
+                )}
+                {profile.annual_revenue && (
+                  <div className="flex items-center gap-3">
+                    <DollarSign className="h-5 w-5 text-muted-foreground" />
+                    <span>
+                      Annual program budget: {formatAmount(profile.annual_revenue)}
+                    </span>
+                  </div>
+                )}
+                {profile.government_focus && (
+                  <div>
+                    <h4 className="font-medium">Primary Focus Areas</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.government_focus}
+                    </p>
+                  </div>
+                )}
+                {profile.programs && (
+                  <div>
+                    <h4 className="font-medium">Key Programs & Initiatives</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.programs}
+                    </p>
+                  </div>
+                )}
+                {profile.partnership_needs && (
+                  <div className="flex items-center gap-3">
+                    <Handshake className="h-5 w-5 text-muted-foreground" />
+                    <span className="text-muted-foreground whitespace-pre-line">
+                      {profile.partnership_needs}
+                    </span>
+                  </div>
+                )}
+                {profile.impact_focus && (
+                  <div>
+                    <h4 className="font-medium">Impact Priorities</h4>
+                    <p className="text-muted-foreground whitespace-pre-line">
+                      {profile.impact_focus}
+                    </p>
                   </div>
                 )}
               </>

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -740,9 +740,9 @@ export class ProfileService extends BaseService<Profile> {
           sole_proprietor: ['business_name', 'registration_number'],
           professional: ['qualifications', 'specialization'],
           sme: ['business_name', 'registration_number', 'industry_sector'],
-          investor: ['business_name', 'annual_revenue'],
-          donor: ['business_name'],
-          government: ['business_name', 'registration_number'],
+          investor: ['business_name', 'annual_revenue', 'investment_focus', 'investment_stage'],
+          donor: ['business_name', 'donor_type', 'annual_funding_budget', 'funding_focus'],
+          government: ['business_name', 'registration_number', 'institution_type', 'department', 'government_focus'],
           admin: []
         };
 

--- a/src/pages/ProfileSetup.tsx
+++ b/src/pages/ProfileSetup.tsx
@@ -102,9 +102,9 @@ export const ProfileSetup = () => {
 
   const handleProfileSubmit = async (profileData: any) => {
     if (!user) return;
-    
+
     setLoading(true);
-    
+
     try {
       const sanitizeValue = (value?: string | null) => {
         if (!value) return null;
@@ -251,6 +251,14 @@ export const ProfileSetup = () => {
         : [];
 
       const sanitizedProfile: Record<string, unknown> = {};
+      const numericFields = new Set([
+        'experience_years',
+        'employees_count',
+        'annual_revenue',
+        'annual_funding_budget',
+        'investment_ticket_min',
+        'investment_ticket_max'
+      ]);
 
       for (const [key, value] of Object.entries(profilePayload)) {
         if (Array.isArray(value)) {
@@ -264,7 +272,15 @@ export const ProfileSetup = () => {
             sanitizedProfile[key] = value;
           }
         } else if (typeof value === 'string') {
-          sanitizedProfile[key] = sanitizeValue(value);
+          const sanitizedValue = sanitizeValue(value);
+          if (sanitizedValue === null) {
+            sanitizedProfile[key] = null;
+          } else if (numericFields.has(key)) {
+            const numeric = Number(sanitizedValue.replace(/,/g, ''));
+            sanitizedProfile[key] = Number.isFinite(numeric) ? numeric : sanitizedValue;
+          } else {
+            sanitizedProfile[key] = sanitizedValue;
+          }
         } else {
           sanitizedProfile[key] = value ?? null;
         }


### PR DESCRIPTION
## Summary
- extend the Supabase schema with new profile columns and needs assessment tables for each account type
- update the profile setup form and review screen so investors, donors, and government institutions can capture the correct details
- refresh TypeScript definitions and profile completion requirements to cover the additional account data

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f9f4d12b5083288e2e7aaffc411e13