### PR TITLE
Implement password reset flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import Marketplace from "./pages/Marketplace";
 import Resources from "./pages/Resources";
 import NotFound from "./pages/NotFound";
 import { SignIn } from "./pages/SignIn";
+import ForgotPassword from "./pages/ForgotPassword";
+import ResetPassword from "./pages/ResetPassword";
 import { GetStarted } from "./pages/GetStarted";
 import { SubscriptionPlans } from "./pages/SubscriptionPlans";
 import { PartnershipHub } from "./pages/PartnershipHub";
@@ -29,6 +31,8 @@ export const AppRoutes = () => (
     <Route path="/freelancer-hub" element={<FreelancerHub />} />
     <Route path="/resources" element={<Resources />} />
     <Route path="/signin" element={<SignIn />} />
+    <Route path="/forgot-password" element={<ForgotPassword />} />
+    <Route path="/reset-password" element={<ResetPassword />} />
     <Route path="/get-started" element={<GetStarted />} />
     <Route path="/profile-setup" element={<ProfileSetup />} />
     <Route path="/profile-review" element={<ProfileReview />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const SignIn = lazy(() =>
   import("./pages/SignIn").then((module) => ({ default: module.SignIn }))
 );
+const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
+const ResetPassword = lazy(() => import("./pages/ResetPassword"));
 const GetStarted = lazy(() =>
   import("./pages/GetStarted").then((module) => ({ default: module.GetStarted }))
 );
@@ -79,6 +81,8 @@ export const AppRoutes = () => (
       <Route path="/freelancer-hub" element={<FreelancerHub />} />
       <Route path="/resources" element={<Resources />} />
       <Route path="/signin" element={<SignIn />} />
+      <Route path="/forgot-password" element={<ForgotPassword />} />
+      <Route path="/reset-password" element={<ResetPassword />} />
       <Route path="/get-started" element={<GetStarted />} />
       <Route path="/profile-setup" element={<ProfileSetup />} />
       <Route path="/profile-review" element={<ProfileReview />} />

--- a/src/__tests__/AppRoutes.test.tsx
+++ b/src/__tests__/AppRoutes.test.tsx
@@ -6,6 +6,8 @@ jest.mock('../pages/Marketplace', () => ({ default: () => <div>Marketplace Page<
 jest.mock('../pages/Resources', () => ({ default: () => <div>Resources Page</div> }));
 jest.mock('../pages/NotFound', () => ({ default: () => <div>Not Found</div> }));
 jest.mock('../pages/SignIn', () => ({ SignIn: () => <div>Sign In Page</div> }));
+jest.mock('../pages/ForgotPassword', () => ({ default: () => <div>Forgot Password Page</div> }));
+jest.mock('../pages/ResetPassword', () => ({ default: () => <div>Reset Password Page</div> }));
 jest.mock('../pages/GetStarted', () => ({ GetStarted: () => <div>Get Started Page</div> }));
 jest.mock('../pages/SubscriptionPlans', () => ({ SubscriptionPlans: () => <div>Subscription Plans Page</div> }));
 jest.mock('../pages/PartnershipHub', () => ({ PartnershipHub: () => <div>Partnership Hub Page</div> }));
@@ -30,6 +32,8 @@ const publicRoutes = [
   { path: '/freelancer-hub', text: 'Freelancer Hub Page' },
   { path: '/resources', text: 'Resources Page' },
   { path: '/signin', text: 'Sign In Page' },
+  { path: '/forgot-password', text: 'Forgot Password Page' },
+  { path: '/reset-password', text: 'Reset Password Page' },
   { path: '/get-started', text: 'Get Started Page' },
   { path: '/profile-setup', text: 'Profile Setup Page' },
   { path: '/profile-review', text: 'Profile Review Page' },

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Link } from 'react-router-dom';
+import { Mail, ArrowLeft, CheckCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useToast } from '@/hooks/use-toast';
+import { userService } from '@/lib/services';
+
+const forgotPasswordSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .email('Please enter a valid email address'),
+});
+
+type ForgotPasswordFormData = z.infer<typeof forgotPasswordSchema>;
+
+const ForgotPassword = () => {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ForgotPasswordFormData>({
+    resolver: zodResolver(forgotPasswordSchema),
+    mode: 'onBlur',
+  });
+
+  const onSubmit = handleSubmit(async ({ email }) => {
+    setLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const { error } = await userService.requestPasswordReset(email);
+
+      if (error) {
+        const message =
+          error.message || 'We could not send a reset link right now. Please try again shortly.';
+        setErrorMessage(message);
+        toast({
+          variant: 'destructive',
+          title: 'Unable to send reset link',
+          description: message,
+        });
+        return;
+      }
+
+      setSuccess(true);
+      toast({
+        title: 'Check your email',
+        description: 'We sent you a link to reset your password.',
+      });
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-emerald-50 py-16 px-4">
+      <div className="mx-auto w-full max-w-md">
+        <Card className="shadow-xl border border-orange-100">
+          <CardHeader className="space-y-2 text-center">
+            <CardTitle className="text-3xl font-bold text-gray-900">Forgot Password</CardTitle>
+            <CardDescription className="text-gray-600">
+              Enter the email address associated with your account and we'll send you reset instructions.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {success ? (
+              <div className="space-y-6 text-center">
+                <div className="flex justify-center">
+                  <CheckCircle className="h-12 w-12 text-emerald-500" aria-hidden="true" />
+                </div>
+                <div className="space-y-2">
+                  <h2 className="text-xl font-semibold text-gray-900">Reset link sent</h2>
+                  <p className="text-gray-600">
+                    Please check your inbox for an email with the next steps. The link will expire shortly for security reasons.
+                  </p>
+                </div>
+                <Button asChild className="w-full">
+                  <Link to="/signin">Return to sign in</Link>
+                </Button>
+              </div>
+            ) : (
+              <form onSubmit={onSubmit} className="space-y-6">
+                {errorMessage && (
+                  <Alert variant="destructive">
+                    <AlertDescription>{errorMessage}</AlertDescription>
+                  </Alert>
+                )}
+
+                <div className="space-y-2">
+                  <Label htmlFor="email" className="text-left text-gray-700 font-medium">
+                    Email address
+                  </Label>
+                  <div className="relative">
+                    <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" aria-hidden="true" />
+                    <Input
+                      id="email"
+                      type="email"
+                      autoComplete="email"
+                      placeholder="Enter your email"
+                      {...register('email')}
+                      className={`pl-10 border-orange-200 focus:border-orange-400 focus:ring-orange-400 ${
+                        errors.email ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
+                      }`}
+                      aria-invalid={errors.email ? 'true' : 'false'}
+                    />
+                  </div>
+                  {errors.email && (
+                    <p className="text-sm text-red-600" role="alert">
+                      {errors.email.message}
+                    </p>
+                  )}
+                </div>
+
+                <Button
+                  type="submit"
+                  className="w-full bg-gradient-to-r from-orange-600 to-orange-700 hover:from-orange-700 hover:to-orange-800 text-white py-3"
+                  disabled={loading}
+                >
+                  {loading ? 'Sending reset link…' : 'Send reset link'}
+                </Button>
+
+                <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
+                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                  <Link to="/signin" className="font-medium text-orange-600 hover:text-orange-700">
+                    Back to sign in
+                  </Link>
+                </div>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Loader2, Lock, CheckCircle, ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useToast } from '@/hooks/use-toast';
+import { supabase, userService } from '@/lib/services';
+
+const resetPasswordSchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, 'Password must be at least 8 characters long')
+      .regex(/^(?=.*[A-Za-z])(?=.*\d).+$/, 'Use a mix of letters and numbers for a stronger password'),
+    confirmPassword: z.string().min(1, 'Please confirm your new password'),
+  })
+  .refine(data => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;
+
+const ResetPassword = () => {
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [checkingSession, setCheckingSession] = useState(true);
+  const [sessionError, setSessionError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ResetPasswordFormData>({
+    resolver: zodResolver(resetPasswordSchema),
+    mode: 'onBlur',
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const initialiseSession = async () => {
+      setCheckingSession(true);
+
+      try {
+        const hash = typeof window !== 'undefined' ? window.location.hash : '';
+
+        if (hash.includes('type=recovery')) {
+          const { error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
+          if (error) {
+            if (!isMounted) {
+              return;
+            }
+            setSessionError(
+              'This password reset link is invalid or has expired. Please request a new one.',
+            );
+            setCheckingSession(false);
+            return;
+          }
+
+          if (typeof window !== 'undefined') {
+            const url = new URL(window.location.href);
+            url.hash = '';
+            window.history.replaceState({}, document.title, url.toString());
+          }
+        }
+
+        const { data, error } = await supabase.auth.getUser();
+        if (!isMounted) {
+          return;
+        }
+
+        if (error || !data?.user) {
+          setSessionError('We could not validate your session. Please request a new reset link.');
+          setCheckingSession(false);
+          return;
+        }
+
+        setSessionError(null);
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+        setSessionError('Something went wrong while preparing your password reset. Please try again.');
+      } finally {
+        if (isMounted) {
+          setCheckingSession(false);
+        }
+      }
+    };
+
+    initialiseSession();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [location]);
+
+  useEffect(() => {
+    if (!success) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      navigate('/signin');
+    }, 3000);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [success, navigate]);
+
+  const onSubmit = handleSubmit(async ({ password }) => {
+    setSubmitting(true);
+    setSessionError(null);
+
+    try {
+      const { error } = await userService.updatePassword(password);
+
+      if (error) {
+        const message = error.message || 'We could not update your password. Please try again.';
+        setSessionError(message);
+        toast({
+          variant: 'destructive',
+          title: 'Password update failed',
+          description: message,
+        });
+        return;
+      }
+
+      reset();
+      setSuccess(true);
+      toast({
+        title: 'Password updated',
+        description: 'Your password has been changed successfully. Redirecting to sign in…',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  });
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-white to-orange-50 py-16 px-4">
+      <div className="mx-auto w-full max-w-md">
+        <Card className="shadow-xl border border-emerald-100">
+          <CardHeader className="space-y-2 text-center">
+            <CardTitle className="text-3xl font-bold text-gray-900">Reset Password</CardTitle>
+            <CardDescription className="text-gray-600">
+              Create a new password for your account.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {checkingSession ? (
+              <div className="flex flex-col items-center justify-center gap-4 py-10 text-gray-600">
+                <Loader2 className="h-8 w-8 animate-spin" aria-hidden="true" />
+                <p>Preparing your password reset…</p>
+              </div>
+            ) : success ? (
+              <div className="space-y-6 text-center">
+                <div className="flex justify-center">
+                  <CheckCircle className="h-12 w-12 text-emerald-500" aria-hidden="true" />
+                </div>
+                <div className="space-y-2">
+                  <h2 className="text-xl font-semibold text-gray-900">Password updated</h2>
+                  <p className="text-gray-600">
+                    You will be redirected to the sign in page. If nothing happens, click the button below.
+                  </p>
+                </div>
+                <Button asChild className="w-full">
+                  <Link to="/signin">Go to sign in</Link>
+                </Button>
+              </div>
+            ) : (
+              <form onSubmit={onSubmit} className="space-y-6">
+                {sessionError && (
+                  <Alert variant="destructive">
+                    <AlertDescription>{sessionError}</AlertDescription>
+                  </Alert>
+                )}
+
+                <div className="space-y-2">
+                  <Label htmlFor="password" className="text-left text-gray-700 font-medium">
+                    New password
+                  </Label>
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" aria-hidden="true" />
+                    <Input
+                      id="password"
+                      type="password"
+                      autoComplete="new-password"
+                      placeholder="Enter a new password"
+                      {...register('password')}
+                      className={`pl-10 border-emerald-200 focus:border-emerald-400 focus:ring-emerald-400 ${
+                        errors.password ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
+                      }`}
+                      aria-invalid={errors.password ? 'true' : 'false'}
+                    />
+                  </div>
+                  {errors.password && (
+                    <p className="text-sm text-red-600" role="alert">
+                      {errors.password.message}
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="confirmPassword" className="text-left text-gray-700 font-medium">
+                    Confirm password
+                  </Label>
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" aria-hidden="true" />
+                    <Input
+                      id="confirmPassword"
+                      type="password"
+                      autoComplete="new-password"
+                      placeholder="Re-enter your new password"
+                      {...register('confirmPassword')}
+                      className={`pl-10 border-emerald-200 focus:border-emerald-400 focus:ring-emerald-400 ${
+                        errors.confirmPassword ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
+                      }`}
+                      aria-invalid={errors.confirmPassword ? 'true' : 'false'}
+                    />
+                  </div>
+                  {errors.confirmPassword && (
+                    <p className="text-sm text-red-600" role="alert">
+                      {errors.confirmPassword.message}
+                    </p>
+                  )}
+                </div>
+
+                <Button
+                  type="submit"
+                  className="w-full bg-gradient-to-r from-emerald-600 to-orange-600 hover:from-emerald-700 hover:to-orange-700 text-white py-3"
+                  disabled={submitting || !!sessionError}
+                >
+                  {submitting ? 'Updating password…' : 'Update password'}
+                </Button>
+
+                <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
+                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                  <Link to="/signin" className="font-medium text-orange-600 hover:text-orange-700">
+                    Back to sign in
+                  </Link>
+                </div>
+
+                {!sessionError && (
+                  <p className="text-xs text-gray-500 text-center">
+                    Passwords must be at least 8 characters long and include a mix of letters and numbers.
+                  </p>
+                )}
+              </form>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
## Summary
- add dedicated pages for requesting and completing password resets using Supabase auth
- extend the user service to send password reset links and update passwords with improved redirect handling
- register the new routes and update routing tests to cover them

## Testing
- npm test -- --runTestsByPath src/__tests__/AppRoutes.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d87f1bae08328a39f829ec92df961)