### PR TITLE
Stabilize Supabase onboarding and profile bootstrap

### DIFF
--- a/src/contexts/__tests__/AppContext.test.tsx
+++ b/src/contexts/__tests__/AppContext.test.tsx
@@ -34,6 +34,18 @@ jest.mock('@/components/ui/use-toast', () => ({
   toast: (...args: any[]) => mockToast(...args),
 }));
 
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/supabaseClient', () => ({
+  logSupabaseAuthError: jest.fn(),
+}));
+
 const renderContext = async () => {
   let context: ReturnType<typeof useAppContext> | null = null;
 
@@ -94,9 +106,9 @@ describe('AppContext auth actions', () => {
 
     expect(mockSignUp).toHaveBeenCalledWith('new@example.com', 'Password123', {
       full_name: 'Test User',
-      msisdn: ' +260 955 000 000 ',
-      phone: '+260 955 000 000 ',
-      payment_phone: '+260 955 000 000 ',
+      msisdn: '+260955000000',
+      phone: '+260955000000',
+      payment_phone: '+260955000000',
     });
 
     expect(mockCreateProfile).toHaveBeenCalledWith(

--- a/src/hooks/__tests__/useProfile.test.tsx
+++ b/src/hooks/__tests__/useProfile.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react';
+import type { User, Profile } from '@/@types/database';
+import { useProfile } from '../useProfile';
+
+const mockRefreshUser = jest.fn();
+
+const mockContext: {
+  user: User | null;
+  profile: Profile | null;
+  loading: boolean;
+} = {
+  user: null,
+  profile: null,
+  loading: false,
+};
+
+jest.mock('@/contexts/AppContext', () => ({
+  useAppContext: () => ({
+    user: mockContext.user,
+    profile: mockContext.profile,
+    loading: mockContext.loading,
+    refreshUser: mockRefreshUser,
+  }),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+describe('useProfile', () => {
+  beforeEach(() => {
+    mockContext.user = null;
+    mockContext.profile = null;
+    mockContext.loading = false;
+    mockRefreshUser.mockReset();
+  });
+
+  it('returns context values', () => {
+    mockContext.user = { id: 'user-1' } as User;
+    mockContext.profile = { id: 'user-1', profile_completed: true } as Profile;
+
+    const { result } = renderHook(() => useProfile({ refreshOnMount: false }));
+
+    expect(result.current.user).toBe(mockContext.user);
+    expect(result.current.profile).toBe(mockContext.profile);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.needsProfile).toBe(false);
+  });
+
+  it('triggers refresh when profile missing and loading completed', () => {
+    mockContext.user = { id: 'user-2' } as User;
+    mockContext.profile = null;
+    mockContext.loading = false;
+
+    renderHook(() => useProfile({ refreshOnMount: false, refreshOnMissing: true }));
+
+    expect(mockRefreshUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger refresh when loading', () => {
+    mockContext.user = { id: 'user-3' } as User;
+    mockContext.profile = null;
+    mockContext.loading = true;
+
+    renderHook(() => useProfile({ refreshOnMount: false, refreshOnMissing: true }));
+
+    expect(mockRefreshUser).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,0 +1,73 @@
+import { useEffect, useMemo } from 'react';
+import { useAppContext } from '@/contexts/AppContext';
+import { logger } from '@/lib/logger';
+
+interface UseProfileOptions {
+  refreshOnMount?: boolean;
+  refreshOnMissing?: boolean;
+}
+
+type AppContextValue = ReturnType<typeof useAppContext>;
+
+interface UseProfileResult {
+  user: AppContextValue['user'];
+  profile: AppContextValue['profile'];
+  loading: AppContextValue['loading'];
+  refresh: AppContextValue['refreshUser'];
+  needsProfile: boolean;
+}
+
+const defaultOptions: UseProfileOptions = {
+  refreshOnMount: false,
+  refreshOnMissing: true,
+};
+
+export const useProfile = (options: UseProfileOptions = {}): UseProfileResult => {
+  const { refreshOnMount, refreshOnMissing } = { ...defaultOptions, ...options };
+  const { user, profile, loading, refreshUser } = useAppContext();
+
+  useEffect(() => {
+    if (!refreshOnMount) {
+      return;
+    }
+
+    const maybePromise = refreshUser();
+
+    if (maybePromise && typeof (maybePromise as PromiseLike<unknown>).catch === 'function') {
+      (maybePromise as PromiseLike<unknown>).catch(error => {
+        logger.error('useProfile failed to refresh on mount', error, {
+          component: 'useProfile',
+        });
+      });
+    }
+  }, [refreshOnMount, refreshUser]);
+
+  useEffect(() => {
+    if (!refreshOnMissing || loading || !user || profile) {
+      return;
+    }
+
+    const maybePromise = refreshUser();
+
+    if (maybePromise && typeof (maybePromise as PromiseLike<unknown>).catch === 'function') {
+      (maybePromise as PromiseLike<unknown>).catch(error => {
+        logger.error('useProfile failed to hydrate missing profile', error, {
+          component: 'useProfile',
+          userId: user.id,
+        });
+      });
+    }
+  }, [refreshOnMissing, loading, profile, refreshUser, user]);
+
+  const needsProfile = useMemo(() => Boolean(user && !profile), [user, profile]);
+
+  return {
+    user,
+    profile,
+    loading,
+    refresh: refreshUser,
+    needsProfile,
+  };
+};
+
+export default useProfile;

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,4 @@
-import {
-  createClient,
-  type SupabaseClient as SupabaseJsClient,
-  type SupabaseClientOptions,
-} from "@supabase/supabase-js";
+import { createClient, type SupabaseClientOptions } from "@supabase/supabase-js";
 
 import type { Database } from "@/@types/database";
 import { getSupabaseClientConfiguration, supabaseConfigStatus } from "@/config/appConfig";
@@ -15,95 +11,85 @@ const clientOptions: SupabaseClientOptions<"public"> = {
   },
 };
 
-type SupabaseClientType = SupabaseJsClient<Database>;
+const sanitizeEnvValue = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
 
-const createFallbackSupabaseClient = (error: Error): SupabaseClientType => {
-  const rejected = async () => {
-    throw error;
-  };
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.toLowerCase() === "undefined" || trimmed.toLowerCase() === "null") {
+    return undefined;
+  }
 
-  const noopSubscription = {
-    unsubscribe: () => {},
-  };
-
-  return {
-    auth: {
-      getSession: rejected,
-      signInWithPassword: rejected,
-      signUp: rejected,
-      signOut: rejected,
-      onAuthStateChange: () => ({ data: { subscription: noopSubscription }, error }),
-      getUser: rejected,
-      updateUser: rejected,
-    },
-    from: () => ({
-      select: rejected,
-      insert: rejected,
-      update: rejected,
-      upsert: rejected,
-      delete: rejected,
-      eq: () => ({
-        select: rejected,
-        insert: rejected,
-        update: rejected,
-        upsert: rejected,
-        delete: rejected,
-      }),
-      neq: () => ({
-        select: rejected,
-      }),
-      single: rejected,
-      maybeSingle: rejected,
-      limit: () => ({
-        select: rejected,
-      }),
-      order: () => ({
-        select: rejected,
-      }),
-      throwOnError: () => ({
-        select: rejected,
-      }),
-    }),
-    rpc: rejected,
-    channel: () => ({
-      subscribe: () => ({ error }),
-      on: () => ({ subscribe: () => ({ error }) }),
-    }),
-    removeChannel: () => ({ error }),
-    getChannels: () => [],
-    storage: {
-      from: () => ({
-        upload: rejected,
-        download: rejected,
-        remove: rejected,
-        list: rejected,
-      }),
-    },
-    functions: {
-      invoke: rejected,
-    },
-  } as unknown as SupabaseClientType;
+  return trimmed.replace(/^['"`]+|['"`]+$/g, "").trim();
 };
 
-let internalClient: SupabaseClientType;
+const resolveCanonicalEnv = (key: "VITE_SUPABASE_URL" | "VITE_SUPABASE_ANON_KEY"): string | undefined => {
+  const metaEnv = typeof import.meta !== "undefined" ? (import.meta as any)?.env : undefined;
+  const direct = sanitizeEnvValue(metaEnv?.[key]);
+  if (direct) {
+    return direct;
+  }
+
+  if (typeof process !== "undefined" && process.env) {
+    const processValue = sanitizeEnvValue(process.env[key]);
+    if (processValue) {
+      return processValue;
+    }
+  }
+
+  if (typeof globalThis !== "undefined") {
+    const runtimeValue = sanitizeEnvValue((globalThis as any)?.__APP_CONFIG__?.[key]);
+    if (runtimeValue) {
+      return runtimeValue;
+    }
+  }
+
+  return undefined;
+};
+
+const supabaseUrl = resolveCanonicalEnv("VITE_SUPABASE_URL");
+const supabaseAnonKey = resolveCanonicalEnv("VITE_SUPABASE_ANON_KEY");
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  const errorMessage =
+    supabaseConfigStatus.errorMessage ||
+    `Supabase configuration missing. Set ${supabaseConfigStatus.canonicalUrlKey} and ${supabaseConfigStatus.canonicalAnonKey}.`;
+
+  if (typeof console !== "undefined" && !import.meta.env.SSR) {
+    console.error("Supabase config missing: check VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY", {
+      resolvedUrlKey: supabaseConfigStatus.resolvedUrlKey,
+      resolvedAnonKeyKey: supabaseConfigStatus.resolvedAnonKeyKey,
+      missingUrlKeys: supabaseConfigStatus.missingUrlKeys,
+      missingAnonKeys: supabaseConfigStatus.missingAnonKeys,
+    });
+  }
+
+  supabaseConfigStatus.hasValidConfig = false;
+  supabaseConfigStatus.resolvedUrl = undefined;
+  supabaseConfigStatus.resolvedAnonKey = undefined;
+  supabaseConfigStatus.resolvedUrlKey = undefined;
+  supabaseConfigStatus.resolvedAnonKeyKey = undefined;
+  supabaseConfigStatus.missingUrlKeys = [
+    supabaseConfigStatus.canonicalUrlKey,
+    ...supabaseConfigStatus.aliasUrlKeys,
+  ];
+  supabaseConfigStatus.missingAnonKeys = [
+    supabaseConfigStatus.canonicalAnonKey,
+    ...supabaseConfigStatus.aliasAnonKeys,
+  ];
+  supabaseConfigStatus.errorMessage = errorMessage;
+
+  throw new Error("Missing Supabase environment configuration");
+}
 
 const resolvedConfig = getSupabaseClientConfiguration(clientOptions);
 
-if (resolvedConfig) {
-  internalClient = createClient<Database>(resolvedConfig.url, resolvedConfig.anonKey, resolvedConfig.options);
-} else {
-  const error = new Error(
-    supabaseConfigStatus.errorMessage ||
-      `Supabase configuration missing. Set ${supabaseConfigStatus.canonicalUrlKey} and ${supabaseConfigStatus.canonicalAnonKey}.`,
-  );
-
-  if (typeof console !== "undefined" && !import.meta.env.SSR) {
-    console.error("[supabaseClient]", error.message);
-  }
-
-  internalClient = createFallbackSupabaseClient(error);
-  supabaseConfigStatus.usingFallbackClient = true;
-}
+const internalClient = createClient<Database>(
+  resolvedConfig?.url ?? supabaseUrl,
+  resolvedConfig?.anonKey ?? supabaseAnonKey,
+  resolvedConfig?.options ?? clientOptions,
+);
 
 export type SupabaseClient = typeof internalClient;
 


### PR DESCRIPTION
## Summary
- enforce canonical Supabase environment keys and stop bootstrapping when they are missing
- harden auth flows with structured logging, sanitized sign-up metadata, and a coalesced refresh pipeline
- require MSISDN for profile creation and add a reusable profile hook with unit coverage

## Testing
- npm run test:jest *(fails: Jest environment cannot parse modules that reference import.meta)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69157b91d2c8832899e2ab32c5a700d4)