### PR TITLE
Improve authentication flows

### DIFF
--- a/src/lib/api/register-user.ts
+++ b/src/lib/api/register-user.ts
@@ -97,19 +97,57 @@ export const registerUser = async (
     clearTimeout(timeoutId);
   }
 
-  let data: unknown;
-  try {
-    data = await response.json();
-  } catch (error) {
-    if (!response.ok) {
-      throw new Error('Failed to register user with backend');
+  const contentType = response.headers.get('content-type') ?? '';
+  const contentLength = response.headers.get('content-length');
+  const isEmptyBody =
+    response.status === 204 ||
+    response.status === 205 ||
+    (contentLength !== null && Number(contentLength) === 0);
+
+  let data: unknown = null;
+
+  if (!isEmptyBody) {
+    const isJson = contentType.includes('application/json');
+    try {
+      if (isJson) {
+        data = await response.json();
+      } else {
+        const raw = await response.text();
+        if (raw) {
+          try {
+            data = JSON.parse(raw);
+          } catch {
+            data = raw;
+          }
+        }
+      }
+    } catch (error) {
+      if (!response.ok) {
+        throw new Error('Failed to register user with backend');
+      }
+
+      console.warn('[register-user] Unable to parse registration response:', error);
     }
-    throw error;
   }
 
   if (!response.ok) {
     const errorMessage = extractErrorMessage(data) || 'Failed to register user with backend';
     throw new Error(errorMessage);
+  }
+
+  if (!data || typeof data !== 'object') {
+    return {
+      user: {
+        id: 'pending-registration',
+        firstName: payload.firstName,
+        lastName: payload.lastName,
+        email: payload.email,
+        accountType: payload.accountType,
+        company: payload.company ?? null,
+        mobileNumber: payload.mobileNumber ?? null,
+        registeredAt: new Date().toISOString(),
+      },
+    } satisfies RegisterUserResponse;
   }
 
   return data as RegisterUserResponse;

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -315,7 +315,10 @@ export class UserService extends BaseService<User> {
     return withErrorHandling(
       async () => {
         try {
-          const offlineAccount = getOfflineAccount(email, password);
+          const trimmedEmail = (email || '').trim();
+          const resolvedEmail = normaliseEmail(trimmedEmail) || trimmedEmail;
+
+          const offlineAccount = getOfflineAccount(resolvedEmail, password);
 
           if (offlineAccount) {
             return {
@@ -325,7 +328,7 @@ export class UserService extends BaseService<User> {
           }
 
           const { data, error } = await supabase.auth.signInWithPassword({
-            email,
+            email: resolvedEmail,
             password,
           });
 
@@ -372,9 +375,11 @@ export class UserService extends BaseService<User> {
       async () => {
         try {
           const emailRedirectTo = getEmailRedirectTo();
+          const trimmedEmail = (email || '').trim();
+          const resolvedEmail = normaliseEmail(trimmedEmail) || trimmedEmail;
 
           const { error } = await supabase.auth.signInWithOtp({
-            email,
+            email: resolvedEmail,
             options: {
               shouldCreateUser: false,
               ...(emailRedirectTo ? { emailRedirectTo } : {}),
@@ -415,8 +420,10 @@ export class UserService extends BaseService<User> {
     return withErrorHandling(
       async () => {
         try {
+          const trimmedEmail = (email || '').trim();
+          const resolvedEmail = normaliseEmail(trimmedEmail) || trimmedEmail;
           const { data, error } = await supabase.auth.verifyOtp({
-            email,
+            email: resolvedEmail,
             token,
             type: 'email',
           });
@@ -469,6 +476,8 @@ export class UserService extends BaseService<User> {
       async () => {
         try {
           const emailRedirectTo = getEmailRedirectTo();
+          const trimmedEmail = (email || '').trim();
+          const resolvedEmail = normaliseEmail(trimmedEmail) || trimmedEmail;
 
           const signUpOptions: { data?: Record<string, any>; emailRedirectTo?: string } = {};
 
@@ -481,7 +490,7 @@ export class UserService extends BaseService<User> {
           }
 
           const signUpPayload = {
-            email,
+            email: resolvedEmail,
             password,
             ...(Object.keys(signUpOptions).length ? { options: signUpOptions } : {}),
           };
@@ -524,7 +533,8 @@ export class UserService extends BaseService<User> {
     return withErrorHandling(
       async () => {
         try {
-          const normalizedEmail = normaliseEmail(email);
+          const trimmedEmail = (email || '').trim();
+          const normalizedEmail = normaliseEmail(trimmedEmail);
           const offlineAccount = offlineAccounts.find(
             account => normaliseEmail(account.email) === normalizedEmail
           );
@@ -535,7 +545,7 @@ export class UserService extends BaseService<User> {
 
           const emailRedirectTo = getEmailRedirectTo('/reset-password');
 
-          const { error } = await supabase.auth.resetPasswordForEmail(email, {
+          const { error } = await supabase.auth.resetPasswordForEmail(normalizedEmail || trimmedEmail, {
             ...(emailRedirectTo ? { redirectTo: emailRedirectTo } : {}),
           });
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -16,6 +16,7 @@ import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp
 const signInSchema = z.object({
   email: z
     .string()
+    .trim()
     .min(1, 'Email is required')
     .email('Please enter a valid email address'),
   password: z
@@ -68,7 +69,8 @@ const SignIn = () => {
     setOtpError('');
 
     try {
-      const result = await initiateSignIn(data.email, data.password);
+      const normalizedEmail = data.email.trim();
+      const result = await initiateSignIn(normalizedEmail, data.password);
 
       if (result.offlineState) {
         reset();
@@ -76,7 +78,7 @@ const SignIn = () => {
         return;
       }
 
-      setPendingEmail(data.email);
+      setPendingEmail(normalizedEmail);
       setStep('otp');
       setOtpCode('');
       setResendCountdown(30);


### PR DESCRIPTION
## Summary
- normalise email inputs across sign-in, OTP, sign-up, and password reset paths so Supabase receives trimmed addresses
- trim sign-in form emails before submission and display to keep the OTP step in sync
- make registration API helper resilient to empty or non-JSON responses so successful sign-ups are not treated as failures

## Testing
- npm test -- SignIn.test.tsx
- npm test -- SignUp.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f20a09e6483289a79a159fc51aca3)