### PR TITLE
Add OTP verification flow and improve sign-up resilience

### DIFF
--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -13,6 +13,7 @@ import { User, Mail, Lock, Building, Eye, EyeOff, Phone } from 'lucide-react';
 import { useAppContext } from '@/contexts/AppContext';
 import { validatePhoneNumber } from '@/lib/payment-config';
 import { registerUser } from '@/lib/api/register-user';
+import { toast } from '@/components/ui/use-toast';
 
 // Validation schema
 const getStartedSchema = z
@@ -109,14 +110,22 @@ export const GetStarted = () => {
         profile_completed: false,
       });
 
-      await registerUser({
-        firstName: trimmedFirstName,
-        lastName: trimmedLastName,
-        email: data.email.trim(),
-        accountType: data.accountType,
-        company: trimmedCompany ? trimmedCompany : null,
-        mobileNumber: trimmedMobile ? trimmedMobile : null,
-      });
+      try {
+        await registerUser({
+          firstName: trimmedFirstName,
+          lastName: trimmedLastName,
+          email: data.email.trim(),
+          accountType: data.accountType,
+          company: trimmedCompany ? trimmedCompany : null,
+          mobileNumber: trimmedMobile ? trimmedMobile : null,
+        });
+      } catch (registrationError: any) {
+        console.warn('Optional CRM registration failed:', registrationError);
+        toast({
+          title: 'Profile sync delayed',
+          description: 'Your account is ready, and we\'ll finish syncing your profile shortly.',
+        });
+      }
 
       navigate('/profile-setup');
     } catch (error: any) {
@@ -159,18 +168,19 @@ export const GetStarted = () => {
           </div>
         )}
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} autoComplete="on" className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="firstName">First Name</Label>
               <div className="relative">
                 <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                <Input
-                  id="firstName"
-                  placeholder="First name"
-                  {...register('firstName')}
-                  className={`pl-10 ${errors.firstName ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
-                />
+              <Input
+                id="firstName"
+                autoComplete="given-name"
+                placeholder="First name"
+                {...register('firstName')}
+                className={`pl-10 ${errors.firstName ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
+              />
               </div>
               {errors.firstName && (
                 <p className="text-sm text-red-600 mt-1">{errors.firstName.message}</p>
@@ -180,6 +190,7 @@ export const GetStarted = () => {
               <Label htmlFor="lastName">Last Name</Label>
               <Input
                 id="lastName"
+                autoComplete="family-name"
                 placeholder="Last name"
                 {...register('lastName')}
                 className={errors.lastName ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}
@@ -197,6 +208,7 @@ export const GetStarted = () => {
               <Input
                 id="email"
                 type="email"
+                autoComplete="email"
                 placeholder="Enter your email"
                 {...register('email')}
                 className={`pl-10 ${errors.email ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
@@ -214,6 +226,7 @@ export const GetStarted = () => {
               <Input
                 id="mobileNumber"
                 type="tel"
+                autoComplete="tel"
                 placeholder="e.g., +260 96 1234567"
                 {...register('mobileNumber')}
                 className={`pl-10 ${errors.mobileNumber ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
@@ -233,6 +246,7 @@ export const GetStarted = () => {
               <Building className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
               <Input
                 id="company"
+                autoComplete="organization"
                 placeholder="Company name"
                 {...register('company')}
                 className="pl-10"
@@ -271,13 +285,14 @@ export const GetStarted = () => {
               <Label htmlFor="password">Password</Label>
               <div className="relative">
                 <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                <Input
-                  id="password"
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder="Password"
-                  {...register('password')}
-                  className={`pl-10 pr-10 ${errors.password ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
-                />
+              <Input
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                autoComplete="new-password"
+                placeholder="Password"
+                {...register('password')}
+                className={`pl-10 pr-10 ${errors.password ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
+              />
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
@@ -293,13 +308,14 @@ export const GetStarted = () => {
             <div className="space-y-2">
               <Label htmlFor="confirmPassword">Confirm Password</Label>
               <div className="relative">
-                <Input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? 'text' : 'password'}
-                  placeholder="Confirm password"
-                  {...register('confirmPassword')}
-                  className={`pr-10 ${errors.confirmPassword ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
-                />
+              <Input
+                id="confirmPassword"
+                type={showConfirmPassword ? 'text' : 'password'}
+                autoComplete="new-password"
+                placeholder="Confirm password"
+                {...register('confirmPassword')}
+                className={`pr-10 ${errors.confirmPassword ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''}`}
+              />
                 <button
                   type="button"
                   onClick={() => setShowConfirmPassword(!showConfirmPassword)}

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -7,9 +7,10 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Eye, EyeOff, Mail, Lock, ArrowRight } from 'lucide-react';
+import { Eye, EyeOff, Mail, Lock, ArrowRight, RotateCw } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAppContext } from '@/contexts/AppContext';
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp';
 
 // Validation schema
 const signInSchema = z.object({
@@ -28,36 +29,126 @@ type SignInFormData = z.infer<typeof signInSchema>;
 const SignIn = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [otpLoading, setOtpLoading] = useState(false);
   const [error, setError] = useState('');
-  const { signIn } = useAppContext();
+  const [otpError, setOtpError] = useState('');
+  const [step, setStep] = useState<'credentials' | 'otp'>('credentials');
+  const [pendingEmail, setPendingEmail] = useState('');
+  const [otpCode, setOtpCode] = useState('');
+  const [resendCountdown, setResendCountdown] = useState(0);
+  const [resendLoading, setResendLoading] = useState(false);
+  const { initiateSignIn, verifyOtp, resendOtp } = useAppContext();
   const navigate = useNavigate();
 
   const {
     register,
     handleSubmit,
+    reset,
     formState: { errors },
   } = useForm<SignInFormData>({
     resolver: zodResolver(signInSchema),
-    mode: 'onBlur', // Validate on blur for better UX
+    mode: 'onBlur',
   });
+
+  useEffect(() => {
+    if (resendCountdown <= 0) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setResendCountdown(prev => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+
+    return () => window.clearInterval(timer);
+  }, [resendCountdown]);
 
   const onSubmit = async (data: SignInFormData) => {
     setLoading(true);
     setError('');
+    setOtpError('');
 
     try {
-      await signIn(data.email, data.password);
-      navigate('/');
+      const result = await initiateSignIn(data.email, data.password);
+
+      if (result.offlineState) {
+        reset();
+        navigate('/');
+        return;
+      }
+
+      setPendingEmail(data.email);
+      setStep('otp');
+      setOtpCode('');
+      setResendCountdown(30);
     } catch (err: any) {
-      // Display user-friendly error message
       const errorMessage = err.message || 'Failed to sign in. Please try again.';
       setError(errorMessage);
-      
-      // Log the full error for debugging
       console.error('Sign in error:', err);
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleOtpSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!pendingEmail) {
+      setOtpError('Please restart the sign-in process.');
+      return;
+    }
+
+    if (otpCode.trim().length < 6) {
+      setOtpError('Enter the 6-digit verification code.');
+      return;
+    }
+
+    setOtpLoading(true);
+    setOtpError('');
+
+    try {
+      await verifyOtp(pendingEmail, otpCode.trim());
+      reset();
+      setStep('credentials');
+      setPendingEmail('');
+      setOtpCode('');
+      setResendCountdown(0);
+      navigate('/');
+    } catch (err: any) {
+      const errorMessage = err.message || 'We could not verify the code. Please try again.';
+      setOtpError(errorMessage);
+      console.error('OTP verification error:', err);
+    } finally {
+      setOtpLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!pendingEmail || resendCountdown > 0) {
+      return;
+    }
+
+    setOtpError('');
+    setResendLoading(true);
+
+    try {
+      await resendOtp(pendingEmail);
+      setResendCountdown(30);
+    } catch (err: any) {
+      const errorMessage = err.message || 'Unable to resend verification code. Please try again.';
+      setOtpError(errorMessage);
+      console.error('OTP resend error:', err);
+    } finally {
+      setResendLoading(false);
+    }
+  };
+
+  const handleUseDifferentEmail = () => {
+    setStep('credentials');
+    setPendingEmail('');
+    setOtpCode('');
+    setOtpError('');
+    setError('');
+    setResendCountdown(0);
   };
 
   return (
@@ -84,88 +175,162 @@ const SignIn = () => {
 
         <Card className="border-2 border-orange-100 shadow-xl">
           <CardHeader className="space-y-1 pb-6">
-            <CardTitle className="text-2xl text-center text-gray-900">Sign In</CardTitle>
+            <CardTitle className="text-2xl text-center text-gray-900">
+              {step === 'otp' ? 'Verify Sign In' : 'Sign In'}
+            </CardTitle>
             <CardDescription className="text-center text-gray-600">
-              Enter your credentials to access your account
+              {step === 'otp'
+                ? `Enter the verification code sent to ${pendingEmail}.`
+                : 'Enter your credentials to access your account'}
             </CardDescription>
           </CardHeader>
           <CardContent>
-            {error && (
-              <Alert className="mb-6 border-red-200 bg-red-50">
-                <AlertDescription className="text-red-700">{error}</AlertDescription>
-              </Alert>
-            )}
-            
-            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="email" className="text-gray-700 font-medium">Email</Label>
-                <div className="relative">
-                  <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="Enter your email"
-                    {...register('email')}
-                    className={`pl-10 border-orange-200 focus:border-orange-400 focus:ring-orange-400 ${
-                      errors.email ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
-                    }`}
-                  />
-                </div>
-                {errors.email && (
-                  <p className="text-sm text-red-600 mt-1">{errors.email.message}</p>
+            {step === 'credentials' ? (
+              <>
+                {error && (
+                  <Alert className="mb-6 border-red-200 bg-red-50">
+                    <AlertDescription className="text-red-700">{error}</AlertDescription>
+                  </Alert>
                 )}
-              </div>
-              
-              <div className="space-y-2">
-                <Label htmlFor="password" className="text-gray-700 font-medium">Password</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="password"
-                    type={showPassword ? 'text' : 'password'}
-                    placeholder="Enter your password"
-                    {...register('password')}
-                    className={`pl-10 pr-10 border-orange-200 focus:border-orange-400 focus:ring-orange-400 ${
-                      errors.password ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
-                    }`}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
+
+                <form onSubmit={handleSubmit(onSubmit)} autoComplete="on" className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="email" className="text-gray-700 font-medium">Email</Label>
+                    <div className="relative">
+                      <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                      <Input
+                        id="email"
+                        type="email"
+                        autoComplete="email"
+                        placeholder="Enter your email"
+                        {...register('email')}
+                        className={`pl-10 border-orange-200 focus:border-orange-400 focus:ring-orange-400 ${
+                          errors.email ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
+                        }`}
+                      />
+                    </div>
+                    {errors.email && (
+                      <p className="text-sm text-red-600 mt-1">{errors.email.message}</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="password" className="text-gray-700 font-medium">Password</Label>
+                    <div className="relative">
+                      <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                      <Input
+                        id="password"
+                        type={showPassword ? 'text' : 'password'}
+                        autoComplete="current-password"
+                        placeholder="Enter your password"
+                        {...register('password')}
+                        className={`pl-10 pr-10 border-orange-200 focus:border-orange-400 focus:ring-orange-400 ${
+                          errors.password ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
+                        }`}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword(!showPassword)}
+                        className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
+                        aria-label={showPassword ? 'Hide password' : 'Show password'}
+                      >
+                        {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    </div>
+                    {errors.password && (
+                      <p className="text-sm text-red-600 mt-1">{errors.password.message}</p>
+                    )}
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <Link to="/forgot-password" className="text-sm text-orange-600 hover:text-orange-700 font-medium">
+                      Forgot password?
+                    </Link>
+                  </div>
+
+                  <Button
+                    type="submit"
+                    className="w-full bg-gradient-to-r from-orange-600 to-orange-700 hover:from-orange-700 hover:to-orange-800 text-white py-3"
+                    disabled={loading}
                   >
-                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
+                    {loading ? 'Signing in...' : 'Sign In'}
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </form>
+
+                <div className="mt-6 text-center">
+                  <p className="text-gray-600">
+                    Don't have an account?{' '}
+                    <Link to="/get-started" className="text-orange-600 hover:text-orange-700 font-medium">
+                      Get Started
+                    </Link>
+                  </p>
                 </div>
-                {errors.password && (
-                  <p className="text-sm text-red-600 mt-1">{errors.password.message}</p>
+              </>
+            ) : (
+              <>
+                {otpError && (
+                  <Alert className="mb-6 border-red-200 bg-red-50">
+                    <AlertDescription className="text-red-700">{otpError}</AlertDescription>
+                  </Alert>
                 )}
-              </div>
 
-              <div className="flex items-center justify-between">
-                <Link to="/forgot-password" className="text-sm text-orange-600 hover:text-orange-700 font-medium">
-                  Forgot password?
-                </Link>
-              </div>
+                <div className="mb-4 text-sm text-gray-600 text-center">
+                  We sent a verification code to{' '}
+                  <span className="font-medium break-all">{pendingEmail}</span>. Enter it below to continue.
+                </div>
 
-              <Button 
-                type="submit" 
-                className="w-full bg-gradient-to-r from-orange-600 to-orange-700 hover:from-orange-700 hover:to-orange-800 text-white py-3"
-                disabled={loading}
-              >
-                {loading ? 'Signing in...' : 'Sign In'}
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Button>
-            </form>
+                <form onSubmit={handleOtpSubmit} className="space-y-6">
+                  <div className="flex justify-center">
+                    <InputOTP
+                      value={otpCode}
+                      onChange={value => setOtpCode(value)}
+                      maxLength={6}
+                      inputMode="numeric"
+                      pattern="\d*"
+                      autoFocus
+                      aria-label="One-time password"
+                      containerClassName="gap-3"
+                    >
+                      <InputOTPGroup>
+                        {Array.from({ length: 6 }).map((_, index) => (
+                          <InputOTPSlot key={index} index={index} />
+                        ))}
+                      </InputOTPGroup>
+                    </InputOTP>
+                  </div>
 
-            <div className="mt-6 text-center">
-              <p className="text-gray-600">
-                Don't have an account?{' '}
-                <Link to="/get-started" className="text-orange-600 hover:text-orange-700 font-medium">
-                  Get Started
-                </Link>
-              </p>
-            </div>
+                  <div className="space-y-3">
+                    <Button
+                      type="submit"
+                      className="w-full bg-gradient-to-r from-orange-600 to-orange-700 hover:from-orange-700 hover:to-orange-800 text-white py-3"
+                      disabled={otpLoading}
+                    >
+                      {otpLoading ? 'Verifying…' : 'Verify and Continue'}
+                      <ArrowRight className="ml-2 h-4 w-4" />
+                    </Button>
+
+                    <div className="flex items-center justify-between text-sm text-gray-600">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={handleResend}
+                        disabled={resendLoading || resendCountdown > 0}
+                        className="flex items-center gap-2"
+                      >
+                        <RotateCw className="h-4 w-4" />
+                        {resendCountdown > 0 ? `Resend in ${resendCountdown}s` : 'Resend code'}
+                      </Button>
+
+                      <Button type="button" variant="ghost" size="sm" onClick={handleUseDifferentEmail}>
+                        Use a different email
+                      </Button>
+                    </div>
+                  </div>
+                </form>
+              </>
+            )}
           </CardContent>
         </Card>
 

--- a/src/pages/__tests__/SignIn.test.tsx
+++ b/src/pages/__tests__/SignIn.test.tsx
@@ -5,7 +5,9 @@ import SignIn from '../SignIn';
 // Mock the AppContext
 jest.mock('@/contexts/AppContext', () => ({
   useAppContext: () => ({
-    signIn: jest.fn().mockRejectedValue(new Error('Invalid credentials')),
+    initiateSignIn: jest.fn().mockResolvedValue({ otpSent: true, offlineState: null }),
+    verifyOtp: jest.fn().mockResolvedValue({ user: null, profile: null }),
+    resendOtp: jest.fn(),
   }),
 }));
 
@@ -46,7 +48,7 @@ describe('SignIn Validation', () => {
   it('shows validation error for short password', async () => {
     render(<SignInWrapper />);
     
-    const passwordInput = screen.getByLabelText(/password/i);
+    const passwordInput = screen.getByLabelText(/password/i, { selector: 'input' });
     const submitButton = screen.getByRole('button', { name: /sign in/i });
 
     fireEvent.change(passwordInput, { target: { value: '123' } });
@@ -61,7 +63,7 @@ describe('SignIn Validation', () => {
     render(<SignInWrapper />);
     
     const emailInput = screen.getByLabelText(/email/i);
-    const passwordInput = screen.getByLabelText(/password/i);
+    const passwordInput = screen.getByLabelText(/password/i, { selector: 'input' });
     const submitButton = screen.getByRole('button', { name: /sign in/i });
 
     fireEvent.change(emailInput, { target: { value: 'test@example.com' } });


### PR DESCRIPTION
## Summary
- add context helpers for OTP-based sign-in, resend support, and offline session handling
- update the sign-in screen with a two-step OTP flow, autofill-friendly fields, and resend controls
- harden account creation by tolerating CRM sync failures, improving autocomplete hints, and exercising updated tests

## Testing
- npm run test:jest -- SignIn

------
https://chatgpt.com/codex/tasks/task_e_68f9fdbff3c883289fd25691011fa343