### PR TITLE
Add lazy-loaded routes with loading fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,111 +1,152 @@
+import { Suspense, lazy } from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AppProvider } from "@/contexts/AppContext";
-import "./i18n";
-import Index from "./pages/Index";
-import Marketplace from "./pages/Marketplace";
-import Resources from "./pages/Resources";
-import NotFound from "./pages/NotFound";
-import { SignIn } from "./pages/SignIn";
-import { GetStarted } from "./pages/GetStarted";
-import { SubscriptionPlans } from "./pages/SubscriptionPlans";
-import { PartnershipHub } from "./pages/PartnershipHub";
-import FundingHub from "./pages/FundingHub";
-import { ProfileSetup } from "./pages/ProfileSetup";
-import { ProfileReview } from "./components/ProfileReview";
-import FreelancerHub from "./pages/FreelancerHub";
-import PrivacyPolicy from "./pages/PrivacyPolicy";
-import TermsOfService from "./pages/TermsOfService";
-import Messages from "./pages/Messages";
-import AboutUs from "./pages/AboutUs";
-import TestError from "./pages/TestError";
-import { SMEAssessment } from "./pages/SMEAssessment";
-import { InvestorAssessment } from "./pages/InvestorAssessment";
-import { DonorAssessment } from "./pages/DonorAssessment";
-import { ProfessionalAssessment } from "./pages/ProfessionalAssessment";
-import { GovernmentAssessment } from "./pages/GovernmentAssessment";
+import { LoadingScreen } from "@/components/LoadingScreen";
 import { PrivateRoute } from "./components/PrivateRoute";
+import "./i18n";
 
 const queryClient = new QueryClient();
 
+const Index = lazy(() => import("./pages/Index"));
+const Marketplace = lazy(() => import("./pages/Marketplace"));
+const Resources = lazy(() => import("./pages/Resources"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+const SignIn = lazy(() =>
+  import("./pages/SignIn").then((module) => ({ default: module.SignIn }))
+);
+const GetStarted = lazy(() =>
+  import("./pages/GetStarted").then((module) => ({ default: module.GetStarted }))
+);
+const SubscriptionPlans = lazy(() =>
+  import("./pages/SubscriptionPlans").then((module) => ({
+    default: module.SubscriptionPlans,
+  }))
+);
+const PartnershipHub = lazy(() =>
+  import("./pages/PartnershipHub").then((module) => ({
+    default: module.PartnershipHub,
+  }))
+);
+const FundingHub = lazy(() => import("./pages/FundingHub"));
+const ProfileSetup = lazy(() =>
+  import("./pages/ProfileSetup").then((module) => ({ default: module.ProfileSetup }))
+);
+const ProfileReview = lazy(() =>
+  import("./components/ProfileReview").then((module) => ({
+    default: module.ProfileReview,
+  }))
+);
+const FreelancerHub = lazy(() => import("./pages/FreelancerHub"));
+const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
+const TermsOfService = lazy(() => import("./pages/TermsOfService"));
+const Messages = lazy(() => import("./pages/Messages"));
+const AboutUs = lazy(() => import("./pages/AboutUs"));
+const TestError = lazy(() => import("./pages/TestError"));
+const SMEAssessment = lazy(() =>
+  import("./pages/SMEAssessment").then((module) => ({ default: module.SMEAssessment }))
+);
+const InvestorAssessment = lazy(() =>
+  import("./pages/InvestorAssessment").then((module) => ({
+    default: module.InvestorAssessment,
+  }))
+);
+const DonorAssessment = lazy(() =>
+  import("./pages/DonorAssessment").then((module) => ({
+    default: module.DonorAssessment,
+  }))
+);
+const ProfessionalAssessment = lazy(() =>
+  import("./pages/ProfessionalAssessment").then((module) => ({
+    default: module.ProfessionalAssessment,
+  }))
+);
+const GovernmentAssessment = lazy(() =>
+  import("./pages/GovernmentAssessment").then((module) => ({
+    default: module.GovernmentAssessment,
+  }))
+);
+
 export const AppRoutes = () => (
-  <Routes>
-    <Route path="/" element={<Index />} />
-    <Route path="/marketplace" element={<Marketplace />} />
-    <Route path="/freelancer-hub" element={<FreelancerHub />} />
-    <Route path="/resources" element={<Resources />} />
-    <Route path="/signin" element={<SignIn />} />
-    <Route path="/get-started" element={<GetStarted />} />
-    <Route path="/profile-setup" element={<ProfileSetup />} />
-    <Route path="/profile-review" element={<ProfileReview />} />
-    <Route path="/subscription-plans" element={<SubscriptionPlans />} />
-    <Route path="/partnership-hub" element={<PartnershipHub />} />
-    <Route
-      path="/funding-hub"
-      element={
-        <PrivateRoute>
-          <FundingHub />
-        </PrivateRoute>
-      }
-    />
-    <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-    <Route path="/terms-of-service" element={<TermsOfService />} />
-    <Route path="/about-us" element={<AboutUs />} />
-    <Route path="/test-error" element={<TestError />} />
-    <Route
-      path="/messages"
-      element={
-        <PrivateRoute>
-          <Messages />
-        </PrivateRoute>
-      }
-    />
-    <Route
-      path="/sme-assessment"
-      element={
-        <PrivateRoute>
-          <SMEAssessment />
-        </PrivateRoute>
-      }
-    />
-    <Route
-      path="/investor-assessment"
-      element={
-        <PrivateRoute>
-          <InvestorAssessment />
-        </PrivateRoute>
-      }
-    />
-    <Route
-      path="/donor-assessment"
-      element={
-        <PrivateRoute>
-          <DonorAssessment />
-        </PrivateRoute>
-      }
-    />
-    <Route
-      path="/professional-assessment"
-      element={
-        <PrivateRoute>
-          <ProfessionalAssessment />
-        </PrivateRoute>
-      }
-    />
-    <Route
-      path="/government-assessment"  
-      element={
-        <PrivateRoute>
-          <GovernmentAssessment />
-        </PrivateRoute>
-      }
-    />
-    <Route path="*" element={<NotFound />} />
-  </Routes>
+  <Suspense fallback={<LoadingScreen />}>
+    <Routes>
+      <Route path="/" element={<Index />} />
+      <Route path="/marketplace" element={<Marketplace />} />
+      <Route path="/freelancer-hub" element={<FreelancerHub />} />
+      <Route path="/resources" element={<Resources />} />
+      <Route path="/signin" element={<SignIn />} />
+      <Route path="/get-started" element={<GetStarted />} />
+      <Route path="/profile-setup" element={<ProfileSetup />} />
+      <Route path="/profile-review" element={<ProfileReview />} />
+      <Route path="/subscription-plans" element={<SubscriptionPlans />} />
+      <Route path="/partnership-hub" element={<PartnershipHub />} />
+      <Route
+        path="/funding-hub"
+        element={
+          <PrivateRoute>
+            <FundingHub />
+          </PrivateRoute>
+        }
+      />
+      <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+      <Route path="/terms-of-service" element={<TermsOfService />} />
+      <Route path="/about-us" element={<AboutUs />} />
+      <Route path="/test-error" element={<TestError />} />
+      <Route
+        path="/messages"
+        element={
+          <PrivateRoute>
+            <Messages />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/sme-assessment"
+        element={
+          <PrivateRoute>
+            <SMEAssessment />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/investor-assessment"
+        element={
+          <PrivateRoute>
+            <InvestorAssessment />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/donor-assessment"
+        element={
+          <PrivateRoute>
+            <DonorAssessment />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/professional-assessment"
+        element={
+          <PrivateRoute>
+            <ProfessionalAssessment />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/government-assessment"
+        element={
+          <PrivateRoute>
+            <GovernmentAssessment />
+          </PrivateRoute>
+        }
+      />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  </Suspense>
 );
 
 const App = () => (

--- a/src/__tests__/AppRoutes.test.tsx
+++ b/src/__tests__/AppRoutes.test.tsx
@@ -45,14 +45,14 @@ const protectedRoutes = [
 ];
 
 describe('AppRoutes', () => {
-  it.each(publicRoutes)('renders %s', ({ path, text }) => {
+  it.each(publicRoutes)('renders %s', async ({ path, text }) => {
     appContextMock.user = null;
     render(
       <MemoryRouter initialEntries={[path]}>
         <AppRoutes />
       </MemoryRouter>
     );
-    expect(screen.getByText(text)).toBeInTheDocument();
+    expect(await screen.findByText(text)).toBeInTheDocument();
   });
 
   describe('protected routes', () => {
@@ -66,24 +66,24 @@ describe('AppRoutes', () => {
       expect(await screen.findByText('Sign In Page')).toBeInTheDocument();
     });
 
-    it.each(protectedRoutes)('renders %s when authenticated', ({ path, text }) => {
+    it.each(protectedRoutes)('renders %s when authenticated', async ({ path, text }) => {
       appContextMock.user = { id: '1' };
       render(
         <MemoryRouter initialEntries={[path]}>
           <AppRoutes />
         </MemoryRouter>
       );
-      expect(screen.getByText(text)).toBeInTheDocument();
+      expect(await screen.findByText(text)).toBeInTheDocument();
     });
   });
 
-  it('renders NotFound for unknown paths', () => {
+  it('renders NotFound for unknown paths', async () => {
     appContextMock.user = null;
     render(
       <MemoryRouter initialEntries={['/unknown']}>
         <AppRoutes />
       </MemoryRouter>
     );
-    expect(screen.getByText('Not Found')).toBeInTheDocument();
+    expect(await screen.findByText('Not Found')).toBeInTheDocument();
   });
 });

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,14 @@
+import { Loader2 } from "lucide-react";
+
+export const LoadingScreen = () => (
+  <div
+    role="status"
+    aria-live="polite"
+    className="flex min-h-[50vh] flex-col items-center justify-center gap-4"
+  >
+    <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
+    <span className="text-muted-foreground">Preparing your experience…</span>
+  </div>
+);
+
+export default LoadingScreen;


### PR DESCRIPTION
## Summary
- lazy load major route components behind React Suspense to reduce the main bundle size
- add an accessible LoadingScreen fallback for route-level code splitting
- update routing tests to wait for lazy-loaded screens

## Testing
- npm run lint
- npm test
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d755c7a14832887b44d6959c9fa91)