### PR TITLE
Set default registration API base URL for dev

### DIFF
--- a/src/lib/api/register-user.ts
+++ b/src/lib/api/register-user.ts
@@ -5,7 +5,11 @@ const normalizeBaseUrl = (baseUrl: string | undefined) => {
 
 const API_TIMEOUT_MS = 15000;
 
-const API_BASE_URL = normalizeBaseUrl(import.meta.env.VITE_API_BASE_URL);
+const DEFAULT_DEV_API_BASE_URL = import.meta.env.DEV ? 'http://localhost:3000' : undefined;
+
+const API_BASE_URL = normalizeBaseUrl(
+  import.meta.env.VITE_API_BASE_URL ?? DEFAULT_DEV_API_BASE_URL,
+);
 
 export type RegisterUserPayload = {
   firstName: string;


### PR DESCRIPTION
## Summary
- default the registration API base URL to http://localhost:3000 during development when VITE_API_BASE_URL is not set

## Testing
- npm run test:jest -- SignUp *(fails: Type 'false' is not assignable to type 'true')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc6171f1c832883940ece61507c2f)