### PR TITLE
Add webhook_logs table schema

### DIFF
--- a/backend/supabase/provision.sh
+++ b/backend/supabase/provision.sh
@@ -7,6 +7,7 @@ SQL_FILES=(
   "profiles_schema.sql"
   "registrations.sql"
   "frontend_logs.sql"
+  "webhook_logs.sql"
   "profiles_policies.sql"
 )
 

--- a/backend/supabase/webhook_logs.sql
+++ b/backend/supabase/webhook_logs.sql
@@ -1,0 +1,21 @@
+-- Stores raw webhook payloads received from external providers like Lenco.
+create table if not exists public.webhook_logs (
+  id bigserial primary key,
+  source text not null default 'lenco',
+  event text,
+  payload jsonb,
+  http_status integer,
+  error text,
+  received_at timestamptz not null default now()
+);
+
+create index if not exists webhook_logs_received_at_idx on public.webhook_logs (received_at desc);
+create index if not exists webhook_logs_source_idx on public.webhook_logs (source);
+
+alter table public.webhook_logs enable row level security;
+
+create policy if not exists "webhook_logs_service_insert"
+  on public.webhook_logs
+  for insert
+  to service_role
+  with check (true);

--- a/scripts/provision-supabase.sh
+++ b/scripts/provision-supabase.sh
@@ -36,6 +36,7 @@ SQL_FILES=(
   "profiles_schema.sql"
   "registrations.sql"
   "frontend_logs.sql"
+  "webhook_logs.sql"
   "profiles_policies.sql"
 )
 


### PR DESCRIPTION
## Summary
- add a Supabase schema file for the webhook_logs table with indices and an insert policy for the service role
- update provisioning scripts so the new schema is applied alongside existing database scripts

## Testing
- not run (SQL schema change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691118c2701c83289ef47e4f09fd09f9)