### PR TITLE
Normalize phone data to restore profile creation

### DIFF
--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { normalizeMsisdn } from '@/utils/phone';
 
 const baseSchema = z.object({
   email: z
@@ -55,9 +56,8 @@ interface AuthFormProps {
 
 const normalizePhone = (value: string | undefined) => {
   if (!value) return undefined;
-  const trimmed = value.trim();
-  if (!trimmed) return undefined;
-  return trimmed.startsWith('+') ? trimmed : `+${trimmed.replace(/^0+/, '')}`;
+  const normalized = normalizeMsisdn(value);
+  return normalized ?? undefined;
 };
 
 export const AuthForm = ({ mode, redirectTo, onSuccess }: AuthFormProps) => {

--- a/src/components/DonateButton.tsx
+++ b/src/components/DonateButton.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useMemo, useState } from "react";
 import { supabaseClient } from "@/lib/supabaseClient";
 import { supabaseConfigStatus } from "@/config/appConfig";
+import { MSISDN_REGEX, normalizeMsisdn } from "@/utils/phone";
 
 type PaymentMethod = "mobile_money" | "card";
 
@@ -9,20 +10,6 @@ const PRESET_AMOUNTS = [20, 50, 100, 250];
 const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
   mobile_money: "Mobile Money",
   card: "Card",
-};
-
-const MSISDN_REGEX = /^\+?[0-9]{9,15}$/;
-
-const normalizeMsisdn = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed) return "";
-  if (trimmed.startsWith("+")) {
-    return trimmed.replace(/\s+/g, "");
-  }
-
-  const digits = trimmed.replace(/\D+/g, "");
-  if (!digits) return "";
-  return `+${digits}`;
 };
 
 const formatCurrency = (amount: number) =>

--- a/src/contexts/__tests__/AppContext.test.tsx
+++ b/src/contexts/__tests__/AppContext.test.tsx
@@ -85,10 +85,28 @@ describe('AppContext auth actions', () => {
     mockCreateProfile.mockResolvedValue({ data: { id: 'profile-1', profile_completed: false }, error: null });
 
     const ctx = await renderContext();
-    await ctx.signUp('new@example.com', 'Password123', { full_name: 'Test User', msisdn: '+260955000000' });
+    await ctx.signUp('new@example.com', 'Password123', {
+      full_name: 'Test User',
+      msisdn: ' +260 955 000 000 ',
+      phone: '+260 955 000 000 ',
+      payment_phone: '+260 955 000 000 ',
+    });
 
-    expect(mockSignUp).toHaveBeenCalledWith('new@example.com', 'Password123', { full_name: 'Test User', msisdn: '+260955000000' });
-    expect(mockCreateProfile).toHaveBeenCalledWith('user-2', expect.any(Object));
+    expect(mockSignUp).toHaveBeenCalledWith('new@example.com', 'Password123', {
+      full_name: 'Test User',
+      msisdn: ' +260 955 000 000 ',
+      phone: '+260 955 000 000 ',
+      payment_phone: '+260 955 000 000 ',
+    });
+
+    expect(mockCreateProfile).toHaveBeenCalledWith(
+      'user-2',
+      expect.objectContaining({
+        msisdn: '+260955000000',
+        phone: '+260955000000',
+        payment_phone: '+260955000000',
+      })
+    );
     expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Account created!' }));
   });
 

--- a/src/utils/__tests__/phone.test.ts
+++ b/src/utils/__tests__/phone.test.ts
@@ -1,0 +1,31 @@
+import { normalizeMsisdn, normalizePhoneNumber } from "@/utils/phone";
+
+describe("phone utilities", () => {
+  describe("normalizePhoneNumber", () => {
+    it("removes formatting but preserves leading plus", () => {
+      expect(normalizePhoneNumber("+260 97-123 4567")).toBe("+260971234567");
+    });
+
+    it("returns digits only when plus is missing", () => {
+      expect(normalizePhoneNumber("097 123 4567")).toBe("0971234567");
+    });
+
+    it("returns null for empty values", () => {
+      expect(normalizePhoneNumber("")).toBeNull();
+      expect(normalizePhoneNumber(null)).toBeNull();
+      expect(normalizePhoneNumber(undefined)).toBeNull();
+    });
+  });
+
+  describe("normalizeMsisdn", () => {
+    it("normalizes phone numbers to E.164 format", () => {
+      expect(normalizeMsisdn(" +260 97 123 4567 ")).toBe("+260971234567");
+      expect(normalizeMsisdn("260971234567")).toBe("+260971234567");
+    });
+
+    it("returns null when length is outside allowed range", () => {
+      expect(normalizeMsisdn("1234")).toBeNull();
+      expect(normalizeMsisdn("+12345678901234567890")).toBeNull();
+    });
+  });
+});

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -1,0 +1,49 @@
+const NON_DIGIT_REGEX = /\D+/g;
+
+export const MSISDN_MIN_LENGTH = 9;
+export const MSISDN_MAX_LENGTH = 15;
+export const MSISDN_REGEX = /^\+?[0-9]{9,15}$/;
+
+const hasText = (value: unknown): value is string => typeof value === "string";
+
+export const stripToDigits = (value?: string | null): string => {
+  if (!hasText(value)) {
+    return "";
+  }
+
+  return value.replace(NON_DIGIT_REGEX, "");
+};
+
+export const normalizePhoneNumber = (value?: string | null): string | null => {
+  if (!hasText(value)) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const digits = stripToDigits(trimmed);
+  if (!digits) {
+    return null;
+  }
+
+  return trimmed.startsWith("+") ? `+${digits}` : digits;
+};
+
+export const normalizeMsisdn = (value?: string | null): string | null => {
+  const normalized = normalizePhoneNumber(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const digits = stripToDigits(normalized);
+  if (digits.length < MSISDN_MIN_LENGTH || digits.length > MSISDN_MAX_LENGTH) {
+    return null;
+  }
+
+  return `+${digits}`;
+};
+
+export const isMsisdnValid = (value?: string | null): boolean => normalizeMsisdn(value) !== null;


### PR DESCRIPTION
## Summary
- add shared phone/MSISDN normalisation utilities and use them during auth, onboarding, and profile setup so inserts respect database constraints
- ensure profile setup flows persist a consistent MSISDN value for payment methods and log invalid metadata for easier debugging
- update supporting tests (including new unit coverage) to exercise the sanitisation logic and guard against regressions

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a5a677748328883023586538e11f)