### PR TITLE
Add Supabase bootstrap profile edge function and config guard

### DIFF
--- a/supabase/functions/bootstrap-profile/index.ts
+++ b/supabase/functions/bootstrap-profile/index.ts
@@ -1,0 +1,128 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error("[bootstrap-profile] missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in environment");
+  throw new Error("bootstrap-profile: missing env");
+}
+
+const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { persistSession: false },
+});
+
+type Body = {
+  userId: string;
+  email?: string | null;
+  full_name?: string | null;
+  msisdn?: string | null;
+  profile_type?: string | null;
+};
+
+type JsonRecord = Record<string, unknown> | null;
+
+const json = (obj: Record<string, unknown>, status = 200) =>
+  new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const logUserEvent = async (userId: string, kind: string, payload: JsonRecord = null) => {
+  const { error } = await supabaseAdmin.from("user_events").insert({
+    user_id: userId,
+    kind,
+    payload,
+  });
+
+  if (error) {
+    console.error(`[bootstrap-profile] failed to log user_event ${kind}`, error);
+  }
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") {
+    return json({ error: "Only POST" }, 405);
+  }
+
+  let body: Body | null = null;
+
+  try {
+    body = (await req.json()) as Body;
+  } catch (error) {
+    console.error("[bootstrap-profile] invalid JSON", error);
+    return json({ error: "invalid json" }, 400);
+  }
+
+  if (!body || typeof body !== "object") {
+    return json({ error: "invalid body" }, 400);
+  }
+
+  const { userId, email, full_name, msisdn, profile_type } = body;
+
+  if (!userId) {
+    return json({ error: "userId required" }, 400);
+  }
+
+  await logUserEvent(userId, "bootstrap_profile_start", {
+    email,
+    msisdn,
+    profile_type,
+  });
+
+  if (!msisdn || msisdn.trim() === "") {
+    await logUserEvent(userId, "bootstrap_profile_missing_msisdn", {
+      email,
+      full_name,
+      msisdn,
+    });
+
+    return json({ error: "msisdn required" }, 400);
+  }
+
+  try {
+    const ensureResult = await supabaseAdmin.rpc("ensure_profile_exists", {
+      p_user_id: userId,
+      p_email: email ?? null,
+      p_full_name: full_name ?? null,
+      p_msisdn: msisdn,
+      p_profile_type: profile_type ?? "customer",
+    });
+
+    if (ensureResult.error) {
+      console.error("[bootstrap-profile] ensure_profile_exists error", ensureResult.error);
+      await logUserEvent(userId, "bootstrap_profile_error", {
+        error: ensureResult.error.message,
+        hint: ensureResult.error.hint,
+        code: ensureResult.error.code,
+      });
+
+      return json({ error: "failed to ensure profile" }, 500);
+    }
+
+    const { data: profile, error } = await supabaseAdmin
+      .from("profiles")
+      .select("*")
+      .eq("id", userId)
+      .single();
+
+    if (error) {
+      console.error("[bootstrap-profile] profile select error", error);
+      await logUserEvent(userId, "bootstrap_profile_error", { error: error.message, code: error.code });
+
+      return json({ error: "failed to read profile" }, 500);
+    }
+
+    await logUserEvent(userId, "bootstrap_profile_ok", {
+      profile_id: profile.id,
+    });
+
+    return json({ ok: true, profile }, 200);
+  } catch (error) {
+    console.error("[bootstrap-profile] unexpected error", error);
+    await logUserEvent(userId, "bootstrap_profile_error", { error: String(error) });
+
+    return json({ error: "internal error" }, 500);
+  }
+});

--- a/supabase/migrations/20250201090000_ensure_profile_exists.sql
+++ b/supabase/migrations/20250201090000_ensure_profile_exists.sql
@@ -1,0 +1,38 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+ALTER TABLE IF EXISTS public.profiles
+  ADD COLUMN IF NOT EXISTS msisdn text;
+
+ALTER TABLE IF EXISTS public.profiles
+  ADD COLUMN IF NOT EXISTS profile_type text;
+
+CREATE OR REPLACE FUNCTION public.ensure_profile_exists(
+  p_user_id uuid,
+  p_email text,
+  p_full_name text,
+  p_msisdn text,
+  p_profile_type text DEFAULT 'customer'
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, full_name, msisdn, profile_type)
+  VALUES (p_user_id, p_email, p_full_name, p_msisdn, COALESCE(p_profile_type, 'customer'))
+  ON CONFLICT (id) DO UPDATE
+    SET
+      email = COALESCE(NULLIF(public.profiles.email, ''), EXCLUDED.email),
+      full_name = COALESCE(NULLIF(public.profiles.full_name, ''), EXCLUDED.full_name),
+      msisdn = CASE
+        WHEN public.profiles.msisdn IS NULL OR public.profiles.msisdn = '' THEN EXCLUDED.msisdn
+        ELSE public.profiles.msisdn
+      END,
+      profile_type = COALESCE(public.profiles.profile_type, EXCLUDED.profile_type, 'customer'),
+      updated_at = now();
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20250201090500_profiles_rls.sql
+++ b/supabase/migrations/20250201090500_profiles_rls.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS profiles_select_owner ON public.profiles;
+CREATE POLICY profiles_select_owner ON public.profiles
+  FOR SELECT
+  TO authenticated
+  USING (id = auth.uid());
+
+DROP POLICY IF EXISTS profiles_update_owner ON public.profiles;
+CREATE POLICY profiles_update_owner ON public.profiles
+  FOR UPDATE
+  TO authenticated
+  USING (id = auth.uid())
+  WITH CHECK (id = auth.uid());
+
+DROP POLICY IF EXISTS profiles_insert_none ON public.profiles;
+CREATE POLICY profiles_insert_none ON public.profiles
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (false);
+
+DROP POLICY IF EXISTS profiles_admin_all ON public.profiles;
+CREATE POLICY profiles_admin_all ON public.profiles
+  FOR ALL
+  TO authenticated
+  USING ((auth.jwt() ->> 'user_role') = 'admin' OR (auth.jwt() ->> 'role') = 'admin')
+  WITH CHECK ((auth.jwt() ->> 'user_role') = 'admin' OR (auth.jwt() ->> 'role') = 'admin');
+
+COMMIT;


### PR DESCRIPTION
## Summary
- hard-fail Supabase client initialization when required environment variables are missing and log diagnostic details
- add a `bootstrap-profile` Edge Function to idempotently create profiles and emit user event telemetry
- create database migrations for the `ensure_profile_exists` RPC and tightened RLS policies on `profiles`

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158685b6c08328a03f09647ac701fa)