### PR TITLE
Handle Supabase RLS errors during profile creation

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -550,8 +550,10 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         const profileErrorCode = (profileError as any)?.code;
         const isAuthPending = profileErrorCode === 'PGRST301' ||
           profileErrorCode === '401' ||
+          profileErrorCode === '42501' ||
           message.includes('jwt') ||
-          message.includes('unauthorized');
+          message.includes('unauthorized') ||
+          message.includes('row-level security');
 
         if (!isAuthPending) {
           let profileErrorMessage = 'Failed to create user profile';


### PR DESCRIPTION
## Summary
- treat Supabase row-level security violations as pending authentication during profile creation
- prevent the signup flow from surfacing a false "Failed to create user profile" error when RLS temporarily blocks inserts

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8acd22308328b46686dacfe2c320)