### PR TITLE
feat: add guided account type selection to sign-up

### DIFF
--- a/src/components/AccountTypeSelection.tsx
+++ b/src/components/AccountTypeSelection.tsx
@@ -1,0 +1,100 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CheckCircle2 } from 'lucide-react';
+import type { AccountTypeDefinition } from '@/data/accountTypes';
+
+interface AccountTypeSelectionProps {
+  options: AccountTypeDefinition[];
+  selected?: string;
+  onSelect: (value: string) => void;
+}
+
+export const AccountTypeSelection = ({ options, selected, onSelect }: AccountTypeSelectionProps) => {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-gray-600">
+        Choose the account type that matches your role so we can tailor the onboarding experience and forms for you.
+      </p>
+      <div className="grid gap-4 md:grid-cols-2">
+        {options.map((option) => {
+          const Icon = option.icon;
+          const isSelected = option.value === selected;
+
+          return (
+            <button
+              type="button"
+              key={option.value}
+              onClick={() => onSelect(option.value)}
+              className="w-full text-left focus:outline-none"
+              aria-pressed={isSelected}
+              aria-label={`Select ${option.label} account type`}
+            >
+              <Card
+                className={
+                  `h-full transition-shadow ${
+                    isSelected
+                      ? 'border-blue-500 shadow-lg ring-2 ring-blue-200'
+                      : 'hover:border-blue-300 hover:shadow-md'
+                  }`
+                }
+              >
+                <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+                  <div className="flex items-start gap-3">
+                    <div
+                      className={`rounded-md p-2 ${
+                        isSelected ? 'bg-blue-600 text-white' : 'bg-blue-50 text-blue-600'
+                      }`}
+                    >
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <div>
+                      <CardTitle className="text-lg">{option.label}</CardTitle>
+                      <CardDescription className="mt-1 text-sm text-gray-600">
+                        {option.description}
+                      </CardDescription>
+                    </div>
+                  </div>
+                  {isSelected && (
+                    <Badge variant="secondary" className="border-blue-200 bg-blue-100 text-blue-700">
+                      Selected
+                    </Badge>
+                  )}
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Ideal for</p>
+                    <ul className="mt-2 space-y-2 text-sm text-gray-600">
+                      {option.idealFor.map((item) => (
+                        <li key={item} className="flex items-start gap-2">
+                          <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-500" />
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                      Onboarding focus
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {option.onboardingFocus.map((focus) => (
+                        <Badge
+                          key={focus}
+                          variant="outline"
+                          className={isSelected ? 'border-blue-200 text-blue-700' : ''}
+                        >
+                          {focus}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+

--- a/src/data/accountTypes.ts
+++ b/src/data/accountTypes.ts
@@ -1,0 +1,95 @@
+import type { LucideIcon } from 'lucide-react';
+import { User, Users, Building, TrendingUp, Heart, Landmark } from 'lucide-react';
+
+export type AccountTypeValue =
+  | 'sole_proprietor'
+  | 'professional'
+  | 'sme'
+  | 'investor'
+  | 'donor'
+  | 'government';
+
+export interface AccountTypeDefinition {
+  value: AccountTypeValue;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  idealFor: string[];
+  onboardingFocus: string[];
+}
+
+export const accountTypes: AccountTypeDefinition[] = [
+  {
+    value: 'sole_proprietor',
+    label: 'Sole Proprietor',
+    description: 'For individual entrepreneurs and micro businesses building their first digital presence.',
+    icon: User,
+    idealFor: [
+      'Freelancers and independent consultants',
+      'Market vendors and small retail businesses',
+      'Founders testing new products or services'
+    ],
+    onboardingFocus: ['Business profile', 'Mobile money payments', 'Marketplace listing']
+  },
+  {
+    value: 'professional',
+    label: 'Professional',
+    description: 'Ideal for specialists offering professional services and looking to showcase expertise.',
+    icon: Users,
+    idealFor: [
+      'Consultants and subject matter experts',
+      'Creative professionals and agencies',
+      'Advisors and technical service providers'
+    ],
+    onboardingFocus: ['Portfolio & credentials', 'Client services', 'Skills directory']
+  },
+  {
+    value: 'sme',
+    label: 'SME (Small & Medium Enterprise)',
+    description: 'Comprehensive tools for established businesses preparing to scale operations.',
+    icon: Building,
+    idealFor: [
+      'Registered companies with growing teams',
+      'Businesses expanding into new markets',
+      'Firms seeking investment or partnerships'
+    ],
+    onboardingFocus: ['Company structure', 'Team & operations', 'Funding readiness']
+  },
+  {
+    value: 'investor',
+    label: 'Investor',
+    description: 'Built for funds and angels sourcing quality deals and managing portfolios.',
+    icon: TrendingUp,
+    idealFor: [
+      'Angel investors and syndicates',
+      'Impact and venture funds',
+      'Corporate innovation teams'
+    ],
+    onboardingFocus: ['Ticket sizes', 'Sector focus', 'Support services']
+  },
+  {
+    value: 'donor',
+    label: 'Donor',
+    description: 'Purpose-built for grant makers and development partners tracking outcomes.',
+    icon: Heart,
+    idealFor: [
+      'Foundations and philanthropic funds',
+      'CSR and corporate giving teams',
+      'International development partners'
+    ],
+    onboardingFocus: ['Program focus', 'Funding priorities', 'Impact metrics']
+  },
+  {
+    value: 'government',
+    label: 'Government Institution',
+    description: 'Enterprise workflows for public sector agencies supporting MSMEs.',
+    icon: Landmark,
+    idealFor: [
+      'Ministries and public agencies',
+      'State-owned enterprises',
+      'Economic development programs'
+    ],
+    onboardingFocus: ['Institution profile', 'Key programs', 'Partnership needs']
+  }
+];
+

--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -14,6 +14,8 @@ import { useAppContext } from '@/contexts/AppContext';
 import { validatePhoneNumber } from '@/lib/payment-config';
 import { registerUser } from '@/lib/api/register-user';
 import { toast } from '@/components/ui/use-toast';
+import { AccountTypeSelection } from '@/components/AccountTypeSelection';
+import { accountTypes } from '@/data/accountTypes';
 
 // Validation schema
 const getStartedSchema = z
@@ -67,6 +69,8 @@ export const GetStarted = () => {
     register,
     handleSubmit,
     control,
+    setValue,
+    watch,
     formState: { errors, isValid },
   } = useForm<GetStartedFormData>({
     resolver: zodResolver(getStartedSchema),
@@ -83,6 +87,12 @@ export const GetStarted = () => {
       agreeToTerms: false,
     },
   });
+
+  const selectedAccountType = watch('accountType');
+
+  const handleAccountTypeSelect = (value: string) => {
+    setValue('accountType', value, { shouldValidate: true, shouldDirty: true });
+  };
 
   const onSubmit = async (data: GetStartedFormData) => {
     setLoading(true);
@@ -254,30 +264,42 @@ export const GetStarted = () => {
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="accountType">Account Type</Label>
-            <Controller
-              name="accountType"
-              control={control}
-              render={({ field }) => (
-                <Select onValueChange={field.onChange} value={field.value}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select account type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="sole_proprietor">Sole Proprietor</SelectItem>
-                    <SelectItem value="professional">Professional</SelectItem>
-                    <SelectItem value="sme">Small & Medium Enterprise</SelectItem>
-                    <SelectItem value="investor">Investor</SelectItem>
-                    <SelectItem value="donor">Donor</SelectItem>
-                    <SelectItem value="government">Government Institution</SelectItem>
-                  </SelectContent>
-                </Select>
+          <div className="space-y-4">
+            <div>
+              <Label>Account Type</Label>
+              <AccountTypeSelection
+                options={accountTypes}
+                selected={selectedAccountType}
+                onSelect={handleAccountTypeSelect}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="accountType">Account Type (Dropdown)</Label>
+              <Controller
+                name="accountType"
+                control={control}
+                render={({ field }) => (
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <SelectTrigger id="accountType">
+                      <SelectValue placeholder="Select account type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {accountTypes.map((type) => (
+                        <SelectItem key={type.value} value={type.value}>
+                          {type.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              <p className="text-xs text-gray-500">
+                Prefer using the keyboard? Pick your account type from this accessible dropdown.
+              </p>
+              {errors.accountType && (
+                <p className="text-sm text-red-600 mt-1">{errors.accountType.message}</p>
               )}
-            />
-            {errors.accountType && (
-              <p className="text-sm text-red-600 mt-1">{errors.accountType.message}</p>
-            )}
+            </div>
           </div>
 
           <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- add structured metadata for each account type to drive onboarding copy
- build an accessible AccountTypeSelection component that highlights the chosen user type
- enhance the Get Started sign-up form with guided account type cards while keeping the dropdown control

## Testing
- npm test -- GetStarted

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8d6519d48328a5147711545261ad)