### PR TITLE
Standardize support contact details to wathaci.com

### DIFF
--- a/ENVIRONMENT_SETUP_GUIDE.md
+++ b/ENVIRONMENT_SETUP_GUIDE.md
@@ -294,7 +294,7 @@ If you're still experiencing issues:
 1. Check the browser console for error messages
 2. Verify environment variables are being read: check the Network tab for API calls
 3. Review the [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) file
-4. Contact support@wathaci.org
+4. Contact support@wathaci.com
 
 ## Summary Checklist
 

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -43,7 +43,7 @@ router.post('/', validate(userSchema), async (req, res) => {
       const status = error.status ?? 500;
       const message =
         status === 503
-          ? 'Registrations are temporarily unavailable. Please contact support.'
+          ? 'Registrations are temporarily unavailable. Please contact support@wathaci.com.'
           : 'Unable to save registration. Please try again later.';
       return res.status(status).json({ error: message });
     }

--- a/backend/supabase-functions/industry-matcher.ts
+++ b/backend/supabase-functions/industry-matcher.ts
@@ -277,7 +277,7 @@ serve(async (req) => {
         matches: { freelancers: [], funding: [], partnerships: [] },
         recommendations: {
           priority: 'Unable to generate recommendations at this time.',
-          nextSteps: 'Please retry the request or contact support if the issue persists.',
+          nextSteps: 'Please retry the request or contact support@wathaci.com if the issue persists.',
           timeline: 'Pending resolution.'
         },
         error: message

--- a/backend/supabase/maintenance/purge_non_production_users.sql
+++ b/backend/supabase/maintenance/purge_non_production_users.sql
@@ -15,8 +15,7 @@ begin;
 create temp table purge_allowed_domains(domain text);
 insert into purge_allowed_domains(domain)
 values
-  ('wathaci.com'),
-  ('wathaci.org');
+  ('wathaci.com');
 
 create temp table purge_allowed_emails(email text);
 insert into purge_allowed_emails(email)

--- a/docs/PAYMENT_INTEGRATION_GUIDE.md
+++ b/docs/PAYMENT_INTEGRATION_GUIDE.md
@@ -784,8 +784,8 @@ All webhook events are logged to `webhook_logs` table with:
 
 For technical support and questions:
 
-- Email: support@wathaci.org
-- Documentation: https://docs.wathaci.org
+- Email: support@wathaci.com
+- Documentation: https://docs.wathaci.com
 - GitHub Issues: https://github.com/Kena440/WATHACI-CONNECT.-V1/issues
 
 ## License

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta property="og:title" content="WATHACI CONNECT - Empowering Zambian Business Excellence" />
     <meta property="og:description" content="Connect with professional services, find skilled freelancers, and access resources designed specifically for Zambian businesses." />
     <meta property="og:image" content="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png" />
-    <meta property="og:url" content="https://wathaci.org" />
+    <meta property="og:url" content="https://wathaci.com" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="WATHACI CONNECT - Empowering Zambian Business Excellence" />

--- a/scripts/setup-payments.sh
+++ b/scripts/setup-payments.sh
@@ -245,7 +245,7 @@ echo -e "${BLUE}🆘 Need Help?${NC}"
 echo "- Check the documentation"
 echo "- Run payment tests: npm run test:jest"
 echo "- Review application logs"
-echo "- Contact support: support@wathaci.org"
+echo "- Contact support: support@wathaci.com"
 
 echo ""
 echo -e "${GREEN}Happy coding! 🚀${NC}"

--- a/src/components/ConfigurationError.tsx
+++ b/src/components/ConfigurationError.tsx
@@ -115,7 +115,7 @@ npm run preview`}
         </section>
 
         <footer className="text-xs text-gray-500">
-          Need help? Email <a className="text-blue-600 underline" href="mailto:support@wathaci.org">support@wathaci.org</a> or
+          Need help? Email <a className="text-blue-600 underline" href="mailto:support@wathaci.com">support@wathaci.com</a> or
           check the deployment runbook.
         </footer>
       </div>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -146,8 +146,8 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
           <div className="space-y-2">
             <h2 className="text-xl font-semibold text-gray-900">Something went wrong.</h2>
             <p className="max-w-md text-sm text-gray-600">
-              An unexpected error occurred while rendering WATHACI CONNECT. Try reloading the page or contact support if the
-              problem continues.
+              An unexpected error occurred while rendering WATHACI CONNECT. Try reloading the page or contact
+              support@wathaci.com if the problem continues.
             </p>
           </div>
           {import.meta.env.DEV && this.state.error && (
@@ -176,11 +176,11 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
             </button>
             <p>
               Need help?{" "}
-              <a className="text-blue-600 underline" href="mailto:support@wathaci.org">
+              <a className="text-blue-600 underline" href="mailto:support@wathaci.com">
                 Contact support
               </a>{" "}
               or visit our{" "}
-              <a className="text-blue-600 underline" href="https://wathaci.org/help" target="_blank" rel="noreferrer">
+              <a className="text-blue-600 underline" href="https://wathaci.com/help" target="_blank" rel="noreferrer">
                 help center
               </a>
               .

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -49,7 +49,16 @@ const Footer = () => {
             <h3 className="text-lg font-semibold mb-4 text-orange-400">Support</h3>
             <ul className="space-y-2">
               <li><Link to="/get-started" className="text-gray-300 hover:text-white transition-colors">Get Started</Link></li>
-              <li><Link to="/resources" className="text-gray-300 hover:text-white transition-colors">Help Center</Link></li>
+              <li>
+                <a
+                  href="https://wathaci.com/help"
+                  className="text-gray-300 hover:text-white transition-colors"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Help Center
+                </a>
+              </li>
               <li><Link to="/privacy-policy" className="text-gray-300 hover:text-white transition-colors">Privacy Policy</Link></li>
               <li><Link to="/terms-of-service" className="text-gray-300 hover:text-white transition-colors">Terms of Service</Link></li>
             </ul>

--- a/src/components/LencoPayment.tsx
+++ b/src/components/LencoPayment.tsx
@@ -46,7 +46,7 @@ export const LencoPayment = ({ amount, description, transactionType = 'marketpla
     const newErrors: Record<string, string> = {};
 
     if (!isConfigured) {
-      newErrors.config = 'Payment system is not properly configured. Please contact support.';
+      newErrors.config = 'Payment system is not properly configured. Please contact support@wathaci.com.';
     }
 
     if (totalAmount < paymentConfig.minAmount) {
@@ -176,7 +176,7 @@ export const LencoPayment = ({ amount, description, transactionType = 'marketpla
           <Alert variant="destructive">
             <AlertCircle className="h-4 w-4" />
             <AlertDescription>
-              Payment system is currently unavailable. Please contact support.
+              Payment system is currently unavailable. Please contact support@wathaci.com.
             </AlertDescription>
           </Alert>
         </CardContent>

--- a/src/components/PaymentStatusTracker.tsx
+++ b/src/components/PaymentStatusTracker.tsx
@@ -336,8 +336,8 @@ export const PaymentStatusTracker = ({
           <Alert variant="destructive">
             <XCircle className="h-4 w-4" />
             <AlertDescription>
-              Payment {paymentStatus?.status}. 
-              {paymentStatus?.status === 'failed' && ' Please try again or contact support.'}
+              Payment {paymentStatus?.status}.
+              {paymentStatus?.status === 'failed' && ' Please try again or contact support@wathaci.com.'}
             </AlertDescription>
           </Alert>
         )}
@@ -357,7 +357,7 @@ export const PaymentStatusTracker = ({
           <Alert variant="destructive">
             <AlertTriangle className="h-4 w-4" />
             <AlertDescription>
-              Payment tracking will timeout soon. Please contact support if your payment was deducted.
+              Payment tracking will timeout soon. Please contact support@wathaci.com if your payment was deducted.
             </AlertDescription>
           </Alert>
         )}

--- a/src/components/SubscriptionCard.tsx
+++ b/src/components/SubscriptionCard.tsx
@@ -147,7 +147,7 @@ export const SubscriptionCard = ({ plan, userType, compact = false }: Subscripti
       console.error('Payment verification error:', error);
       toast({
         title: "Payment Verification Failed",
-        description: "Please contact support if payment was deducted",
+        description: "Please contact support@wathaci.com if payment was deducted",
         variant: "destructive",
       });
     }

--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -812,9 +812,9 @@ export const withErrorHandling = async <T>(
       
       if (errorMessage.includes('Invalid API key') || 
           errorMessage.includes('Invalid Supabase URL')) {
-        return { 
-          data: null, 
-          error: new Error('Configuration error. Please contact support.') 
+        return {
+          data: null,
+          error: new Error('Configuration error. Please contact support@wathaci.com.')
         };
       }
       

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -128,7 +128,7 @@ const Marketplace = () => {
       console.error('Error saving order:', error);
       toast({
         title: 'Order save failed',
-        description: 'Please contact support if payment was deducted.',
+        description: 'Please contact support@wathaci.com if payment was deducted.',
         variant: 'destructive'
       });
     }


### PR DESCRIPTION
## Summary
- replace all remaining wathaci.org references with wathaci.com, including support email and help center URLs across UI, docs, scripts, and backend utilities
- align error states, payment flows, and configuration messaging to direct users to support@wathaci.com and https://wathaci.com/help
- update metadata and maintenance allowlists to reflect the canonical wathaci.com domain

## Testing
- npm run build
- npm run preview -- --host --port 4173

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a5bbd99c8328836b3a7c69c37dc0)