### PR TITLE
Add required Supabase anon key and Lenco webhook URL to production env

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -15,6 +15,8 @@ POSTGRES_DATABASE="postgres"
 # --- Frontend (Vite) configuration ---
 VITE_SUPABASE_URL="https://nrjcbdrzaxqvomeogptf.supabase.co"
 VITE_SUPABASE_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5yamNiZHJ6YXhxdm9tZW9ncHRmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3MjIyMjcsImV4cCI6MjA3MjI5ODIyN30.eK5EbJW99QmeMO6pDQxzghk3OgcDj7dEJVKVVRwE92M"
+# Canonical anon key for Supabase client integrations
+VITE_SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5yamNiZHJ6YXhxdm9tZW9ncHRmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3MjIyMjcsImV4cCI6MjA3MjI5ODIyN30.eK5EbJW99QmeMO6pDQxzghk3OgcDj7dEJVKVVRwE92M"
 # Optional aliases supported by the build tooling
 # VITE_SUPABASE_PROJECT_URL="https://nrjcbdrzaxqvomeogptf.supabase.co"
 # VITE_SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5yamNiZHJ6YXhxdm9tZW9ncHRmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3MjIyMjcsImV4cCI6MjA3MjI5ODIyN30.eK5EbJW99QmeMO6pDQxzghk3OgcDj7dEJVKVVRwE92M"
@@ -28,6 +30,7 @@ VITE_LENCO_PUBLIC_KEY="pub-35ba3d1c6faa7c6e16db56d67d9e48ad6a08f2849d6cad06"
 LENCO_SECRET_KEY="add0bc72c819e18ad1296e45ceffe5006094e71d5d84ff7ecfebd3743f7bf508"
 LENCO_WEBHOOK_SECRET="33ab0f329f3cbb7fb1c1ea194a73d662c72584bbbb6b4626b0901e69010e5f76"
 VITE_LENCO_API_URL="https://api.lenco.co/access/v2"
+VITE_LENCO_WEBHOOK_URL="https://nrjcbdrzaxqvomeogptf.supabase.co/functions/v1/lenco-payments-validator"
 
 # Payment Configuration
 VITE_PAYMENT_CURRENCY="ZMW"


### PR DESCRIPTION
## Summary
- add the canonical VITE_SUPABASE_ANON_KEY entry so production builds expose the Supabase anon key
- define the VITE_LENCO_WEBHOOK_URL used by the frontend readiness checks

## Testing
- npm run env:check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130c98e4248328aba603eabfbe92a2)