### PR TITLE
Align Lenco payments validator with signature header

### DIFF
--- a/supabase/functions/lenco-payments-validator/index.ts
+++ b/supabase/functions/lenco-payments-validator/index.ts
@@ -10,7 +10,7 @@ const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 
 Deno.serve(async (req) => {
-  const incomingSecret = req.headers.get("x-lenco-secret");
+  const incomingSecret = req.headers.get("x-lenco-signature");
 
   // Simple auth check
   if (incomingSecret !== EXPECTED_SECRET) {
@@ -18,7 +18,7 @@ Deno.serve(async (req) => {
       {
         ok: false,
         error: "unauthorized",
-        reason: "x-lenco-secret header is missing or incorrect",
+        reason: "x-lenco-signature header is missing or incorrect",
       },
       401,
     );


### PR DESCRIPTION
## Summary
- update the Lenco payments validator edge function to read the `x-lenco-signature` header
- adjust the unauthorized response message to reflect the new header name

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69119b013cc88328853662e4f9aa5de7)