### PR TITLE
Add home navigation button and profile edit flow

### DIFF
--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -53,6 +53,7 @@ export interface PersonalInfo {
   };
   profile_image_url?: string;
   linkedin_url?: string;
+  bio?: string;
 }
 
 export interface BusinessInfo {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { PartnershipHub } from "./pages/PartnershipHub";
 import FundingHub from "./pages/FundingHub";
 import { ProfileSetup } from "./pages/ProfileSetup";
 import { ProfileReview } from "./components/ProfileReview";
+import { ProfileEdit } from "./pages/ProfileEdit";
 import FreelancerHub from "./pages/FreelancerHub";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
@@ -41,6 +42,14 @@ export const AppRoutes = () => (
     <Route path="/signin" element={<SignIn />} />
     <Route path="/get-started" element={<GetStarted />} />
     <Route path="/profile-setup" element={<ProfileSetup />} />
+    <Route
+      path="/profile-edit"
+      element={
+        <PrivateRoute>
+          <ProfileEdit />
+        </PrivateRoute>
+      }
+    />
     <Route path="/profile-review" element={<ProfileReview />} />
     <Route path="/subscription-plans" element={<SubscriptionPlans />} />
     <Route path="/partnership-hub" element={<PartnershipHub />} />

--- a/src/components/BackToHomeButton.tsx
+++ b/src/components/BackToHomeButton.tsx
@@ -1,0 +1,31 @@
+import type { ComponentProps } from 'react';
+import { Link } from 'react-router-dom';
+import { Home } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface BackToHomeButtonProps {
+  className?: string;
+  variant?: ComponentProps<typeof Button>['variant'];
+  size?: ComponentProps<typeof Button>['size'];
+}
+
+export const BackToHomeButton = ({
+  className,
+  variant = 'secondary',
+  size = 'sm',
+}: BackToHomeButtonProps) => {
+  return (
+    <div className={cn('inline-flex', className)}>
+      <Button asChild variant={variant} size={size} className="gap-2">
+        <Link to="/">
+          <Home className="h-4 w-4" aria-hidden="true" />
+          <span className="font-semibold">Back to Home</span>
+        </Link>
+      </Button>
+    </div>
+  );
+};
+
+export default BackToHomeButton;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -44,6 +44,7 @@ const Header = () => {
   };
 
   const showGetStarted = !user || !user.profile_completed;
+  const editProfilePath = user?.profile_completed ? '/profile-edit' : '/profile-setup';
 
   return (
     <header className="bg-gradient-to-r from-orange-50 to-green-50 shadow-lg sticky top-0 z-50 border-b-2 border-orange-200">
@@ -113,7 +114,7 @@ const Header = () => {
                     <Link to="/profile-review">{t('viewProfile')}</Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>
-                    <Link to="/profile-setup">{t('editProfile')}</Link>
+                    <Link to={editProfilePath}>{t('editProfile')}</Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>
                     <Link to="/subscription-plans">{t('subscriptionPlans')}</Link>
@@ -198,6 +199,11 @@ const Header = () => {
                       <Button variant="outline" size="sm" className="w-full border-orange-300">
                         <User className="w-4 h-4 mr-2" />
                         {t('viewProfile')}
+                      </Button>
+                    </Link>
+                    <Link to={editProfilePath}>
+                      <Button variant="outline" size="sm" className="w-full border-orange-300">
+                        {t('editProfile')}
                       </Button>
                     </Link>
                     <Link to="/subscription-plans">

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -690,16 +690,18 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
           {/* Bio Section */}
           <div>
             <Label>Bio</Label>
-            <Textarea 
-              value={formData.bio || ''}
-              onChange={(e) => handleInputChange('bio', e.target.value)}
-              placeholder="Tell others about yourself and what you do..."
-              rows={4}
-            />
-            <p className="text-sm text-muted-foreground mt-1">
-              This will be shown to anyone who views your profile
-            </p>
+          <Textarea
+            value={formData.bio || ''}
+            onChange={(e) => handleInputChange('bio', e.target.value)}
+            placeholder="Tell others about yourself and what you do..."
+            rows={4}
+            maxLength={400}
+          />
+          <div className="flex items-center justify-between text-sm text-muted-foreground mt-1">
+            <span>This will be shown to anyone who views your profile</span>
+            <span>{(formData.bio?.length ?? 0)} / 400</span>
           </div>
+        </div>
           </div>
 
           {/* Account Type Specific Fields */}

--- a/src/components/ProfileReview.tsx
+++ b/src/components/ProfileReview.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
+import BackToHomeButton from '@/components/BackToHomeButton';
 import {
   Edit,
   MapPin,
@@ -68,22 +69,30 @@ export const ProfileReview = () => {
   }, [user, navigate, fetchProfile]);
 
   const handleEditProfile = () => {
-    navigate('/profile-setup');
+    navigate('/profile-edit');
   };
 
   if (loading) {
-    return <div className="min-h-screen flex items-center justify-center">Loading profile...</div>;
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+        <BackToHomeButton />
+        <span className="text-muted-foreground">Loading profile...</span>
+      </div>
+    );
   }
 
   if (!profile) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <Card className="w-full max-w-md">
-          <CardContent className="pt-6 text-center">
-            <p className="text-muted-foreground mb-4">Profile not found.</p>
-            <Button onClick={() => navigate('/profile-setup')}>
-              Create Profile
-            </Button>
+          <CardContent className="pt-6 text-center space-y-4">
+            <p className="text-muted-foreground">Profile not found.</p>
+            <div className="flex flex-col gap-2">
+              <Button onClick={() => navigate('/profile-setup')}>
+                Create Profile
+              </Button>
+              <Button variant="outline" onClick={() => navigate('/')}>Go Home</Button>
+            </div>
           </CardContent>
         </Card>
       </div>
@@ -180,6 +189,8 @@ export const ProfileReview = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-emerald-50 py-8 px-4">
       <div className="max-w-4xl mx-auto space-y-6">
+        <BackToHomeButton />
+
         {/* Header */}
         <Card>
           <CardHeader>
@@ -212,6 +223,20 @@ export const ProfileReview = () => {
             </div>
           </CardHeader>
         </Card>
+
+        {profile.bio && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Bio</CardTitle>
+              <CardDescription>Share this overview with the community.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground whitespace-pre-line leading-relaxed">
+                {profile.bio}
+              </p>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Contact Information */}
         <Card>

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -47,6 +47,7 @@ const offlineAccounts: OfflineAccount[] = [
       payment_method: 'phone',
       payment_phone: '+260211000000',
       use_same_phone: true,
+      bio: 'Administrator account for WATHACI CONNECT platform operations.',
       qualifications: [],
       gaps_identified: [],
     };
@@ -91,6 +92,7 @@ const offlineAccounts: OfflineAccount[] = [
       payment_phone: '+260955000000',
       use_same_phone: true,
       industry_sector: 'Technology',
+      bio: 'Sample SME account showcasing platform capabilities.',
       qualifications: [],
       gaps_identified: [],
     };

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Linkedin, ArrowLeft } from "lucide-react";
-import { Link } from "react-router-dom";
+import { Linkedin } from "lucide-react";
 import AppLayout from "@/components/AppLayout";
+import BackToHomeButton from "@/components/BackToHomeButton";
 
 interface TeamMember {
   name: string;
@@ -46,13 +46,7 @@ export default function AboutUs() {
         />
         <div className="absolute inset-0 bg-gradient-to-br from-white/80 via-white/70 to-blue-50/60" />
         <div className="relative z-10 container mx-auto px-4 py-8 max-w-4xl space-y-8 min-h-screen">
-          <Link
-            to="/"
-            className="inline-flex items-center text-sm text-blue-600 hover:underline"
-          >
-            <ArrowLeft className="mr-1 h-4 w-4" />
-            Back to Home
-          </Link>
+          <BackToHomeButton variant="secondary" />
           <Card>
             <CardHeader>
               <CardTitle className="text-3xl font-bold text-center">About Us</CardTitle>

--- a/src/pages/DonorAssessment.tsx
+++ b/src/pages/DonorAssessment.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { supabase } from '@/lib/supabase-enhanced';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 interface AssessmentData {
   assessment: any;
@@ -133,7 +134,8 @@ export const DonorAssessment = () => {
   if (currentView === 'intro') {
     return (
       <div className="min-h-screen bg-gradient-to-br from-red-50 to-pink-50 py-8 px-4">
-        <div className="max-w-2xl mx-auto">
+        <div className="max-w-2xl mx-auto space-y-6">
+          <BackToHomeButton />
           <Card>
             <CardHeader className="text-center">
               <CardTitle className="text-2xl text-red-900">Donor Needs Assessment</CardTitle>
@@ -195,10 +197,13 @@ export const DonorAssessment = () => {
   if (currentView === 'assessment') {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <DonorNeedsAssessment 
-          onComplete={handleAssessmentComplete}
-          onSkip={handleSkipAssessment}
-        />
+        <div className="max-w-4xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <DonorNeedsAssessment
+            onComplete={handleAssessmentComplete}
+            onSkip={handleSkipAssessment}
+          />
+        </div>
       </div>
     );
   }
@@ -207,12 +212,15 @@ export const DonorAssessment = () => {
   if (currentView === 'results' && assessmentData) {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <AssessmentResults
-          assessment={assessmentData.assessment}
-          recommendations={assessmentData.strategy || []}
-          onContactProfessional={handleContactProfessional}
-          onRetakeAssessment={handleRetakeAssessment}
-        />
+        <div className="max-w-5xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <AssessmentResults
+            assessment={assessmentData.assessment}
+            recommendations={assessmentData.strategy || []}
+            onContactProfessional={handleContactProfessional}
+            onRetakeAssessment={handleRetakeAssessment}
+          />
+        </div>
       </div>
     );
   }

--- a/src/pages/FreelancerHub.tsx
+++ b/src/pages/FreelancerHub.tsx
@@ -7,6 +7,7 @@ import { DonateButton } from '@/components/DonateButton';
 import AppLayout from '@/components/AppLayout';
 import IndustryMatcher from '@/components/industry/IndustryMatcher';
 import { Users, Lightbulb, Heart, Target } from 'lucide-react';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 const FreelancerHub = () => {
   const [activeTab, setActiveTab] = useState('directory');
@@ -22,6 +23,9 @@ const FreelancerHub = () => {
         />
         <div className="absolute inset-0 bg-gradient-to-br from-blue-600/70 via-emerald-600/60 to-blue-800/70" />
         <div className="relative z-10 py-16 text-white">
+          <div className="max-w-6xl mx-auto px-6 mb-8">
+            <BackToHomeButton variant="secondary" />
+          </div>
           <div className="max-w-6xl mx-auto px-6">
             <div className="flex items-center justify-between">
               <div>

--- a/src/pages/FundingHub.tsx
+++ b/src/pages/FundingHub.tsx
@@ -4,6 +4,7 @@ import { FundingHub as FundingHubComponent } from '@/components/funding/FundingH
 import { FundingMatcher } from '@/components/funding/FundingMatcher';
 import LiveFundingMatcher from '@/components/funding/LiveFundingMatcher';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 const FundingHub = () => {
   return (
@@ -17,6 +18,9 @@ const FundingHub = () => {
         />
         <div className="absolute inset-0 bg-gradient-to-br from-orange-50/70 via-white/60 to-green-50/70" />
         <div className="relative z-10 container mx-auto px-4 py-8 min-h-screen">
+          <div className="mb-6">
+            <BackToHomeButton />
+          </div>
           <div className="mb-8">
             <h1 className="text-3xl font-bold text-gray-900 mb-2">AI-Powered Funding Hub</h1>
             <p className="text-gray-600">

--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -13,6 +13,7 @@ import { User, Mail, Lock, Building, Eye, EyeOff, Phone } from 'lucide-react';
 import { useAppContext } from '@/contexts/AppContext';
 import { validatePhoneNumber } from '@/lib/payment-config';
 import { registerUser } from '@/lib/api/register-user';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 // Validation schema
 const getStartedSchema = z
@@ -133,26 +134,29 @@ export const GetStarted = () => {
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4 relative">
-      <div 
+      <div
         className="fixed inset-0 bg-center bg-cover"
         style={{
           backgroundImage: "url('/images/Partnership%20Hub.png')",
         }}
       />
       <div className="absolute inset-0 bg-gradient-to-br from-orange-50/70 via-white/60 to-green-50/70" />
+      <div className="absolute top-6 left-6 z-20">
+        <BackToHomeButton />
+      </div>
       <Card className="w-full max-w-lg relative z-10">
-      <CardHeader className="text-center">
-        <img
-          src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
-          alt="WATHACI CONNECT"
-          loading="lazy"
-          decoding="async"
-          className="h-20 w-auto mx-auto mb-4 drop-shadow-lg"
-        />
-        <CardTitle className="text-2xl">Get Started</CardTitle>
-        <CardDescription>Create your WATHACI account</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
+        <CardHeader className="text-center">
+          <img
+            src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
+            alt="WATHACI CONNECT"
+            loading="lazy"
+            decoding="async"
+            className="h-20 w-auto mx-auto mb-4 drop-shadow-lg"
+          />
+          <CardTitle className="text-2xl">Get Started</CardTitle>
+          <CardDescription>Create your WATHACI account</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
         {serverError && (
           <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">
             {serverError}

--- a/src/pages/GovernmentAssessment.tsx
+++ b/src/pages/GovernmentAssessment.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { supabase } from '@/lib/supabase-enhanced';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 interface AssessmentData {
   assessment: any;
@@ -133,7 +134,8 @@ export const GovernmentAssessment = () => {
   if (currentView === 'intro') {
     return (
       <div className="min-h-screen bg-gradient-to-br from-green-50 to-emerald-50 py-8 px-4">
-        <div className="max-w-2xl mx-auto">
+        <div className="max-w-2xl mx-auto space-y-6">
+          <BackToHomeButton />
           <Card>
             <CardHeader className="text-center">
               <CardTitle className="text-2xl text-green-900">Government Institution Assessment</CardTitle>
@@ -195,10 +197,13 @@ export const GovernmentAssessment = () => {
   if (currentView === 'assessment') {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <GovernmentNeedsAssessment 
-          onComplete={handleAssessmentComplete}
-          onSkip={handleSkipAssessment}
-        />
+        <div className="max-w-4xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <GovernmentNeedsAssessment
+            onComplete={handleAssessmentComplete}
+            onSkip={handleSkipAssessment}
+          />
+        </div>
       </div>
     );
   }
@@ -207,12 +212,15 @@ export const GovernmentAssessment = () => {
   if (currentView === 'results' && assessmentData) {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <AssessmentResults
-          assessment={assessmentData.assessment}
-          recommendations={assessmentData.strategy || []}
-          onContactProfessional={handleContactProfessional}
-          onRetakeAssessment={handleRetakeAssessment}
-        />
+        <div className="max-w-5xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <AssessmentResults
+            assessment={assessmentData.assessment}
+            recommendations={assessmentData.strategy || []}
+            onContactProfessional={handleContactProfessional}
+            onRetakeAssessment={handleRetakeAssessment}
+          />
+        </div>
       </div>
     );
   }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,6 +7,7 @@ import StatsSection from '@/components/StatsSection';
 import TestimonialsSection from '@/components/TestimonialsSection';
 import { SubscriptionBanner } from '@/components/SubscriptionBanner';
 import { useAppContext } from '@/contexts/AppContext';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 const Index: React.FC = () => {
   const { user } = useAppContext();
@@ -27,6 +28,9 @@ const Index: React.FC = () => {
           className="absolute inset-0 bg-gradient-to-r from-blue-600/70 to-emerald-600/70"
         />
         <div className="relative z-10">
+          <div className="container mx-auto px-4 py-4 flex justify-end">
+            <BackToHomeButton variant="outline" />
+          </div>
           <HeroSection />
           {user && (
             <div className="container mx-auto px-4 py-6">

--- a/src/pages/InvestorAssessment.tsx
+++ b/src/pages/InvestorAssessment.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { supabase } from '@/lib/supabase-enhanced';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 interface AssessmentData {
   assessment: any;
@@ -133,7 +134,8 @@ export const InvestorAssessment = () => {
   if (currentView === 'intro') {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-emerald-50 py-8 px-4">
-        <div className="max-w-2xl mx-auto">
+        <div className="max-w-2xl mx-auto space-y-6">
+          <BackToHomeButton />
           <Card>
             <CardHeader className="text-center">
               <CardTitle className="text-2xl text-blue-900">Investor Needs Assessment</CardTitle>
@@ -195,10 +197,13 @@ export const InvestorAssessment = () => {
   if (currentView === 'assessment') {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <InvestorNeedsAssessment 
-          onComplete={handleAssessmentComplete}
-          onSkip={handleSkipAssessment}
-        />
+        <div className="max-w-4xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <InvestorNeedsAssessment
+            onComplete={handleAssessmentComplete}
+            onSkip={handleSkipAssessment}
+          />
+        </div>
       </div>
     );
   }
@@ -207,12 +212,15 @@ export const InvestorAssessment = () => {
   if (currentView === 'results' && assessmentData) {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <AssessmentResults
-          assessment={assessmentData.assessment}
-          recommendations={assessmentData.strategy || []}
-          onContactProfessional={handleContactProfessional}
-          onRetakeAssessment={handleRetakeAssessment}
-        />
+        <div className="max-w-5xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <AssessmentResults
+            assessment={assessmentData.assessment}
+            recommendations={assessmentData.strategy || []}
+            onContactProfessional={handleContactProfessional}
+            onRetakeAssessment={handleRetakeAssessment}
+          />
+        </div>
       </div>
     );
   }

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -16,6 +16,7 @@ import { supabase } from '@/lib/supabase-enhanced';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { PaymentStatusTracker } from '@/components/PaymentStatusTracker';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 // Products will be fetched from database in production
 
@@ -83,7 +84,7 @@ const Marketplace = () => {
   return (
     <AppLayout>
       <div className="min-h-screen bg-gray-50 relative">
-        <div 
+        <div
           className="fixed inset-0 bg-center bg-cover"
           style={{
             backgroundImage:
@@ -92,6 +93,9 @@ const Marketplace = () => {
         />
         <div className="absolute inset-0 bg-gradient-to-r from-blue-600/70 to-emerald-600/70" />
         <div className="relative z-10 py-16 text-white">
+          <div className="max-w-6xl mx-auto px-6 mb-6 flex justify-start">
+            <BackToHomeButton variant="secondary" />
+          </div>
           <div className="max-w-6xl mx-auto px-6 text-center">
             <h1 className="text-5xl font-bold mb-4">AI-Powered Marketplace</h1>
             <p className="text-xl mb-8">Discover services from freelancers, partners, and resources with intelligent AI analysis</p>

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -1,9 +1,13 @@
 import { MessageCenter } from '@/components/messaging/MessageCenter';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 const Messages = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 to-green-50 py-8">
       <div className="max-w-6xl mx-auto px-6">
+        <div className="mb-6">
+          <BackToHomeButton />
+        </div>
         <div className="text-center mb-8">
           <h1 className="text-4xl font-bold text-gray-900 mb-4">
             Messages

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import BackToHomeButton from "@/components/BackToHomeButton";
 
 const NotFound = () => {
   const location = useLocation();
@@ -16,9 +17,9 @@ const NotFound = () => {
       <div className="text-center p-8 rounded-lg border border-border bg-card shadow-md animate-slide-in">
         <h1 className="text-5xl font-bold mb-6 text-primary">404</h1>
         <p className="text-xl text-card-foreground mb-6">Page not found</p>
-        <a href="/" className="text-primary hover:text-primary/80 underline transition-colors">
-          Return to Home
-        </a>
+        <div className="flex justify-center">
+          <BackToHomeButton variant="outline" />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/PartnershipHub.tsx
+++ b/src/pages/PartnershipHub.tsx
@@ -12,6 +12,7 @@ import { Footer } from '@/components/Footer';
 import { supabase } from '@/lib/supabase-enhanced';
 import IndustryMatcher from '@/components/industry/IndustryMatcher';
 import { Handshake, Users, TrendingUp, Award, Building, Globe, CheckCircle, Star, Target } from 'lucide-react';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 const partnerTypes = [
   {
@@ -104,6 +105,9 @@ export const PartnershipHub = () => {
       />
       <div className="absolute inset-0 bg-gradient-to-br from-orange-50/70 via-white/60 to-green-50/70" />
       <div className="relative z-10 py-16 text-gray-900">
+        <div className="max-w-6xl mx-auto px-6 mb-6 flex justify-start">
+          <BackToHomeButton />
+        </div>
         <div className="max-w-6xl mx-auto px-6 text-center">
           <Handshake className="w-16 h-16 mx-auto mb-6 text-gray-900" />
           <h1 className="text-4xl font-bold mb-4 text-gray-900">Partnership Hub</h1>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,8 +1,12 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import BackToHomeButton from "@/components/BackToHomeButton";
 
 export default function PrivacyPolicy() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <div className="mb-6">
+        <BackToHomeButton />
+      </div>
       <Card>
         <CardHeader>
           <CardTitle className="text-3xl font-bold text-center">Privacy Policy</CardTitle>

--- a/src/pages/ProfessionalAssessment.tsx
+++ b/src/pages/ProfessionalAssessment.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { supabase } from '@/lib/supabase-enhanced';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 interface AssessmentData {
   assessment: any;
@@ -133,7 +134,8 @@ export const ProfessionalAssessment = () => {
   if (currentView === 'intro') {
     return (
       <div className="min-h-screen bg-gradient-to-br from-purple-50 to-indigo-50 py-8 px-4">
-        <div className="max-w-2xl mx-auto">
+        <div className="max-w-2xl mx-auto space-y-6">
+          <BackToHomeButton />
           <Card>
             <CardHeader className="text-center">
               <CardTitle className="text-2xl text-purple-900">Professional Needs Assessment</CardTitle>
@@ -195,10 +197,13 @@ export const ProfessionalAssessment = () => {
   if (currentView === 'assessment') {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <ProfessionalNeedsAssessment 
-          onComplete={handleAssessmentComplete}
-          onSkip={handleSkipAssessment}
-        />
+        <div className="max-w-4xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <ProfessionalNeedsAssessment
+            onComplete={handleAssessmentComplete}
+            onSkip={handleSkipAssessment}
+          />
+        </div>
       </div>
     );
   }
@@ -207,12 +212,15 @@ export const ProfessionalAssessment = () => {
   if (currentView === 'results' && assessmentData) {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <AssessmentResults
-          assessment={assessmentData.assessment}
-          recommendations={assessmentData.strategy || []}
-          onContactProfessional={handleContactProfessional}
-          onRetakeAssessment={handleRetakeAssessment}
-        />
+        <div className="max-w-5xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <AssessmentResults
+            assessment={assessmentData.assessment}
+            recommendations={assessmentData.strategy || []}
+            onContactProfessional={handleContactProfessional}
+            onRetakeAssessment={handleRetakeAssessment}
+          />
+        </div>
       </div>
     );
   }

--- a/src/pages/ProfileEdit.tsx
+++ b/src/pages/ProfileEdit.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { supabase } from '@/lib/supabase-enhanced';
+import { useAppContext } from '@/contexts/AppContext';
+import { useToast } from '@/hooks/use-toast';
+import { ProfileForm } from '@/components/ProfileForm';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { prepareProfileForUpsert } from '@/utils/profile';
+import BackToHomeButton from '@/components/BackToHomeButton';
+
+export const ProfileEdit = () => {
+  const { user, refreshUser } = useAppContext();
+  const [profile, setProfile] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  const fetchProfile = useCallback(async () => {
+    if (!user) return;
+
+    setLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('id', user.id)
+        .single();
+
+      if (error) throw error;
+      setProfile(data);
+    } catch (error: any) {
+      toast({
+        title: 'Unable to load profile',
+        description: error.message ?? 'Please try again later.',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast, user]);
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/signin');
+      return;
+    }
+
+    void fetchProfile();
+  }, [user, navigate, fetchProfile]);
+
+  const handleSubmit = async (formValues: any) => {
+    if (!user) return;
+
+    setSaving(true);
+    try {
+      const { upsertPayload } = prepareProfileForUpsert({
+        profileData: formValues,
+        userId: user.id,
+        userEmail: user.email,
+        existingProfile: profile,
+      });
+
+      const { error } = await supabase.from('profiles').upsert(upsertPayload);
+      if (error) throw error;
+
+      await refreshUser();
+
+      toast({
+        title: 'Profile updated',
+        description: 'Your profile information was saved successfully.',
+      });
+
+      navigate('/profile-review');
+    } catch (error: any) {
+      toast({
+        title: 'Update failed',
+        description: error.message ?? 'Please review your details and try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!user || loading) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center space-y-4 bg-gradient-to-br from-blue-50 to-emerald-50">
+        <BackToHomeButton />
+        <p className="text-muted-foreground">Loading your profile...</p>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-emerald-50 py-8 px-4">
+        <div className="max-w-2xl mx-auto space-y-6">
+          <BackToHomeButton />
+          <Card>
+            <CardHeader>
+              <CardTitle>Profile not found</CardTitle>
+              <CardDescription>
+                We could not find your profile information. Please create your profile to continue.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex justify-end">
+              <Button onClick={() => navigate('/profile-setup')}>Create Profile</Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  const accountType = profile.account_type || user.account_type;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-emerald-50 py-8 px-4">
+      <div className="max-w-6xl mx-auto space-y-6">
+        <BackToHomeButton />
+        <Card>
+          <CardHeader>
+            <CardTitle>Edit Your Profile</CardTitle>
+            <CardDescription>
+              Update your information to keep your marketplace presence current.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {accountType ? (
+              <ProfileForm
+                accountType={accountType}
+                onSubmit={handleSubmit}
+                onPrevious={() => navigate('/profile-review')}
+                loading={saving}
+                initialData={profile}
+              />
+            ) : (
+              <div className="space-y-4 text-center py-6">
+                <p className="text-muted-foreground">
+                  We could not determine your account type. Please contact support for assistance.
+                </p>
+                <div className="flex justify-center gap-3">
+                  <Button variant="outline" onClick={() => navigate('/profile-setup')}>
+                    Go to Profile Setup
+                  </Button>
+                  <BackToHomeButton />
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileEdit;

--- a/src/pages/ProfileSetup.tsx
+++ b/src/pages/ProfileSetup.tsx
@@ -11,6 +11,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { UserTypeSubscriptions } from '@/components/UserTypeSubscriptions';
+import { prepareProfileForUpsert } from '@/utils/profile';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 export const ProfileSetup = () => {
   const [selectedAccountType, setSelectedAccountType] = useState<string>('');
@@ -106,198 +108,16 @@ export const ProfileSetup = () => {
     setLoading(true);
 
     try {
-      const sanitizeValue = (value?: string | null) => {
-        if (!value) return null;
-        return value.trim() || null;
-      };
-
-      const extractCardDetails = (cardNumber: string, expiry: string, cardholderName: string | null) => {
-        if (!cardholderName) {
-          throw new Error('Please enter the name on the card.');
-        }
-
-        const normalizedNumber = cardNumber.replace(/\D/g, '');
-        if (normalizedNumber.length < 12) {
-          throw new Error('Please enter a valid card number.');
-        }
-
-        const expiryMatch = expiry.replace(/\s/g, '').match(/^(\d{2})\/(\d{2}|\d{4})$/);
-        if (!expiryMatch) {
-          throw new Error('Please enter the card expiry in MM/YY format.');
-        }
-
-        const month = Number(expiryMatch[1]);
-        if (month < 1 || month > 12) {
-          throw new Error('Please enter a valid expiry month.');
-        }
-
-        let year = expiryMatch[2];
-        if (year.length === 2) {
-          year = `20${year}`;
-        }
-
-        return {
-          last4: normalizedNumber.slice(-4),
-          expiry_month: month,
-          expiry_year: Number(year),
-          cardholder_name: cardholderName,
-        };
-      };
-
-      const {
-        card_number,
-        card_expiry,
-        cardholder_name,
-        card_details: _ignoredCardDetails,
-        use_same_phone,
-        payment_method,
-        coordinates,
-        qualifications,
-        payment_phone,
-        ...profilePayload
-      } = profileData;
-
-      let paymentData: Record<string, unknown> = {};
-      if (use_same_phone) {
-        const phone = sanitizeValue(profilePayload.phone);
-        if (!phone) {
-          throw new Error('Please provide a phone number for subscription payments.');
-        }
-
-        paymentData = {
-          payment_phone: phone,
-          payment_method: 'phone',
-        };
-      } else if (payment_method === 'card') {
-        let cardDetails = null;
-
-        const normalizedCardholderName = sanitizeValue(cardholder_name);
-
-        if (card_number && card_expiry) {
-          cardDetails = extractCardDetails(card_number, card_expiry, normalizedCardholderName);
-        } else if (existingProfile?.card_details) {
-          const existingName = sanitizeValue(existingProfile.card_details.cardholder_name);
-          const finalName = normalizedCardholderName ?? existingName;
-          if (!finalName) {
-            throw new Error('Please enter the name on the card.');
-          }
-
-          cardDetails = {
-            ...existingProfile.card_details,
-            cardholder_name: finalName,
-          };
-        }
-
-        if (!cardDetails) {
-          throw new Error('Card details are required to process subscription payments.');
-        }
-
-        paymentData = {
-          payment_method: 'card',
-          card_details: cardDetails,
-        };
-      } else {
-        const paymentPhone = sanitizeValue(payment_phone);
-        if (!paymentPhone) {
-          throw new Error('Please provide the mobile money number to charge.');
-        }
-
-        paymentData = {
-          payment_method: 'phone',
-          payment_phone: paymentPhone,
-        };
-      }
-
-      const normalizedCoordinates = (() => {
-        if (!coordinates || typeof coordinates !== 'object') {
-          return null;
-        }
-
-        const lat = typeof coordinates.lat === 'number' ? coordinates.lat : Number(coordinates.lat);
-        const lng = typeof coordinates.lng === 'number' ? coordinates.lng : Number(coordinates.lng);
-
-        if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
-          return null;
-        }
-
-        return { lat, lng };
-      })();
-
-      const normalizedQualifications = Array.isArray(qualifications)
-        ? qualifications
-            .map((qualification: Record<string, any>) => {
-              if (!qualification || typeof qualification !== 'object') {
-                return null;
-              }
-
-              const institution = sanitizeValue(qualification.institution);
-              const degree = sanitizeValue(qualification.degree ?? qualification.name);
-              const field = sanitizeValue(qualification.field);
-              const year = sanitizeValue(qualification.year);
-
-              const normalized: Record<string, string> = {};
-
-              if (institution) normalized.institution = institution;
-              if (degree) {
-                normalized.degree = degree;
-                normalized.name = degree;
-              }
-              if (field) normalized.field = field;
-              if (year) normalized.year = year;
-
-              return Object.keys(normalized).length > 0 ? normalized : null;
-            })
-            .filter((qualification): qualification is Record<string, string> => Boolean(qualification))
-        : [];
-
-      const sanitizedProfile: Record<string, unknown> = {};
-      const numericFields = new Set([
-        'experience_years',
-        'employees_count',
-        'annual_revenue',
-        'annual_funding_budget',
-        'investment_ticket_min',
-        'investment_ticket_max'
-      ]);
-
-      for (const [key, value] of Object.entries(profilePayload)) {
-        if (Array.isArray(value)) {
-          if (key === 'gaps_identified') {
-            const sanitizedGaps = value
-              .map((item) => (typeof item === 'string' ? sanitizeValue(item) : null))
-              .filter((item): item is string => Boolean(item));
-
-            sanitizedProfile[key] = sanitizedGaps;
-          } else {
-            sanitizedProfile[key] = value;
-          }
-        } else if (typeof value === 'string') {
-          const sanitizedValue = sanitizeValue(value);
-          if (sanitizedValue === null) {
-            sanitizedProfile[key] = null;
-          } else if (numericFields.has(key)) {
-            const numeric = Number(sanitizedValue.replace(/,/g, ''));
-            sanitizedProfile[key] = Number.isFinite(numeric) ? numeric : sanitizedValue;
-          } else {
-            sanitizedProfile[key] = sanitizedValue;
-          }
-        } else {
-          sanitizedProfile[key] = value ?? null;
-        }
-      }
+      const { upsertPayload } = prepareProfileForUpsert({
+        profileData,
+        userId: user.id,
+        userEmail: user.email,
+        existingProfile,
+      });
 
       const { error } = await supabase
         .from('profiles')
-        .upsert({
-          id: user.id,
-          email: user.email,
-          ...sanitizedProfile,
-          coordinates: normalizedCoordinates,
-          qualifications: normalizedQualifications,
-          ...paymentData,
-          profile_completed: true,
-          updated_at: new Date().toISOString()
-        });
+        .upsert(upsertPayload);
 
       if (error) throw error;
 
@@ -340,7 +160,9 @@ export const ProfileSetup = () => {
   if (!showProfileForm) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-emerald-50 py-8 px-4">
-        <Card className="w-full max-w-2xl mx-auto">
+        <div className="w-full max-w-2xl mx-auto space-y-6">
+          <BackToHomeButton />
+          <Card>
           <CardHeader>
             <CardTitle>Select Your Account Type</CardTitle>
             <CardDescription>
@@ -372,14 +194,16 @@ export const ProfileSetup = () => {
               {loading ? 'Processing...' : 'Continue'}
             </Button>
           </CardContent>
-        </Card>
+          </Card>
+        </div>
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-emerald-50 py-8 px-4">
-      <div className="max-w-6xl mx-auto">
+      <div className="max-w-6xl mx-auto space-y-6">
+        <BackToHomeButton />
         <Card>
           <CardHeader>
             <CardTitle>Complete Your Profile & Verification</CardTitle>

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { FileText, Download, Eye, Calendar, User, Search } from 'lucide-react';
 import AppLayout from '@/components/AppLayout';
+import BackToHomeButton from '@/components/BackToHomeButton';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { LencoPayment } from '@/components/LencoPayment';
 import { useAppContext } from '@/contexts/AppContext';
@@ -219,6 +220,9 @@ const Resources = () => {
         />
         <div className="absolute inset-0 bg-gradient-to-r from-emerald-600/70 to-blue-600/70" />
         <div className="relative z-10 py-16 text-white">
+          <div className="max-w-6xl mx-auto px-6 mb-6 flex justify-start">
+            <BackToHomeButton variant="secondary" />
+          </div>
           <div className="max-w-6xl mx-auto px-6 text-center">
             <h1 className="text-5xl font-bold mb-4">Business Resources</h1>
             <p className="text-xl mb-8">Tools, templates, and knowledge to grow your business</p>

--- a/src/pages/SMEAssessment.tsx
+++ b/src/pages/SMEAssessment.tsx
@@ -7,7 +7,8 @@ import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/lib/supabase-enhanced';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { ArrowLeft, CheckCircle, TrendingUp } from 'lucide-react';
+import { CheckCircle, TrendingUp } from 'lucide-react';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 interface AssessmentData {
   assessment: any;
@@ -134,10 +135,6 @@ export const SMEAssessment = () => {
     }
   };
 
-  const handleBackToHome = () => {
-    navigate('/');
-  };
-
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -154,14 +151,9 @@ export const SMEAssessment = () => {
     return (
       <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-green-50">
         <div className="max-w-4xl mx-auto p-6 pt-12">
-          <Button 
-            variant="ghost" 
-            onClick={handleBackToHome}
-            className="mb-6"
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back to Home
-          </Button>
+          <div className="mb-6">
+            <BackToHomeButton variant="ghost" />
+          </div>
 
           <div className="text-center mb-8">
             <TrendingUp className="w-16 h-16 mx-auto text-orange-600 mb-4" />
@@ -293,10 +285,13 @@ export const SMEAssessment = () => {
   if (currentView === 'assessment') {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <SMENeedsAssessment 
-          onComplete={handleAssessmentComplete}
-          onSkip={handleSkipAssessment}
-        />
+        <div className="max-w-4xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <SMENeedsAssessment
+            onComplete={handleAssessmentComplete}
+            onSkip={handleSkipAssessment}
+          />
+        </div>
       </div>
     );
   }
@@ -305,12 +300,15 @@ export const SMEAssessment = () => {
   if (currentView === 'results' && assessmentData) {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
-        <AssessmentResults
-          assessment={assessmentData.assessment}
-          recommendations={assessmentData.recommendations}
-          onContactProfessional={handleContactProfessional}
-          onRetakeAssessment={handleRetakeAssessment}
-        />
+        <div className="max-w-5xl mx-auto px-4 space-y-6">
+          <BackToHomeButton />
+          <AssessmentResults
+            assessment={assessmentData.assessment}
+            recommendations={assessmentData.recommendations}
+            onContactProfessional={handleContactProfessional}
+            onRetakeAssessment={handleRetakeAssessment}
+          />
+        </div>
       </div>
     );
   }

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -10,6 +10,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Eye, EyeOff, Mail, Lock, ArrowRight } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAppContext } from '@/contexts/AppContext';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 // Validation schema
 const signInSchema = z.object({
@@ -62,13 +63,16 @@ const SignIn = () => {
 
   return (
     <div className="min-h-screen flex items-center justify-center p-6 relative">
-      <div 
+      <div
         className="fixed inset-0 bg-center bg-cover"
         style={{
           backgroundImage: "url('/images/Partnership%20Hub.png')",
         }}
       />
       <div className="absolute inset-0 bg-gradient-to-br from-orange-50/70 via-white/60 to-green-50/70" />
+      <div className="absolute top-6 left-6 z-20">
+        <BackToHomeButton />
+      </div>
       <div className="w-full max-w-md relative z-10">
         <div className="text-center mb-8">
           <img
@@ -170,9 +174,7 @@ const SignIn = () => {
         </Card>
 
         <div className="mt-8 text-center">
-          <Link to="/" className="text-gray-600 hover:text-gray-800 font-medium">
-            ← Back to Home
-          </Link>
+          <BackToHomeButton variant="link" />
         </div>
       </div>
     </div>

--- a/src/pages/SubscriptionPlans.tsx
+++ b/src/pages/SubscriptionPlans.tsx
@@ -8,6 +8,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import { subscriptionPlans, getPlansForUserType, getUserTypeLabel } from '@/data/subscriptionPlans';
 import { UserTypeSubscriptions } from '@/components/UserTypeSubscriptions';
 import { SubscriptionCard } from '@/components/SubscriptionCard';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 export const SubscriptionPlans = () => {
   const [selectedUserType, setSelectedUserType] = useState<string>('all');
@@ -40,6 +41,9 @@ export const SubscriptionPlans = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-emerald-50 py-12 px-4">
       <div className="max-w-7xl mx-auto">
+        <div className="mb-6">
+          <BackToHomeButton />
+        </div>
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold text-gray-900 mb-4">Choose Your Plan</h1>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,8 +1,12 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import BackToHomeButton from "@/components/BackToHomeButton";
 
 export default function TermsOfService() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <div className="mb-6">
+        <BackToHomeButton />
+      </div>
       <Card>
         <CardHeader>
           <CardTitle className="text-3xl font-bold text-center">Terms of Service</CardTitle>

--- a/src/pages/TestError.tsx
+++ b/src/pages/TestError.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import BackToHomeButton from '@/components/BackToHomeButton';
 
 const TestError = () => {
   useEffect(() => {
@@ -7,7 +8,8 @@ const TestError = () => {
   }, []);
 
   return (
-    <div>
+    <div className="p-6 space-y-4">
+      <BackToHomeButton />
       <h1>Test Error Page</h1>
       <p>This page should trigger the ErrorBoundary.</p>
     </div>

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -1,0 +1,240 @@
+interface PrepareProfileForUpsertParams {
+  profileData: Record<string, any>;
+  userId: string;
+  userEmail: string;
+  existingProfile?: Record<string, any> | null;
+}
+
+interface PrepareProfileForUpsertResult {
+  upsertPayload: Record<string, unknown>;
+}
+
+const sanitizeValue = (value?: string | null) => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed;
+};
+
+const extractCardDetails = (
+  cardNumber: string,
+  expiry: string,
+  cardholderName: string | null,
+) => {
+  if (!cardholderName) {
+    throw new Error('Please enter the name on the card.');
+  }
+
+  const normalizedNumber = cardNumber.replace(/\D/g, '');
+  if (normalizedNumber.length < 12) {
+    throw new Error('Please enter a valid card number.');
+  }
+
+  const expiryMatch = expiry.replace(/\s/g, '').match(/^(\d{2})\/(\d{2}|\d{4})$/);
+  if (!expiryMatch) {
+    throw new Error('Please enter the card expiry in MM/YY format.');
+  }
+
+  const month = Number(expiryMatch[1]);
+  if (month < 1 || month > 12) {
+    throw new Error('Please enter a valid expiry month.');
+  }
+
+  let year = expiryMatch[2];
+  if (year.length === 2) {
+    year = `20${year}`;
+  }
+
+  return {
+    last4: normalizedNumber.slice(-4),
+    expiry_month: month,
+    expiry_year: Number(year),
+    cardholder_name: cardholderName,
+  };
+};
+
+const normalizeCoordinates = (coordinates: unknown) => {
+  if (!coordinates || typeof coordinates !== 'object') {
+    return null;
+  }
+
+  const coords = coordinates as Record<string, unknown>;
+  const lat = typeof coords.lat === 'number' ? coords.lat : Number(coords.lat);
+  const lng = typeof coords.lng === 'number' ? coords.lng : Number(coords.lng);
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    return null;
+  }
+
+  return { lat, lng };
+};
+
+const normalizeQualifications = (qualifications: unknown) => {
+  if (!Array.isArray(qualifications)) {
+    return [];
+  }
+
+  return qualifications
+    .map((qualification: Record<string, any>) => {
+      if (!qualification || typeof qualification !== 'object') {
+        return null;
+      }
+
+      const institution = sanitizeValue(qualification.institution);
+      const degree = sanitizeValue(qualification.degree ?? qualification.name);
+      const field = sanitizeValue(qualification.field);
+      const year = sanitizeValue(qualification.year);
+
+      const normalized: Record<string, string> = {};
+
+      if (institution) normalized.institution = institution;
+      if (degree) {
+        normalized.degree = degree;
+        normalized.name = degree;
+      }
+      if (field) normalized.field = field;
+      if (year) normalized.year = year;
+
+      return Object.keys(normalized).length > 0 ? normalized : null;
+    })
+    .filter((qualification): qualification is Record<string, string> => Boolean(qualification));
+};
+
+const sanitizeProfileFields = (
+  profilePayload: Record<string, unknown>,
+) => {
+  const sanitizedProfile: Record<string, unknown> = {};
+  const numericFields = new Set([
+    'experience_years',
+    'employees_count',
+    'annual_revenue',
+    'annual_funding_budget',
+    'investment_ticket_min',
+    'investment_ticket_max',
+  ]);
+
+  for (const [key, value] of Object.entries(profilePayload)) {
+    if (Array.isArray(value)) {
+      if (key === 'gaps_identified') {
+        const sanitizedGaps = value
+          .map((item) => (typeof item === 'string' ? sanitizeValue(item) : null))
+          .filter((item): item is string => Boolean(item));
+
+        sanitizedProfile[key] = sanitizedGaps;
+      } else {
+        sanitizedProfile[key] = value;
+      }
+    } else if (typeof value === 'string') {
+      const sanitizedValue = sanitizeValue(value);
+      if (sanitizedValue === null) {
+        sanitizedProfile[key] = null;
+      } else if (numericFields.has(key)) {
+        const numeric = Number(sanitizedValue.replace(/,/g, ''));
+        sanitizedProfile[key] = Number.isFinite(numeric) ? numeric : sanitizedValue;
+      } else if (key === 'bio') {
+        sanitizedProfile[key] = sanitizedValue.slice(0, 400);
+      } else {
+        sanitizedProfile[key] = sanitizedValue;
+      }
+    } else {
+      sanitizedProfile[key] = value ?? null;
+    }
+  }
+
+  return sanitizedProfile;
+};
+
+export const prepareProfileForUpsert = ({
+  profileData,
+  userId,
+  userEmail,
+  existingProfile,
+}: PrepareProfileForUpsertParams): PrepareProfileForUpsertResult => {
+  const {
+    card_number,
+    card_expiry,
+    cardholder_name,
+    card_details: _ignoredCardDetails,
+    use_same_phone,
+    payment_method,
+    coordinates,
+    qualifications,
+    payment_phone,
+    ...profilePayload
+  } = profileData;
+
+  let paymentData: Record<string, unknown> = {};
+
+  if (use_same_phone) {
+    const phone = sanitizeValue(profilePayload.phone as string | undefined);
+    if (!phone) {
+      throw new Error('Please provide a phone number for subscription payments.');
+    }
+
+    paymentData = {
+      payment_phone: phone,
+      payment_method: 'phone',
+      use_same_phone: true,
+    };
+  } else if (payment_method === 'card') {
+    let cardDetails = null;
+    const normalizedCardholderName = sanitizeValue(cardholder_name);
+
+    if (card_number && card_expiry) {
+      cardDetails = extractCardDetails(card_number, card_expiry, normalizedCardholderName);
+    } else if (existingProfile?.card_details) {
+      const existingName = sanitizeValue(existingProfile.card_details.cardholder_name);
+      const finalName = normalizedCardholderName ?? existingName;
+      if (!finalName) {
+        throw new Error('Please enter the name on the card.');
+      }
+
+      cardDetails = {
+        ...existingProfile.card_details,
+        cardholder_name: finalName,
+      };
+    }
+
+    if (!cardDetails) {
+      throw new Error('Card details are required to process subscription payments.');
+    }
+
+    paymentData = {
+      payment_method: 'card',
+      card_details: cardDetails,
+      use_same_phone: false,
+    };
+  } else {
+    const paymentPhone = sanitizeValue(payment_phone);
+    if (!paymentPhone) {
+      throw new Error('Please provide the mobile money number to charge.');
+    }
+
+    paymentData = {
+      payment_method: 'phone',
+      payment_phone: paymentPhone,
+      use_same_phone: false,
+    };
+  }
+
+  const upsertPayload = {
+    id: userId,
+    email: userEmail,
+    ...sanitizeProfileFields(profilePayload),
+    coordinates: normalizeCoordinates(coordinates),
+    qualifications: normalizeQualifications(qualifications),
+    ...paymentData,
+    profile_completed: true,
+    updated_at: new Date().toISOString(),
+  } satisfies Record<string, unknown>;
+
+  return { upsertPayload };
+};
+
+export type { PrepareProfileForUpsertParams, PrepareProfileForUpsertResult };


### PR DESCRIPTION
## Summary
- add a reusable BackToHomeButton component and wire it into the application pages
- introduce a dedicated ProfileEdit route that reuses shared profile upsert logic
- surface profile bio support in the review experience and offline metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fa00589d988328a053075f6be22bf1