### PR TITLE
feat: generate marketplace services from professional signups

### DIFF
--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -6,13 +6,13 @@ import { createClient } from '@supabase/supabase-js';
 import type { MarketplaceService } from '@/data/marketplace';
 import {
   marketplaceProducts as datasetProducts,
-  marketplaceServices as datasetServices,
   filterServicesByControls,
   runMarketplaceSearch,
   buildMarketplaceRecommendations,
   generatePricingAnalysis,
   generateAssistantResponse,
-  generateProfessionalMatches
+  generateProfessionalMatches,
+  getMarketplaceCatalog
 } from '@/data/marketplace';
 
 type SupabaseClientLike = ReturnType<typeof createClient> | ReturnType<typeof createMockSupabaseClient>;
@@ -145,7 +145,7 @@ const createMockAuthUser = (overrides: Partial<MockAuthUser> = {}): MockAuthUser
 };
 
 function createMockSupabaseClient() {
-  const mockData: Record<string, any[]> = {
+  const mockData: Record<string, any> = {
     user_subscriptions: [
       {
         id: 'sub_mock_active',
@@ -175,8 +175,12 @@ function createMockSupabaseClient() {
       }
     ],
     marketplace_orders: [],
-    marketplace_services: datasetServices.map(service => ({ ...service })),
-    marketplace_products: datasetProducts.map(product => ({ ...product })),
+    get marketplace_services() {
+      return getMarketplaceCatalog();
+    },
+    get marketplace_products() {
+      return datasetProducts.map(product => ({ ...product }));
+    },
     transactions: [
       {
         id: 'txn_mock_recent',

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -21,7 +21,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import { PaymentWithNegotiation } from '@/components/PaymentWithNegotiation';
 import {
   marketplaceProducts as fallbackProducts,
-  marketplaceServices,
+  getMarketplaceCatalog,
   type MarketplaceProduct,
   type MarketplaceService,
   runMarketplaceSearch
@@ -207,7 +207,8 @@ const Marketplace = () => {
         handleViewDetails(match);
       }
     } else if (recommendation?.type === 'service') {
-      const match = marketplaceServices.find(service => service.id === recommendation.id);
+      const catalog = getMarketplaceCatalog();
+      const match = catalog.find(service => service.id === recommendation.id);
       if (match) {
         setActiveTab('integrated');
         handleOrderServiceNow(match);


### PR DESCRIPTION
## Summary
- build the marketplace catalog dynamically by generating services from professional assessments and merging them with the curated fallback data
- update the marketplace loader and mock supabase client to fetch professional profiles, register dynamic services, and keep AI search and recommendations aligned
- ensure recommendation selections look up services from the combined catalog when opening details or checkout flows

## Testing
- npm run lint
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d9fc1ddb08328b638e8ff893e7733)