### PR TITLE
Resolve conflicts for profile edit navigation with V3

### DIFF
--- a/src/components/ProfileReview.tsx
+++ b/src/components/ProfileReview.tsx
@@ -68,7 +68,7 @@ export const ProfileReview = () => {
   }, [user, navigate, fetchProfile]);
 
   const handleEditProfile = () => {
-    navigate('/profile-setup');
+    navigate({ pathname: '/profile-setup', search: '?tab=profile&mode=edit' });
   };
 
   if (loading) {

--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -405,6 +405,12 @@ export const GetStarted = () => {
             Sign In
           </Link>
         </div>
+
+        <div className="mt-6 text-center">
+          <Link to="/" className="text-gray-600 hover:text-gray-800 font-medium">
+            ← Back to Home
+          </Link>
+        </div>
       </CardContent>
     </Card>
     </div>

--- a/src/pages/ProfileSetup.tsx
+++ b/src/pages/ProfileSetup.tsx
@@ -24,6 +24,7 @@ export const ProfileSetup = () => {
   const { user, refreshUser } = useAppContext();
 
   const activeTab = searchParams.get('tab') || 'profile';
+  const mode = searchParams.get('mode');
 
   const checkExistingProfile = useCallback(async () => {
     if (!user) return;
@@ -66,6 +67,13 @@ export const ProfileSetup = () => {
 
     void checkExistingProfile();
   }, [user, navigate, checkExistingProfile]);
+
+  useEffect(() => {
+    if (mode === 'edit' && existingProfile) {
+      setSelectedAccountType(existingProfile.account_type || '');
+      setShowProfileForm(true);
+    }
+  }, [mode, existingProfile]);
 
   const handleAccountTypeSelect = async () => {
     if (!selectedAccountType || !user) return;


### PR DESCRIPTION
## Summary
- preserve profile editing context by routing the review screen to the setup flow with explicit query parameters
- auto-open the profile setup form when edit mode is requested so existing users can update their details without reselecting account type
- restore a Back to Home link on the Get Started screen to match the sign-in experience

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/SignIn.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fa06f8d8548328a12762a6ef93fd96