### PR TITLE
Add maintenance guard and purge safety runbooks

### DIFF
--- a/backend/supabase/maintenance/purge_non_production_users.sql
+++ b/backend/supabase/maintenance/purge_non_production_users.sql
@@ -1,0 +1,78 @@
+-- ============================================================================
+-- Purge Non-Production Supabase Users
+-- ============================================================================
+-- 1. Enable maintenance mode (see docs/runbooks/MAINTENANCE_MODE.md)
+-- 2. Update the allowlists below to reflect the production accounts that must remain
+-- 3. Review the preview query output before running the DELETE
+-- 4. Commit only after verifying that only test/demo users are selected
+-- ============================================================================
+
+begin;
+
+-- --------------------------------------------------------------------------
+-- Configure allowlists (edit before running)
+-- --------------------------------------------------------------------------
+create temp table purge_allowed_domains(domain text);
+insert into purge_allowed_domains(domain)
+values
+  ('wathaci.com'),
+  ('wathaci.org');
+
+create temp table purge_allowed_emails(email text);
+insert into purge_allowed_emails(email)
+values
+  ('founder@wathaci.com');
+
+create temp table purge_allowed_account_types(account_type text);
+insert into purge_allowed_account_types(account_type)
+values
+  ('admin');
+
+-- --------------------------------------------------------------------------
+-- Identify users eligible for deletion
+-- --------------------------------------------------------------------------
+create temp table purge_candidates as
+select
+  u.id,
+  u.email,
+  u.created_at,
+  u.raw_user_meta_data ->> 'account_type' as account_type,
+  u.raw_user_meta_data ->> 'full_name' as full_name,
+  u.raw_user_meta_data ->> 'msisdn' as msisdn
+from auth.users u
+where not exists (
+    select 1
+    from purge_allowed_emails e
+    where lower(u.email) = lower(e.email)
+  )
+  and not exists (
+    select 1
+    from purge_allowed_domains d
+    where lower(u.email) like '%' || lower(d.domain)
+  )
+  and coalesce(u.raw_user_meta_data ->> 'account_type', '') not in (
+    select account_type from purge_allowed_account_types
+  );
+
+-- --------------------------------------------------------------------------
+-- Preview rows that will be deleted (review carefully!)
+-- --------------------------------------------------------------------------
+select
+  id,
+  email,
+  account_type,
+  msisdn,
+  created_at
+from purge_candidates
+order by created_at;
+
+-- --------------------------------------------------------------------------
+-- Uncomment the DELETE once the previewed rows look correct
+-- --------------------------------------------------------------------------
+-- delete from auth.users au
+-- using purge_candidates pc
+-- where au.id = pc.id
+-- returning au.id, au.email;
+
+-- commit;  -- Only after the DELETE has been reviewed
+rollback;  -- Safety default; replace with COMMIT when ready

--- a/backend/supabase/maintenance/verify_user_fk_cascade.sql
+++ b/backend/supabase/maintenance/verify_user_fk_cascade.sql
@@ -1,0 +1,49 @@
+-- ============================================================================
+-- Verify cascading foreign keys for auth.users cleanup
+-- ============================================================================
+-- Run this script after applying migrations to ensure user-owned data cascades
+-- correctly when deleting rows from auth.users.
+-- ============================================================================
+
+with user_fk as (
+  select
+    tc.constraint_name,
+    tc.table_schema,
+    tc.table_name,
+    kcu.column_name,
+    rc.update_rule,
+    rc.delete_rule,
+    ccu.table_schema as referenced_schema,
+    ccu.table_name as referenced_table,
+    ccu.column_name as referenced_column
+  from information_schema.table_constraints tc
+  join information_schema.key_column_usage kcu
+    on tc.constraint_name = kcu.constraint_name
+   and tc.table_schema = kcu.table_schema
+  join information_schema.referential_constraints rc
+    on tc.constraint_name = rc.constraint_name
+   and tc.table_schema = rc.constraint_schema
+  join information_schema.constraint_column_usage ccu
+    on ccu.constraint_name = rc.unique_constraint_name
+   and ccu.constraint_schema = rc.unique_constraint_schema
+  where tc.constraint_type = 'FOREIGN KEY'
+    and (
+      (ccu.table_schema = 'auth' and ccu.table_name = 'users')
+      or (ccu.table_schema = 'public' and ccu.table_name = 'profiles')
+    )
+)
+select
+  table_schema,
+  table_name,
+  column_name,
+  referenced_schema,
+  referenced_table,
+  referenced_column,
+  delete_rule,
+  update_rule,
+  case
+    when delete_rule = 'CASCADE' then '✅'
+    else '⚠️'
+  end as cascade_ok
+from user_fk
+order by referenced_table, table_name, column_name;

--- a/docs/ENVIRONMENT_VARIABLES_QUICK_REFERENCE.md
+++ b/docs/ENVIRONMENT_VARIABLES_QUICK_REFERENCE.md
@@ -36,6 +36,12 @@ npm run env:check
 | `VITE_MAX_PAYMENT_AMOUNT` | Maximum payment amount | `50000` | All |
 | `VITE_APP_ENV` | Runtime environment | `production` or `development` | All |
 | `VITE_APP_NAME` | Application display name | `WATHACI CONNECT` | All |
+| `VITE_MAINTENANCE_MODE` | When `true`, shows maintenance banner and disables sign-ups by default | `false` | All |
+| `VITE_MAINTENANCE_ALLOW_SIGNIN` | Allow sign-in during maintenance | `true` | All |
+| `VITE_MAINTENANCE_ALLOW_SIGNUP` | Allow sign-up during maintenance | `false` when maintenance active | All |
+| `VITE_MAINTENANCE_BANNER_TITLE` | Custom banner heading during maintenance | `Scheduled maintenance in progress` | All |
+| `VITE_MAINTENANCE_BANNER_MESSAGE` | Custom banner body copy during maintenance | `We are preparing Wathaci Connect for production launch...` | All |
+| `VITE_MAINTENANCE_ALLOWED_EMAIL_DOMAINS` | Comma-separated domain allowlist for temporary access messaging | `wathaci.com` | All |
 
 ### Backend (backend/.env files)
 

--- a/docs/env.example
+++ b/docs/env.example
@@ -8,6 +8,12 @@ VITE_LENCO_API_URL=https://api.lenco.co/access/v2
 VITE_LENCO_PUBLIC_KEY=pk_test
 VITE_LENCO_SECRET_KEY=sk_test
 VITE_LENCO_WEBHOOK_URL=https://your-project.supabase.co/functions/v1/lenco-payments-validator
+VITE_MAINTENANCE_MODE=false
+VITE_MAINTENANCE_ALLOW_SIGNIN=true
+VITE_MAINTENANCE_ALLOW_SIGNUP=true
+VITE_MAINTENANCE_BANNER_TITLE=Scheduled maintenance in progress
+VITE_MAINTENANCE_BANNER_MESSAGE=We are preparing Wathaci Connect for production launch. Sign-ups are temporarily disabled while migrations run.
+VITE_MAINTENANCE_ALLOWED_EMAIL_DOMAINS=admin@wathaci.com,wathaci.com
 
 # Backend / Supabase secrets
 SUPABASE_URL=https://your-project.supabase.co

--- a/docs/production-deployment-blueprint.md
+++ b/docs/production-deployment-blueprint.md
@@ -130,7 +130,7 @@ jobs:
 ```sql
 create table if not exists public.donations (
   id uuid primary key default gen_random_uuid(),
-  donor_user_id uuid references auth.users(id),
+  donor_user_id uuid references public.profiles(id) on delete cascade,
   campaign_id uuid,
   amount numeric not null,
   currency text not null default 'ZMW',

--- a/docs/runbooks/BACKUP_AND_RESTORE.md
+++ b/docs/runbooks/BACKUP_AND_RESTORE.md
@@ -1,0 +1,105 @@
+# Backup and Restore Runbook
+
+This runbook documents how to capture and restore Supabase authentication data (and dependent tables) prior to deleting non-production users.
+
+## Scope
+
+- `auth.users`
+- `public.profiles`
+- Dependent needs assessment tables (`sme_needs_assessments`, `professional_needs_assessments`, `investor_needs_assessments`, `donor_needs_assessments`, `government_needs_assessments`)
+- `public.donations`
+- Any other tables cascading from `public.profiles`
+
+## Backup Checklist
+
+1. **Confirm maintenance mode** is enabled (`docs/runbooks/MAINTENANCE_MODE.md`).
+2. **Export authentication and profile tables**:
+
+   ```bash
+   # Authenticate with Supabase
+   supabase login
+   supabase link --project-ref <project-ref>
+
+   # Dump auth schema and dependent tables to a timestamped file
+   supabase db dump \
+     --data-only \
+     --schema auth \
+     --schema public \
+     --table auth.users \
+     --table public.profiles \
+     --table public.sme_needs_assessments \
+     --table public.professional_needs_assessments \
+     --table public.investor_needs_assessments \
+     --table public.donor_needs_assessments \
+     --table public.government_needs_assessments \
+     --table public.donations \
+     --file backups/$(date +%Y%m%d-%H%M)-auth-and-profiles.sql
+   ```
+
+   > **Tip:** Commit the dump to a secure, private S3 bucket or encrypted storage, not to the repository.
+
+3. **Create a full Postgres backup** (recommended for production):
+
+   ```bash
+   pg_dump \
+     --format=custom \
+     --no-owner \
+     --no-privileges \
+     --dbname="postgresql://postgres:<password>@<host>:5432/postgres" \
+     --file backups/$(date +%Y%m%d-%H%M)-full.pgcustom
+   ```
+
+4. **Export storage objects** (if user-uploaded assets exist):
+
+   ```bash
+   supabase storage list-buckets
+   supabase storage download --bucket avatars --path . --destination backups/storage/avatars
+   ```
+
+5. **Verify backups**:
+
+   ```bash
+   ls -lh backups
+   head -n 20 backups/*-auth-and-profiles.sql
+   ```
+
+## Restore Procedures
+
+### Restore a targeted table snapshot
+
+```bash
+supabase db reset --project-ref <project-ref>  # optional (wipes database!)
+
+psql "postgresql://postgres:<password>@<host>:5432/postgres" \
+  -f backups/20250206-0900-auth-and-profiles.sql
+```
+
+### Restore from full pg_dump
+
+```bash
+pg_restore \
+  --clean \
+  --if-exists \
+  --no-owner \
+  --no-privileges \
+  --dbname="postgresql://postgres:<password>@<host>:5432/postgres" \
+  backups/20250206-0900-full.pgcustom
+```
+
+## Verification After Restore
+
+1. Run [`backend/supabase/maintenance/verify_user_fk_cascade.sql`](../../backend/supabase/maintenance/verify_user_fk_cascade.sql) via the Supabase SQL editor.
+2. Confirm `auth.users` contains expected admin emails only.
+3. Validate the application login flow end-to-end.
+4. Ensure maintenance mode is disabled when complete.
+
+## Storage and Retention
+
+- Store encrypted backups in the company-owned S3 bucket (`s3://wathaci-backups/supabase/`).
+- Retain at least two historical snapshots.
+- Rotate credentials after the purge window.
+
+## Related Documents
+
+- [`docs/runbooks/MAINTENANCE_MODE.md`](./MAINTENANCE_MODE.md)
+- [`backend/supabase/maintenance/purge_non_production_users.sql`](../../backend/supabase/maintenance/purge_non_production_users.sql)

--- a/docs/runbooks/MAINTENANCE_MODE.md
+++ b/docs/runbooks/MAINTENANCE_MODE.md
@@ -1,0 +1,85 @@
+# Maintenance Mode Runbook
+
+This runbook documents how to safely enable and disable the Wathaci Connect maintenance guard during database cleanup windows.
+
+## Overview
+
+Maintenance mode ensures no new accounts are created while data is being purged. The frontend displays a blocking banner, disables the authentication forms, and optionally allows a limited email-domain allowlist to pass manual review.
+
+## Prerequisites
+
+- Access to the deployment platform (Vercel) and Supabase project.
+- Ability to update environment variables and redeploy the frontend.
+- Supabase service-role key configured locally for CLI commands.
+
+## Enable Maintenance Mode
+
+1. **Update frontend environment variables** (Vercel dashboard → Project → Settings → Environment Variables or the `.env` file for local builds):
+
+   ```env
+   VITE_MAINTENANCE_MODE=true
+   VITE_MAINTENANCE_ALLOW_SIGNIN=true
+   VITE_MAINTENANCE_ALLOW_SIGNUP=false
+   VITE_MAINTENANCE_BANNER_TITLE="Scheduled maintenance in progress"
+   VITE_MAINTENANCE_BANNER_MESSAGE="We are preparing Wathaci Connect for production launch. Sign-ups are temporarily disabled while we migrate real user data."
+   VITE_MAINTENANCE_ALLOWED_EMAIL_DOMAINS="wathaci.com"
+   ```
+
+2. **Deploy the configuration**:
+
+   - For Vercel, trigger a redeploy after saving the variables.
+   - For local maintenance rehearsals, restart `npm run dev` so Vite picks up the updated `.env` values.
+
+3. **(Optional) Restrict Supabase sign-ups to an allowlist** while the purge runs:
+
+   ```bash
+   supabase login
+   supabase projects list  # identify <project-ref>
+   supabase link --project-ref <project-ref>
+   supabase auth update --disable-signups true
+   supabase auth update --email-allowlist "wathaci.com"
+   ```
+
+4. **Verify maintenance banner**:
+
+   - Navigate to `/signin` and `/signup`.
+   - The forms should render in a disabled state with the maintenance banner visible.
+   - Ensure the submit button reads “Temporarily unavailable”.
+
+## Disable Maintenance Mode
+
+1. **Restore environment variables**:
+
+   ```env
+   VITE_MAINTENANCE_MODE=false
+   VITE_MAINTENANCE_ALLOW_SIGNIN=true
+   VITE_MAINTENANCE_ALLOW_SIGNUP=true
+   VITE_MAINTENANCE_ALLOWED_EMAIL_DOMAINS=""
+   ```
+
+2. **Redeploy the frontend** (or restart the dev server) to pick up the change.
+
+3. **Re-enable Supabase sign-ups** (if they were disabled):
+
+   ```bash
+   supabase auth update --disable-signups false
+   supabase auth update --email-allowlist ""
+   ```
+
+4. **Smoke-test authentication**:
+
+   - Confirm the banner is hidden.
+   - Verify new sign-ups succeed end-to-end (including profile bootstrap).
+   - Confirm existing users can still sign in.
+
+## Troubleshooting
+
+- **Banner still visible after disabling** – check that the deployment picked up the new environment variables and there are no stale preview builds.
+- **Sign-ups still blocked** – confirm Supabase sign-ups were re-enabled and email confirmation settings are correct (Authentication → Providers → Email → “Enable email confirmations”).
+- **Need to allow a temporary tester** – keep maintenance mode on but add their domain or full email to `VITE_MAINTENANCE_ALLOWED_EMAIL_DOMAINS` and the Supabase email allowlist.
+
+## Related Scripts & References
+
+- [`docs/runbooks/BACKUP_AND_RESTORE.md`](./BACKUP_AND_RESTORE.md)
+- [`backend/supabase/maintenance/purge_non_production_users.sql`](../../backend/supabase/maintenance/purge_non_production_users.sql)
+- [`backend/supabase/maintenance/verify_user_fk_cascade.sql`](../../backend/supabase/maintenance/verify_user_fk_cascade.sql)

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,0 +1,86 @@
+type EnvSource = Record<string, string | undefined>;
+
+const getRuntimeEnv = (): EnvSource => {
+  if (typeof import.meta !== 'undefined' && typeof import.meta.env === 'object') {
+    return import.meta.env as EnvSource;
+  }
+
+  if (typeof process !== 'undefined' && typeof process.env === 'object') {
+    return process.env as EnvSource;
+  }
+
+  if (typeof globalThis !== 'undefined' && typeof (globalThis as any).__APP_ENV__ === 'object') {
+    return (globalThis as any).__APP_ENV__ as EnvSource;
+  }
+
+  return {};
+};
+
+const toBoolean = (value: string | undefined, defaultValue: boolean) => {
+  if (typeof value !== 'string') {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (['1', 'true', 'yes', 'on', 'enabled'].includes(normalized)) {
+    return true;
+  }
+
+  if (['0', 'false', 'no', 'off', 'disabled'].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+};
+
+const sanitizeText = (value: string | undefined): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export type MaintenanceConfig = {
+  enabled: boolean;
+  allowSignIn: boolean;
+  allowSignUp: boolean;
+  bannerTitle: string;
+  bannerMessage: string;
+  allowedEmailDomains: string[];
+};
+
+const DEFAULT_BANNER_TITLE = 'Scheduled maintenance in progress';
+const DEFAULT_BANNER_MESSAGE =
+  'We are preparing Wathaci Connect for production launch. Sign-ups are temporarily disabled while we migrate real user data.';
+
+export const getMaintenanceConfig = (): MaintenanceConfig => {
+  const env = getRuntimeEnv();
+
+  const enabled = toBoolean(env.VITE_MAINTENANCE_MODE ?? env.MAINTENANCE_MODE, false);
+  const allowSignIn = toBoolean(env.VITE_MAINTENANCE_ALLOW_SIGNIN ?? env.MAINTENANCE_ALLOW_SIGNIN, true);
+  const allowSignUp = toBoolean(env.VITE_MAINTENANCE_ALLOW_SIGNUP ?? env.MAINTENANCE_ALLOW_SIGNUP, !enabled);
+
+  const bannerTitle = sanitizeText(env.VITE_MAINTENANCE_BANNER_TITLE ?? env.MAINTENANCE_BANNER_TITLE) ?? DEFAULT_BANNER_TITLE;
+  const bannerMessage =
+    sanitizeText(env.VITE_MAINTENANCE_BANNER_MESSAGE ?? env.MAINTENANCE_BANNER_MESSAGE) ?? DEFAULT_BANNER_MESSAGE;
+
+  const rawAllowlist =
+    sanitizeText(env.VITE_MAINTENANCE_ALLOWED_EMAIL_DOMAINS ?? env.MAINTENANCE_ALLOWED_EMAIL_DOMAINS) ?? '';
+
+  const allowedEmailDomains = rawAllowlist
+    .split(',')
+    .map(domain => domain.trim().toLowerCase())
+    .filter(Boolean);
+
+  return {
+    enabled,
+    allowSignIn,
+    allowSignUp,
+    bannerTitle,
+    bannerMessage,
+    allowedEmailDomains,
+  };
+};

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,4 +2,10 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_MAINTENANCE_MODE?: string;
+  readonly VITE_MAINTENANCE_ALLOW_SIGNIN?: string;
+  readonly VITE_MAINTENANCE_ALLOW_SIGNUP?: string;
+  readonly VITE_MAINTENANCE_BANNER_TITLE?: string;
+  readonly VITE_MAINTENANCE_BANNER_MESSAGE?: string;
+  readonly VITE_MAINTENANCE_ALLOWED_EMAIL_DOMAINS?: string;
 }

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,10 +1,23 @@
 import { Link } from 'react-router-dom';
 import AuthForm from '@/components/AuthForm';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { getMaintenanceConfig } from '@/config/featureFlags';
 
 export const SignIn = () => {
+  const maintenance = getMaintenanceConfig();
+  const maintenanceActive = maintenance.enabled;
+  const signInDisabled = maintenanceActive && !maintenance.allowSignIn;
+  const signUpAvailable = !maintenanceActive || maintenance.allowSignUp;
+
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-orange-50 via-white to-green-50 p-6">
       <div className="w-full max-w-md rounded-2xl bg-white/90 p-8 shadow-xl ring-1 ring-orange-100/60 backdrop-blur">
+        {maintenanceActive && (
+          <Alert variant="warning" className="mb-6">
+            <AlertTitle>{maintenance.bannerTitle}</AlertTitle>
+            <AlertDescription>{maintenance.bannerMessage}</AlertDescription>
+          </Alert>
+        )}
         <div className="mb-6 text-center">
           <img
             src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
@@ -19,14 +32,25 @@ export const SignIn = () => {
           </p>
         </div>
 
-        <AuthForm mode="signin" redirectTo="/" />
+        <AuthForm
+          mode="signin"
+          redirectTo="/"
+          disabled={signInDisabled}
+          disabledReason={maintenance.bannerMessage}
+        />
 
-        <p className="mt-6 text-center text-sm text-gray-600">
-          Don&apos;t have an account?{' '}
-          <Link to="/signup" className="font-semibold text-red-600 hover:text-red-700">
-            Create one now
-          </Link>
-        </p>
+        {signUpAvailable ? (
+          <p className="mt-6 text-center text-sm text-gray-600">
+            Don&apos;t have an account?{' '}
+            <Link to="/signup" className="font-semibold text-red-600 hover:text-red-700">
+              Create one now
+            </Link>
+          </p>
+        ) : (
+          <p className="mt-6 text-center text-sm text-gray-600">
+            New registrations are temporarily paused while we complete scheduled maintenance.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,10 +1,23 @@
 import { Link } from 'react-router-dom';
 import AuthForm from '@/components/AuthForm';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { getMaintenanceConfig } from '@/config/featureFlags';
 
 export const SignUp = () => {
+  const maintenance = getMaintenanceConfig();
+  const maintenanceActive = maintenance.enabled;
+  const signUpDisabled = maintenanceActive && !maintenance.allowSignUp;
+  const signInAvailable = !maintenanceActive || maintenance.allowSignIn;
+
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-white via-orange-50 to-green-100 p-6">
       <div className="w-full max-w-xl rounded-2xl bg-white/90 p-8 shadow-xl ring-1 ring-orange-100/60 backdrop-blur">
+        {maintenanceActive && (
+          <Alert variant="warning" className="mb-6">
+            <AlertTitle>{maintenance.bannerTitle}</AlertTitle>
+            <AlertDescription>{maintenance.bannerMessage}</AlertDescription>
+          </Alert>
+        )}
         <div className="mb-6 text-center">
           <img
             src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
@@ -19,14 +32,25 @@ export const SignUp = () => {
           </p>
         </div>
 
-        <AuthForm mode="signup" redirectTo="/" />
+        <AuthForm
+          mode="signup"
+          redirectTo="/"
+          disabled={signUpDisabled}
+          disabledReason={maintenance.bannerMessage}
+        />
 
-        <p className="mt-6 text-center text-sm text-gray-600">
-          Already have an account?{' '}
-          <Link to="/signin" className="font-semibold text-red-600 hover:text-red-700">
-            Sign in instead
-          </Link>
-        </p>
+        {signInAvailable ? (
+          <p className="mt-6 text-center text-sm text-gray-600">
+            Already have an account?{' '}
+            <Link to="/signin" className="font-semibold text-red-600 hover:text-red-700">
+              Sign in instead
+            </Link>
+          </p>
+        ) : (
+          <p className="mt-6 text-center text-sm text-gray-600">
+            Sign-in is temporarily disabled while we finalize our production migration.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/supabase/migrations/20250206093000_enforce_donations_fk_cascade.sql
+++ b/supabase/migrations/20250206093000_enforce_donations_fk_cascade.sql
@@ -1,0 +1,9 @@
+-- Ensure donations.donor_user_id cascades with user/profile deletions
+alter table public.donations
+  drop constraint if exists donations_donor_user_id_fkey;
+
+alter table public.donations
+  add constraint donations_donor_user_id_fkey
+    foreign key (donor_user_id)
+    references public.profiles (id)
+    on delete cascade;


### PR DESCRIPTION
## Summary
- add configurable maintenance-mode guard that disables auth forms and surfaces a banner during production cleanup windows
- document maintenance toggles plus backup and restore procedures, and update environment references for new feature flags
- provide SQL utilities for purging non-production users and verifying cascade integrity, including a migration to enforce cascading donations foreign keys

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/SignIn.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915aaffa2a48328bdc0a7df4ac72876)