### PR TITLE
refactor: harden environment configuration guard

### DIFF
--- a/docs/ENVIRONMENT_CONFIGURATION.md
+++ b/docs/ENVIRONMENT_CONFIGURATION.md
@@ -1,0 +1,111 @@
+# Environment configuration for WATHACI CONNECT
+
+The application now exposes a single, canonical configuration surface for the frontend (Vite) build, runtime hosting environments (e.g. Vercel), and Supabase Edge Functions. This document explains which variables are required, how the readiness guard evaluates them, and how to provision both frontend and backend secrets.
+
+## 1. Canonical environment variables
+
+| Purpose | Canonical key | Accepted aliases | Notes |
+| --- | --- | --- | --- |
+| Supabase project URL | `VITE_SUPABASE_URL` | `VITE_SUPABASE_PROJECT_URL`, `SUPABASE_URL`, `SUPABASE_PROJECT_URL` | Required for any deployment. |
+| Supabase anon/public key | `VITE_SUPABASE_ANON_KEY` | `VITE_SUPABASE_KEY`, `SUPABASE_ANON_KEY`, `SUPABASE_KEY` | Required for any deployment. |
+| Lenco API base URL | `VITE_LENCO_API_URL` | `LENCO_API_URL` | Required when payments are enabled (defaults to production endpoint if omitted). |
+| Lenco public key | `VITE_LENCO_PUBLIC_KEY` | `LENCO_PUBLIC_KEY` | Required (fatal if missing). |
+| Lenco secret key (frontend toggle) | `VITE_LENCO_SECRET_KEY` | `LENCO_SECRET_KEY` | Optional – prefer backend secret when possible. |
+| Lenco webhook destination (frontend awareness) | `VITE_LENCO_WEBHOOK_URL` | `LENCO_WEBHOOK_URL` | Required for launch (fatal if missing). |
+| Payment min amount | `VITE_MIN_PAYMENT_AMOUNT` | `MIN_PAYMENT_AMOUNT` | Optional number. |
+| Payment max amount | `VITE_MAX_PAYMENT_AMOUNT` | `MAX_PAYMENT_AMOUNT` | Optional number. |
+| Platform fee percentage | `VITE_PLATFORM_FEE_PERCENTAGE` | `PLATFORM_FEE_PERCENTAGE` | Optional number. |
+| Payment currency | `VITE_PAYMENT_CURRENCY` | `PAYMENT_CURRENCY` | Defaults to `ZMW`. |
+| Payment country | `VITE_PAYMENT_COUNTRY` | `PAYMENT_COUNTRY` | Defaults to `ZM`. |
+| App environment flag | `VITE_APP_ENV` | — | Optional: `development` \| `production`. |
+
+> ⚠️ Only variables prefixed with `VITE_` are exposed to the browser bundle. Any alias without the prefix is treated as a fallback for compatibility during the readiness check.
+
+## 2. `.env.production` template (frontend build)
+
+Create or update the file `./.env.production` (and optionally `.env` for local development) with the following template:
+
+```env
+# ── Supabase frontend configuration ──────────────────────────────────────
+VITE_SUPABASE_URL="https://<project-ref>.supabase.co"
+VITE_SUPABASE_ANON_KEY="<public-anon-key>"
+
+# ── Lenco payments (browser usage) ───────────────────────────────────────
+VITE_LENCO_API_URL="https://api.lenco.co/access/v2"
+VITE_LENCO_PUBLIC_KEY="<pk_live_or_pk_test_value>"
+# Optional: expose only if the frontend must call privileged endpoints.
+VITE_LENCO_SECRET_KEY="<sk_live_or_test_value>"
+VITE_LENCO_WEBHOOK_URL="https://<project-ref>.supabase.co/functions/v1/lenco-payments-validator"
+
+# ── Payment limits and display settings ───────────────────────────────────
+VITE_MIN_PAYMENT_AMOUNT="20"
+VITE_MAX_PAYMENT_AMOUNT="10000"
+VITE_PLATFORM_FEE_PERCENTAGE="5"
+VITE_PAYMENT_CURRENCY="ZMW"
+VITE_PAYMENT_COUNTRY="ZM"
+
+# ── Environment tags ─────────────────────────────────────────────────────
+# (used to switch between production/test payment credentials)
+VITE_APP_ENV="production"
+```
+
+### Notes
+
+1. **Frontend builds** (`npm run build`) read from `.env.production` by default. Add the same keys to `.env` (without the `.production` suffix) for local development if desired.
+2. **Hosting providers (Vercel, Netlify, Render, etc.)**: define the same `VITE_*` variables in the project’s environment settings. Vercel instructions:
+   - Navigate to *Project Settings → Environment Variables*.
+   - Add each key from the table above under the *Production* environment.
+   - Redeploy the project so that the build picks up the new values.
+3. If you change any variable, trigger a new production build. Hot-swapping runtime values without rebuilding is not supported.
+
+## 3. Supabase backend secrets (Edge Functions and database jobs)
+
+Supabase Edge Functions and server-side integrations must use service-role credentials and the non-prefixed Lenco secrets. Store them via the Supabase CLI or Dashboard (`Settings → API → Config Variables`).
+
+Example `supabase-prod-secrets.env`:
+
+```env
+# ── Supabase core ────────────────────────────────────────────────────────
+SUPABASE_URL="https://<project-ref>.supabase.co"
+SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+
+# ── Lenco secrets for functions/webhooks ─────────────────────────────────
+LENCO_API_SECRET="<lenco-private-api-key>"
+LENCO_SECRET="<shared-secret-if-required>"
+LENCO_WEBHOOK_URL="https://<project-ref>.supabase.co/functions/v1/lenco-payments-validator"
+LENCO_WEBHOOK_SECRET="<webhook-signing-secret-from-lenco>"
+
+# ── Payment constraints mirrored on the backend (optional) ───────────────
+MIN_PAYMENT_AMOUNT="20"
+MAX_PAYMENT_AMOUNT="10000"
+PLATFORM_FEE_PERCENTAGE="5"
+```
+
+Apply them via the CLI:
+
+```bash
+supabase secrets set --env-file supabase-prod-secrets.env
+```
+
+## 4. Lenco dashboard configuration
+
+1. **Webhook URL**: set the dashboard to `https://<project-ref>.supabase.co/functions/v1/lenco-payments-validator` (or your chosen Supabase Function endpoint).
+2. **Webhook signing secret**: copy the value from Lenco into `LENCO_WEBHOOK_SECRET` (Supabase secret) and surface the URL in the frontend via `VITE_LENCO_WEBHOOK_URL` so the readiness helper confirms it is configured.
+3. **Environment parity**: ensure `VITE_APP_ENV="production"` when using live keys. The readiness check prevents deploying with `pk_test_...` keys while `VITE_APP_ENV` resolves to production.
+
+## 5. How the readiness guard works
+
+- `src/config/appConfig.ts` normalises aliases into the canonical keys, sanitises values, and produces an `AppConfig` snapshot.
+- If either `VITE_SUPABASE_URL` or `VITE_SUPABASE_ANON_KEY` (or their aliases) is missing, the UI renders the **Configuration required before launch** screen with precise instructions.
+- Lenco configuration is validated via `src/lib/payment-config.ts` and `App.tsx`. Missing API URL, public key, or webhook URL is treated as a **blocking issue**; the guard will not allow the UI to render until all are provided.
+- All resolved values are logged once on mount (`[app] Mounted`) to aid debugging.
+
+## 6. Deployment checklist
+
+1. Populate `.env.production` locally (or configure environment variables in your hosting provider).
+2. Populate Supabase secrets with service-role keys and Lenco backend secrets.
+3. Configure the Lenco dashboard webhook to point at your Supabase Edge Function.
+4. Rebuild (`npm run build`) and redeploy.
+5. Verify the landing page renders instead of the configuration guard. If the guard still appears, check the blocking issue list—it mirrors the validation performed during build/runtime.
+
+Keeping frontend and backend variables in sync ensures the readiness helper recognises the deployment as production-ready and prevents accidental launches with missing Supabase or Lenco configuration.

--- a/src/components/ConfigurationError.tsx
+++ b/src/components/ConfigurationError.tsx
@@ -1,4 +1,4 @@
-import type { SupabaseConfigStatus } from "@/lib/supabaseClient";
+import type { SupabaseConfigStatus } from "@/config/appConfig";
 import type { PaymentConfig } from "@/lib/payment-config";
 
 interface ConfigurationErrorProps {
@@ -23,15 +23,14 @@ export const ConfigurationError = ({ supabaseStatus, paymentStatus }: Configurat
     const missingSections: string[] = [];
 
     if (supabaseStatus.missingUrlKeys.length > 0) {
-      missingSections.push(
-        `Supabase URL (${supabaseStatus.missingUrlKeys.join(", ")})`
-      );
+      const aliases = supabaseStatus.aliasUrlKeys.length > 0 ? ` (aliases checked: ${supabaseStatus.aliasUrlKeys.join(", ")})` : "";
+      missingSections.push(`Supabase URL → set ${supabaseStatus.canonicalUrlKey}${aliases}`);
     }
 
     if (supabaseStatus.missingAnonKeys.length > 0) {
-      missingSections.push(
-        `Supabase anon/public key (${supabaseStatus.missingAnonKeys.join(", ")})`
-      );
+      const aliases =
+        supabaseStatus.aliasAnonKeys.length > 0 ? ` (aliases checked: ${supabaseStatus.aliasAnonKeys.join(", ")})` : "";
+      missingSections.push(`Supabase anon/public key → set ${supabaseStatus.canonicalAnonKey}${aliases}`);
     }
 
     if (missingSections.length > 0) {

--- a/src/components/DonateButton.tsx
+++ b/src/components/DonateButton.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useMemo, useState } from "react";
-import { supabaseClient, supabaseConfigStatus } from "@/lib/supabaseClient";
+import { supabaseClient } from "@/lib/supabaseClient";
+import { supabaseConfigStatus } from "@/config/appConfig";
 
 type PaymentMethod = "mobile_money" | "card";
 

--- a/src/components/marketplace/AIAssistant.tsx
+++ b/src/components/marketplace/AIAssistant.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { MessageCircle, Send, Bot, User, X } from 'lucide-react';
 import { supabase } from '@/lib/supabase-enhanced';
 import { generateAssistantResponse } from '@/data/marketplace';
-import { supabaseConfigStatus } from '@/lib/supabaseClient';
+import { supabaseConfigStatus } from '@/config/appConfig';
 
 interface Message {
   id: string;

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -1,0 +1,252 @@
+import type { SupabaseClientOptions } from "@supabase/supabase-js";
+
+export type EnvKey =
+  | "VITE_SUPABASE_URL"
+  | "VITE_SUPABASE_PROJECT_URL"
+  | "SUPABASE_URL"
+  | "SUPABASE_PROJECT_URL"
+  | "VITE_SUPABASE_ANON_KEY"
+  | "VITE_SUPABASE_KEY"
+  | "SUPABASE_ANON_KEY"
+  | "SUPABASE_KEY"
+  | "VITE_LENCO_API_URL"
+  | "LENCO_API_URL"
+  | "VITE_LENCO_PUBLIC_KEY"
+  | "LENCO_PUBLIC_KEY"
+  | "VITE_LENCO_SECRET_KEY"
+  | "LENCO_SECRET_KEY"
+  | "VITE_LENCO_WEBHOOK_URL"
+  | "LENCO_WEBHOOK_URL"
+  | "VITE_MIN_PAYMENT_AMOUNT"
+  | "MIN_PAYMENT_AMOUNT"
+  | "VITE_MAX_PAYMENT_AMOUNT"
+  | "MAX_PAYMENT_AMOUNT"
+  | "VITE_PLATFORM_FEE_PERCENTAGE"
+  | "PLATFORM_FEE_PERCENTAGE"
+  | "VITE_PAYMENT_CURRENCY"
+  | "PAYMENT_CURRENCY"
+  | "VITE_PAYMENT_COUNTRY"
+  | "PAYMENT_COUNTRY"
+  | "VITE_APP_ENV";
+
+interface EnvResolution<K extends EnvKey = EnvKey> {
+  key?: K;
+  value?: string;
+}
+
+const sanitizeEnvValue = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.toLowerCase() === "undefined" || trimmed.toLowerCase() === "null") {
+    return undefined;
+  }
+
+  return trimmed.replace(/^['"`]+|['"`]+$/g, "").trim();
+};
+
+const readEnv = (key: EnvKey): string | undefined => {
+  try {
+    const meta = (Function("return typeof import.meta !== 'undefined' ? import.meta : undefined")() as {
+      env?: Record<string, unknown>;
+    })?.env;
+    const candidate = sanitizeEnvValue(meta?.[key]);
+    if (candidate) {
+      return candidate;
+    }
+  } catch (error) {
+    if (typeof console !== "undefined" && typeof process !== "undefined" && process.env?.NODE_ENV !== "production") {
+      console.warn("[config] Unable to access import.meta for", key, error);
+    }
+  }
+
+  if (typeof process !== "undefined" && process.env) {
+    const candidate = sanitizeEnvValue(process.env[key]);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  if (typeof globalThis !== "undefined") {
+    const candidate = sanitizeEnvValue((globalThis as any)?.__APP_CONFIG__?.[key]);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+};
+
+const resolveEnv = <K extends EnvKey>(keys: readonly K[]): EnvResolution<K> => {
+  for (const key of keys) {
+    const value = readEnv(key);
+    if (value) {
+      return { key, value };
+    }
+  }
+
+  return {};
+};
+
+export interface SupabaseConfigStatus {
+  hasValidConfig: boolean;
+  resolvedUrl?: string;
+  resolvedAnonKey?: string;
+  resolvedUrlKey?: EnvKey;
+  resolvedAnonKeyKey?: EnvKey;
+  missingUrlKeys: EnvKey[];
+  missingAnonKeys: EnvKey[];
+  errorMessage?: string;
+  canonicalUrlKey: "VITE_SUPABASE_URL";
+  canonicalAnonKey: "VITE_SUPABASE_ANON_KEY";
+  aliasUrlKeys: EnvKey[];
+  aliasAnonKeys: EnvKey[];
+  usingFallbackClient: boolean;
+}
+
+export type AppConfig = {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  lencoApiUrl?: string;
+  lencoPublicKey?: string;
+  lencoSecretKey?: string;
+  lencoWebhookUrl?: string;
+  paymentCurrency?: string;
+  paymentCountry?: string;
+  minPaymentAmount?: number;
+  maxPaymentAmount?: number;
+  platformFeePercentage?: number;
+  environment?: string;
+};
+
+const SUPABASE_URL_KEYS = [
+  "VITE_SUPABASE_URL",
+  "VITE_SUPABASE_PROJECT_URL",
+  "SUPABASE_URL",
+  "SUPABASE_PROJECT_URL",
+] as const satisfies readonly EnvKey[];
+
+const SUPABASE_ANON_KEYS = [
+  "VITE_SUPABASE_ANON_KEY",
+  "VITE_SUPABASE_KEY",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_KEY",
+] as const satisfies readonly EnvKey[];
+
+const LENCO_API_URL_KEYS = ["VITE_LENCO_API_URL", "LENCO_API_URL"] as const satisfies readonly EnvKey[];
+const LENCO_PUBLIC_KEY_KEYS = ["VITE_LENCO_PUBLIC_KEY", "LENCO_PUBLIC_KEY"] as const satisfies readonly EnvKey[];
+const LENCO_SECRET_KEY_KEYS = ["VITE_LENCO_SECRET_KEY", "LENCO_SECRET_KEY"] as const satisfies readonly EnvKey[];
+const LENCO_WEBHOOK_URL_KEYS = ["VITE_LENCO_WEBHOOK_URL", "LENCO_WEBHOOK_URL"] as const satisfies readonly EnvKey[];
+const PAYMENT_MIN_KEYS = ["VITE_MIN_PAYMENT_AMOUNT", "MIN_PAYMENT_AMOUNT"] as const satisfies readonly EnvKey[];
+const PAYMENT_MAX_KEYS = ["VITE_MAX_PAYMENT_AMOUNT", "MAX_PAYMENT_AMOUNT"] as const satisfies readonly EnvKey[];
+const PAYMENT_FEE_KEYS = ["VITE_PLATFORM_FEE_PERCENTAGE", "PLATFORM_FEE_PERCENTAGE"] as const satisfies readonly EnvKey[];
+const PAYMENT_CURRENCY_KEYS = ["VITE_PAYMENT_CURRENCY", "PAYMENT_CURRENCY"] as const satisfies readonly EnvKey[];
+const PAYMENT_COUNTRY_KEYS = ["VITE_PAYMENT_COUNTRY", "PAYMENT_COUNTRY"] as const satisfies readonly EnvKey[];
+const ENVIRONMENT_KEYS = ["VITE_APP_ENV"] as const satisfies readonly EnvKey[];
+
+const parseNumber = (value?: string): number | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const supabaseUrlResolution = resolveEnv(SUPABASE_URL_KEYS);
+const supabaseAnonResolution = resolveEnv(SUPABASE_ANON_KEYS);
+
+const missingUrlKeys = supabaseUrlResolution.value ? [] : [...SUPABASE_URL_KEYS];
+const missingAnonKeys = supabaseAnonResolution.value ? [] : [...SUPABASE_ANON_KEYS];
+
+const configErrorMessages: string[] = [];
+
+if (!supabaseUrlResolution.value) {
+  configErrorMessages.push(
+    `Missing Supabase URL. Set ${SUPABASE_URL_KEYS[0]} (aliases checked: ${SUPABASE_URL_KEYS.slice(1).join(", ") || "none"}).`,
+  );
+}
+
+if (!supabaseAnonResolution.value) {
+  configErrorMessages.push(
+    `Missing Supabase anon/public key. Set ${SUPABASE_ANON_KEYS[0]} (aliases checked: ${SUPABASE_ANON_KEYS.slice(1).join(", ") || "none"}).`,
+  );
+}
+
+const supabaseStatus: SupabaseConfigStatus = {
+  hasValidConfig: Boolean(supabaseUrlResolution.value && supabaseAnonResolution.value),
+  resolvedUrl: supabaseUrlResolution.value,
+  resolvedAnonKey: supabaseAnonResolution.value,
+  resolvedUrlKey: supabaseUrlResolution.key,
+  resolvedAnonKeyKey: supabaseAnonResolution.key,
+  missingUrlKeys,
+  missingAnonKeys,
+  errorMessage: configErrorMessages.join("\n"),
+  canonicalUrlKey: "VITE_SUPABASE_URL",
+  canonicalAnonKey: "VITE_SUPABASE_ANON_KEY",
+  aliasUrlKeys: SUPABASE_URL_KEYS.slice(1),
+  aliasAnonKeys: SUPABASE_ANON_KEYS.slice(1),
+  usingFallbackClient: false,
+};
+
+const appConfig: AppConfig | undefined = supabaseStatus.hasValidConfig
+  ? {
+      supabaseUrl: supabaseUrlResolution.value!,
+      supabaseAnonKey: supabaseAnonResolution.value!,
+      lencoApiUrl: resolveEnv(LENCO_API_URL_KEYS).value,
+      lencoPublicKey: resolveEnv(LENCO_PUBLIC_KEY_KEYS).value,
+      lencoSecretKey: resolveEnv(LENCO_SECRET_KEY_KEYS).value,
+      lencoWebhookUrl: resolveEnv(LENCO_WEBHOOK_URL_KEYS).value,
+      paymentCurrency: resolveEnv(PAYMENT_CURRENCY_KEYS).value,
+      paymentCountry: resolveEnv(PAYMENT_COUNTRY_KEYS).value,
+      minPaymentAmount: parseNumber(resolveEnv(PAYMENT_MIN_KEYS).value),
+      maxPaymentAmount: parseNumber(resolveEnv(PAYMENT_MAX_KEYS).value),
+      platformFeePercentage: parseNumber(resolveEnv(PAYMENT_FEE_KEYS).value),
+      environment: resolveEnv(ENVIRONMENT_KEYS).value,
+    }
+  : undefined;
+
+export const supabaseConfigStatus = supabaseStatus;
+
+export const getOptionalAppConfig = (): AppConfig | undefined => appConfig;
+
+export const getAppConfig = (): AppConfig => {
+  if (!appConfig) {
+    const message =
+      supabaseStatus.errorMessage?.trim() ||
+      `Supabase configuration missing. Set ${supabaseStatus.canonicalUrlKey} and ${supabaseStatus.canonicalAnonKey}.`;
+    throw new Error(message);
+  }
+
+  return appConfig;
+};
+
+export const getEnvValue = (key: EnvKey): string | undefined => readEnv(key);
+
+export type SupabaseClientConfiguration = {
+  url: string;
+  anonKey: string;
+  options?: SupabaseClientOptions<"public">;
+};
+
+export const getSupabaseClientConfiguration = (
+  options?: SupabaseClientOptions<"public">,
+): SupabaseClientConfiguration | undefined => {
+  if (!supabaseStatus.hasValidConfig || !appConfig) {
+    return undefined;
+  }
+
+  return {
+    url: appConfig.supabaseUrl,
+    anonKey: appConfig.supabaseAnonKey,
+    options,
+  };
+};
+
+export const getEnvDebugSnapshot = () => ({
+  supabase: {
+    ...supabaseStatus,
+  },
+  appConfig,
+});

--- a/supabase-prod-secrets.env.production
+++ b/supabase-prod-secrets.env.production
@@ -1,42 +1,27 @@
 # ───────────────────────────────────────────────
-# SUPABASE SECRETS (PRODUCTION)
+# SUPABASE SECRETS (PRODUCTION TEMPLATE)
 # ───────────────────────────────────────────────
-SUPABASE_URL=https://nrjcbdrzaxqvomeogptf.supabase.co
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5yamNiZHJ6YXhxdm9tZW9ncHRmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3MjIyMjcsImV4cCI6MjA3MjI5ODIyN30.eK5EbJW99QmeMO6pDQxzghk3OgcDj7dEJVKVVRwE92M
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5yamNiZHJ6YXhxdm9tZW9ncHRmIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NjcyMjIyNywiZXhwIjoyMDcyMjk4MjI3fQ.d9-w8I3MaJb1gqBWUTBTGnN9BLOvR0zR5QEvD-Rcm0s
-SUPABASE_DB_URL=https://nrjcbdrzaxqvomeogptf.supabase.co
+SUPABASE_URL="https://<project-ref>.supabase.co"
+SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
 
 # ───────────────────────────────────────────────
-# AI KEYS
+# LENCO / PAYMENTS (BACKEND)
 # ───────────────────────────────────────────────
-VERCEL_AI_GATEWAY_KEY=
-WATHACI_CONNECT_OPENAI=
+LENCO_API_SECRET="<lenco-private-api-key>"
+LENCO_SECRET="<optional-shared-secret>"
+LENCO_WEBHOOK_URL="https://<project-ref>.supabase.co/functions/v1/lenco-payments-validator"
+LENCO_WEBHOOK_SECRET="<lenco-webhook-signing-secret>"
 
 # ───────────────────────────────────────────────
-# LENCO / PAYMENTS
+# PAYMENT LIMITS MIRRORED SERVER-SIDE (OPTIONAL)
 # ───────────────────────────────────────────────
-VITE_LENCO_API_URL=https://api.lenco.co/access/v2
-VITE_LENCO_PUBLIC_KEY=pub-35ba3d1c6faa7c6e16db56d67d9e48ad6a08f2849d6cad06
-VITE_LENCO_SECRET_KEY=add0bc72c819e18ad1296e45ceffe5006094e71d5d84ff7ecfebd3743f7bf508
-VITE_LENCO_WEBHOOK_URL=https://nrjcbdrzaxqvomeogptf.supabase.co/functions/v1/lenco-payments-validator
+MIN_PAYMENT_AMOUNT="20"
+MAX_PAYMENT_AMOUNT="10000"
+PLATFORM_FEE_PERCENTAGE="5"
 
 # ───────────────────────────────────────────────
-# GENERIC LENCO SECRETS (if used separately)
+# OPTIONAL DUPLICATE KEYS (LEGACY SUPPORT)
 # ───────────────────────────────────────────────
-LENCO_SECRET=add0bc72c819e18ad1296e45ceffe5006094e71d5d84ff7ecfebd3743f7bf508
-LENCO_API_SECRET=add0bc72c819e18ad1296e45ceffe5006094e71d5d84ff7ecfebd3743f7bf508
-LENCO_WEBHOOK_URL=https://nrjcbdrzaxqvomeogptf.supabase.co/functions/v1/lenco-payments-validator
-LENCO_WEBHOOK_SECRET=33ab0f329f3cbb7fb1c1ea194a73d662c72584bbbb6b4626b0901e69010e5f76
-
-# ───────────────────────────────────────────────
-# WEBHOOK & MONITORING
-# ───────────────────────────────────────────────
-PAYMENT_WEBHOOK_SECRET_PRIMARY=33ab0f329f3cbb7fb1c1ea194a73d662c72584bbbb6b4626b0901e69010e5f76
-PAYMENT_MONITORING_ENDPOINT=https://nrjcbdrzaxqvomeogptf.supabase.co/functions/v1/lenco-payments-validator
-
-# ───────────────────────────────────────────────
-# DUPLICATE KEYS USED IN SOME CODEPATHS
-# ───────────────────────────────────────────────
-ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5yamNiZHJ6YXhxdm9tZW9ncHRmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3MjIyMjcsImV4cCI6MjA3MjI5ODIyN30.eK5EbJW99QmeMO6pDQxzghk3OgcDj7dEJVKVVRwE92M
-SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5yamNiZHJ6YXhxdm9tZW9ncHRmIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NjcyMjIyNywiZXhwIjoyMDcyMjk4MjI3fQ.d9-w8I3MaJb1gqBWUTBTGnN9BLOvR0zR5QEvD-Rcm0s
+SUPABASE_ANON_KEY="<public-anon-key>" # rarely needed on backend
+SUPABASE_KEY="<public-anon-key>"
 


### PR DESCRIPTION
## Summary
- centralize environment normalization in `src/config/appConfig.ts` and reuse it for Supabase client bootstrapping
- tighten readiness guard messaging for Supabase/Lenco variables and surface canonical key guidance in the UI
- document canonical env vars, update backend secrets template, and ensure Lenco payments/webhook config is treated as blocking when absent

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913076725888328aa24e97356bee1c0)