### PR TITLE
Fix profile creation permissions and fallback

### DIFF
--- a/supabase/migrations/20250309100000_profiles_insert_owner.sql
+++ b/supabase/migrations/20250309100000_profiles_insert_owner.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+DROP POLICY IF EXISTS profiles_insert_none ON public.profiles;
+DROP POLICY IF EXISTS profiles_insert_owner ON public.profiles;
+
+CREATE POLICY profiles_insert_owner ON public.profiles
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (id = auth.uid());
+
+GRANT EXECUTE ON FUNCTION public.ensure_profile_exists(uuid, text, text, text, text) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- allow authenticated users to insert their own profiles and permit RPC bootstrap function
- add RPC fallback in profile creation to bypass RLS and fetch created profile

## Testing
- npm test -- --runInBand src/pages/__tests__/SignUp.test.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919ae19168c8328ab8cf2bd995fa2d2)