### PR TITLE
Adjust homepage background image scaling

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -16,10 +16,11 @@ const Index: React.FC = () => {
       <div className="relative min-h-screen bg-white/50 backdrop-blur-sm">
         <div
           aria-hidden="true"
-          className="fixed inset-0 bg-center bg-cover"
+          className="fixed inset-0 bg-center bg-no-repeat"
           style={{
             backgroundImage:
               "url('/images/ChatGPT%20Image%20Sep%2023%2C%202025%2C%2001_52_19%20PM.png')",
+            backgroundSize: 'contain',
           }}
         />
         <div


### PR DESCRIPTION
## Summary
- update the homepage background container to prevent cropping and keep most of the image visible by using contain sizing
- disable image repetition while maintaining the gradient overlay

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d981237848328a0129bdb06448778)