### PR TITLE
Make homepage sections semi-transparent

### DIFF
--- a/src/components/MarketplacePreview.tsx
+++ b/src/components/MarketplacePreview.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 
 const MarketplacePreview = () => {
   return (
-    <section className="py-16 px-6 bg-white">
+    <section className="py-16 px-6 bg-white/60 backdrop-blur-sm">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-12">
           <Badge className="mb-4 bg-emerald-100 text-emerald-800 border-emerald-300">

--- a/src/components/ServicesGrid.tsx
+++ b/src/components/ServicesGrid.tsx
@@ -48,7 +48,7 @@ const services = [
 
 const ServicesGrid = () => {
   return (
-    <section className="py-16 px-6 bg-gray-50">
+    <section className="py-16 px-6 bg-white/60 backdrop-blur-sm">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-12">
           <Badge className="mb-4 bg-blue-100 text-blue-800 border-blue-300">

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -176,8 +176,8 @@ const StatsSection = () => {
   ];
 
   return (
-    <section className="py-16 bg-gradient-to-r from-orange-50 to-green-50">
-      <div className="max-w-7xl mx-auto px-6">
+    <section className="py-16 px-6 bg-white/60 backdrop-blur-sm">
+      <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">
             Our Impact & Growth

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -44,7 +44,7 @@ const TestimonialsSection = () => {
   };
 
   return (
-    <section className="py-16 px-6 bg-gradient-to-br from-blue-50 to-emerald-50">
+    <section className="py-16 px-6 bg-white/60 backdrop-blur-sm">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-12">
           <Badge className="mb-4 bg-amber-100 text-amber-800 border-amber-300">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,7 +13,7 @@ const Index: React.FC = () => {
 
   return (
     <AppLayout>
-      <div className="relative min-h-screen bg-gray-50">
+      <div className="relative min-h-screen bg-white/50 backdrop-blur-sm">
         <div
           aria-hidden="true"
           className="fixed inset-0 bg-center bg-cover"
@@ -24,7 +24,7 @@ const Index: React.FC = () => {
         />
         <div
           aria-hidden="true"
-          className="absolute inset-0 bg-gradient-to-r from-blue-600/70 to-emerald-600/70"
+          className="absolute inset-0 bg-gradient-to-r from-blue-600/50 to-emerald-600/50"
         />
         <div className="relative z-10">
           <HeroSection />


### PR DESCRIPTION
## Summary
- make the homepage backdrop semi-transparent so the hero background image remains visible
- update homepage sections to use translucent surfaces for consistency

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d94c171648328b87c5cbba2e01921)