### PR TITLE
Align Get Started flow with profile onboarding

### DIFF
--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { Mail, Lock, Eye, EyeOff, Building2, Phone, UserRound } from 'lucide-react';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -51,17 +51,26 @@ export type SignUpFormData = z.infer<typeof signUpSchema>;
 
 export const SignUp = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { signUp } = useAppContext();
   const { toast } = useToast();
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  const preselectedAccountType = (() => {
+    const paramValue = searchParams.get('accountType');
+    if (!paramValue) return undefined;
+
+    return accountTypes.find(({ value }) => value === paramValue)?.value;
+  })();
+
   const {
     register,
     control,
     handleSubmit,
     formState: { errors, isSubmitting, isValid },
+    setValue,
   } = useForm<SignUpFormData>({
     resolver: zodResolver(signUpSchema),
     mode: 'onChange',
@@ -75,8 +84,15 @@ export const SignUp = () => {
       company: '',
       mobileNumber: '',
       termsAccepted: false,
+      ...(preselectedAccountType ? { accountType: preselectedAccountType } : {}),
     },
   });
+
+  useEffect(() => {
+    if (preselectedAccountType) {
+      setValue('accountType', preselectedAccountType);
+    }
+  }, [preselectedAccountType, setValue]);
 
   const onSubmit = handleSubmit(async values => {
     setSubmitError(null);

--- a/src/pages/__tests__/GetStarted.test.tsx
+++ b/src/pages/__tests__/GetStarted.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { GetStarted } from '../GetStarted';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockUseAppContext = jest.fn();
+
+jest.mock('@/contexts/AppContext', () => ({
+  useAppContext: () => mockUseAppContext(),
+}));
+
+describe('GetStarted navigation flows', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockUseAppContext.mockReset();
+  });
+
+  it('redirects unauthenticated users to the signup flow with the selected account type', () => {
+    mockUseAppContext.mockReturnValue({ user: null, profile: null });
+
+    render(
+      <MemoryRouter>
+        <GetStarted />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /start as sole proprietor/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/signup?accountType=sole_proprietor');
+  });
+
+  it('sends authenticated users without completed profiles to profile setup', () => {
+    mockUseAppContext.mockReturnValue({
+      user: { id: 'user-1', profile_completed: false },
+      profile: { account_type: 'professional', profile_completed: false },
+    });
+
+    render(
+      <MemoryRouter>
+        <GetStarted />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /start as professional/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/profile-setup?accountType=professional');
+  });
+
+  it('re-routes users with completed profiles for a different account type to profile setup in edit mode', () => {
+    mockUseAppContext.mockReturnValue({
+      user: { id: 'user-1', profile_completed: true },
+      profile: { account_type: 'sme', profile_completed: true },
+    });
+
+    render(
+      <MemoryRouter>
+        <GetStarted />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /start as investor/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/profile-setup?accountType=investor&mode=edit');
+  });
+
+  it('directs users with completed matching profiles to the appropriate assessment route', () => {
+    mockUseAppContext.mockReturnValue({
+      user: { id: 'user-2', profile_completed: true },
+      profile: { account_type: 'investor', profile_completed: true },
+    });
+
+    render(
+      <MemoryRouter>
+        <GetStarted />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /start as investor/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/investor-assessment');
+  });
+});
+


### PR DESCRIPTION
## Summary
- update the Get Started page to route visitors to signup, profile setup, or the correct assessment based on their account type and profile status
- allow profile setup and signup flows to honour accountType query parameters so forms open pre-selected for production onboarding
- cover the new navigation logic with unit tests

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110a59d0fc8328848b49d59e99ab0d)