### PR TITLE
Add Wathaci auth schema and onboarding flow

### DIFF
--- a/docs/wathaci-auth-onboarding.md
+++ b/docs/wathaci-auth-onboarding.md
@@ -1,0 +1,153 @@
+# Wathaci Auth & Onboarding Blueprint
+
+This guide captures the end-to-end pieces requested for a ZAQA-style flow: database schema, RLS, Supabase client, React components, and a lightweight auth context/route guard.
+
+## DB Schema (SQL)
+
+### profiles table & supporting structures
+
+All SQL is captured in `supabase/migrations/20250501093000_wathaci_profiles_schema.sql` and can be pushed with `supabase db push`.
+
+Key decisions:
+- **Enum**: `account_type_enum` enforces the allowed values (`SME`, `INVESTOR`, `SERVICE_PROVIDER`, `PARTNER`, `ADMIN`). An enum keeps the constraint tight and indexes compact; a lookup table is provided for readability/metadata.
+- **1:1 with auth.users**: `profiles.id` references `auth.users.id` with `ON DELETE CASCADE`.
+- **bookkeeping**: `created_at`/`updated_at` default to UTC with an auto-update trigger.
+
+```sql
+-- Enum and lookup table
+CREATE TYPE public.account_type_enum AS ENUM ('SME','INVESTOR','SERVICE_PROVIDER','PARTNER','ADMIN');
+CREATE TABLE public.account_types (
+  account_type public.account_type_enum PRIMARY KEY,
+  label text NOT NULL UNIQUE
+);
+
+-- Profiles core
+CREATE TABLE public.profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+  email text NOT NULL,
+  full_name text,
+  account_type public.account_type_enum NOT NULL DEFAULT 'SME',
+  company_name text,
+  phone text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Useful indexes
+CREATE UNIQUE INDEX profiles_email_key ON public.profiles (email);
+CREATE INDEX profiles_account_type_idx ON public.profiles (account_type);
+```
+
+### updated_at trigger
+
+```sql
+CREATE OR REPLACE FUNCTION public.set_current_timestamp_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = timezone('utc', now());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_profiles_updated_at
+BEFORE UPDATE ON public.profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.set_current_timestamp_updated_at();
+```
+
+## RLS Policies (SQL)
+
+Defined in the same migration:
+
+```sql
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+-- Owner policies
+CREATE POLICY profiles_select_owner ON public.profiles
+  FOR SELECT TO authenticated USING (id = auth.uid());
+CREATE POLICY profiles_insert_owner ON public.profiles
+  FOR INSERT TO authenticated WITH CHECK (id = auth.uid());
+CREATE POLICY profiles_update_owner ON public.profiles
+  FOR UPDATE TO authenticated USING (id = auth.uid()) WITH CHECK (id = auth.uid());
+
+-- Admin access (ADMIN users can select/update any row)
+CREATE POLICY profiles_admin_all ON public.profiles
+  FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.account_type = 'ADMIN'))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.account_type = 'ADMIN'));
+```
+
+### Optional profile auto-create trigger
+
+```sql
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_email text; BEGIN
+  v_email := NEW.email;
+  INSERT INTO public.profiles (id, email, account_type)
+  VALUES (NEW.id, v_email, 'SME')
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END; $$;
+
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+```
+
+Use the Supabase **service role** when invoking `auth.admin.createUser` or running backfills; client-side signup will work with the insert policy if `id = auth.uid()` matches.
+
+## Supabase Client Setup (TypeScript)
+
+`src/lib/wathaciSupabaseClient.ts` is a minimal, copy/paste-friendly client using Vite env vars. It exports `supabaseClient`, the `AccountType` union, and `accountTypePaths` (redirect map).
+
+```ts
+import { createClient } from "@supabase/supabase-js";
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error("Missing Supabase configuration. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.");
+}
+export const supabaseClient = createClient(supabaseUrl, supabaseAnonKey);
+```
+
+## React Signup Flow Components
+
+Files live in `src/components/auth` and `src/pages/WathaciSignup.tsx`.
+
+### AccountTypeSelector
+
+- Cards for SME, Investor, Service Provider, Partner.
+- Prop: `onSelect(accountType)`.
+
+### SignupForm
+
+- Props: `accountType`, optional `onSuccess`.
+- Handles email/password, full name, company name.
+- Calls `supabase.auth.signUp` then inserts into `profiles` (requires RLS insert policy to pass `id = auth.uid()`).
+- Shows friendly errors; does not throw in UI code.
+
+### SignupFlow
+
+- Orchestrator: Step 1 (select) → Step 2 (form) → Step 3 (success/next steps).
+- Place on a route, e.g., `/signup` using `src/pages/WathaciSignup.tsx`.
+
+### Optional LoginForm
+
+- Email + password.
+- Fetches `profiles.account_type` after sign-in and redirects via `accountTypePaths`.
+
+## Auth Context + Protected Route (light version)
+
+`src/contexts/AuthContextLight.tsx` provides:
+- `AuthProvider` listening to `supabase.auth.onAuthStateChange`.
+- `useAuth()` hook returning `{ session, user, loading, error }`.
+- `ProtectedRoute` wrapper that redirects unauthenticated users to `/login` (using `react-router-dom`'s `Navigate`).
+
+## Notes/Assumptions & How to Adapt
+
+- RLS policies expect `auth.uid()` to match `profiles.id`; admin-wide access hinges on the admin's own profile having `account_type = 'ADMIN'`.
+- If you enforce email confirmation, the signup UI surfaces a "check your email" prompt when `data.session` is null. Without confirmation, it redirects immediately using the account type mapping.
+- Company/phone are optional; extend the schema with additional onboarding fields as needed.
+- The lookup table lets you attach descriptions/ordering later without changing the enum values.

--- a/src/components/auth/AccountTypeSelector.tsx
+++ b/src/components/auth/AccountTypeSelector.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import type { AccountType } from "@/lib/wathaciSupabaseClient";
+
+const accountTypeDetails: { value: AccountType; label: string; description: string }[] = [
+  { value: "SME", label: "SME", description: "Operate and grow your business." },
+  { value: "INVESTOR", label: "Investor", description: "Discover and fund opportunities." },
+  { value: "SERVICE_PROVIDER", label: "Service Provider", description: "Offer services to SMEs and partners." },
+  { value: "PARTNER", label: "Partner", description: "Collaborate as an ecosystem partner." },
+];
+
+export interface AccountTypeSelectorProps {
+  onSelect: (accountType: AccountType) => void;
+  selected?: AccountType;
+}
+
+export const AccountTypeSelector: React.FC<AccountTypeSelectorProps> = ({
+  onSelect,
+  selected,
+}) => {
+  return (
+    <div className="flex flex-col gap-4">
+      <h2 className="text-2xl font-semibold">Choose your account type</h2>
+      <p className="text-sm text-gray-600">
+        Select how you want to use Wathaci. You can request changes later from support.
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {accountTypeDetails.map((type) => {
+          const isSelected = selected === type.value;
+          return (
+            <button
+              key={type.value}
+              type="button"
+              onClick={() => onSelect(type.value)}
+              className={`rounded-lg border p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md ${
+                isSelected ? "border-blue-600 ring-2 ring-blue-200" : "border-gray-200"
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-lg font-medium">{type.label}</span>
+                {isSelected && <span className="text-sm font-semibold text-blue-600">Selected</span>}
+              </div>
+              <p className="mt-2 text-sm text-gray-600">{type.description}</p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default AccountTypeSelector;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from "react";
+import { supabaseClient, accountTypePaths, type AccountType } from "@/lib/wathaciSupabaseClient";
+
+export interface LoginFormProps {
+  onLogin?: (accountType: AccountType) => void;
+}
+
+export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogin = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const { data, error: signInError } = await supabaseClient.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (signInError) {
+        setError(signInError.message);
+        return;
+      }
+
+      const userId = data.user?.id;
+      if (!userId) {
+        setError("Login succeeded but no user data was returned.");
+        return;
+      }
+
+      const { data: profile, error: profileError } = await supabaseClient
+        .from("profiles")
+        .select("account_type")
+        .eq("id", userId)
+        .single();
+
+      if (profileError) {
+        console.error(profileError);
+        setError(profileError.message);
+        return;
+      }
+
+      const accountType = profile?.account_type as AccountType;
+      const destination = accountType ? accountTypePaths[accountType] : "/";
+      onLogin?.(accountType);
+      window.location.href = destination;
+    } catch (unknownError) {
+      console.error(unknownError);
+      setError("Unable to login. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleLogin} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Email</label>
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Password</label>
+        <input
+          type="password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+        />
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full rounded bg-blue-600 px-4 py-2 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-70"
+      >
+        {loading ? "Signing in..." : "Login"}
+      </button>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/src/components/auth/SignupFlow.tsx
+++ b/src/components/auth/SignupFlow.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import type { AccountType } from "@/lib/wathaciSupabaseClient";
+import { AccountTypeSelector } from "./AccountTypeSelector";
+import { SignupForm } from "./SignupForm";
+
+export const SignupFlow: React.FC = () => {
+  const [step, setStep] = useState<"account" | "form" | "success">("account");
+  const [accountType, setAccountType] = useState<AccountType | null>(null);
+
+  const handleSelect = (selected: AccountType) => {
+    setAccountType(selected);
+    setStep("form");
+  };
+
+  const handleSuccess = () => {
+    setStep("success");
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl rounded-xl border bg-white p-8 shadow">
+      <h1 className="text-3xl font-bold">Join Wathaci</h1>
+      <p className="mt-2 text-gray-600">ZAQA-style flow: Select Account Type → Register → Login</p>
+
+      {step === "account" && (
+        <div className="mt-6">
+          <AccountTypeSelector selected={accountType || undefined} onSelect={handleSelect} />
+          <p className="mt-4 text-sm text-gray-600">Click a card to continue.</p>
+        </div>
+      )}
+
+      {step === "form" && accountType && (
+        <SignupForm accountType={accountType} onSuccess={handleSuccess} />
+      )}
+
+      {step === "success" && (
+        <div className="mt-6 space-y-3 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800">
+          <h2 className="text-xl font-semibold">Signup complete</h2>
+          <p>
+            If email confirmation is enabled, check your inbox. After logging in you'll be redirected
+            based on your account type.
+          </p>
+          <ul className="list-disc space-y-1 pl-6 text-sm">
+            <li>SME → /dashboard/sme</li>
+            <li>Investor → /dashboard/investor</li>
+            <li>Service Provider → /dashboard/service-provider</li>
+            <li>Partner → /dashboard/partner</li>
+            <li>Admin → /dashboard/admin</li>
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SignupFlow;

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,0 +1,167 @@
+import React, { useMemo, useState } from "react";
+import { supabaseClient, accountTypePaths, type AccountType } from "@/lib/wathaciSupabaseClient";
+
+export interface SignupFormProps {
+  accountType: AccountType;
+  onSuccess?: (accountType: AccountType) => void;
+}
+
+export const SignupForm: React.FC<SignupFormProps> = ({ accountType, onSuccess }) => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [fullName, setFullName] = useState("");
+  const [companyName, setCompanyName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const redirectPath = useMemo(() => accountTypePaths[accountType], [accountType]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setSuccessMessage(null);
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const { data, error: signUpError } = await supabaseClient.auth.signUp({
+        email,
+        password,
+      });
+
+      if (signUpError) {
+        setError(signUpError.message);
+        return;
+      }
+
+      const userId = data.user?.id;
+      if (!userId) {
+        setError("Signup succeeded but user information is missing. Please check your email.");
+        return;
+      }
+
+      const { error: profileError } = await supabaseClient.from("profiles").insert({
+        id: userId,
+        email,
+        full_name: fullName || null,
+        account_type: accountType,
+        company_name: companyName || null,
+      });
+
+      if (profileError) {
+        console.error("Profile insert failed", profileError);
+        setError(profileError.message);
+        return;
+      }
+
+      if (!data.session) {
+        setSuccessMessage(
+          "Account created. Please check your email to confirm before logging in."
+        );
+      } else {
+        setSuccessMessage("Account created. Redirecting to your dashboard...");
+        setTimeout(() => {
+          window.location.href = redirectPath;
+        }, 1200);
+      }
+
+      onSuccess?.(accountType);
+    } catch (unknownError) {
+      console.error(unknownError);
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Account type</label>
+        <input
+          value={accountType}
+          readOnly
+          className="mt-1 w-full rounded border bg-gray-50 p-2 text-gray-700"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Email</label>
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Password</label>
+        <input
+          type="password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Confirm password</label>
+        <input
+          type="password"
+          required
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Full name</label>
+        <input
+          type="text"
+          value={fullName}
+          onChange={(e) => setFullName(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+          placeholder="Jane Doe"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Company name</label>
+        <input
+          type="text"
+          value={companyName}
+          onChange={(e) => setCompanyName(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+          placeholder="Optional"
+        />
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {successMessage && <p className="text-sm text-green-600">{successMessage}</p>}
+
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full rounded bg-blue-600 px-4 py-2 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-70"
+      >
+        {loading ? "Creating account..." : "Create account"}
+      </button>
+
+      {dataPrivacyCopy}
+    </form>
+  );
+};
+
+const dataPrivacyCopy = (
+  <p className="text-xs text-gray-500">
+    By continuing you agree to Wathaci's terms. Do not access session.user if session is
+    null—always check Supabase auth state before using protected endpoints.
+  </p>
+);
+
+export default SignupForm;

--- a/src/contexts/AuthContextLight.tsx
+++ b/src/contexts/AuthContextLight.tsx
@@ -1,0 +1,83 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import type { Session, User } from "@supabase/supabase-js";
+import { supabaseClient } from "@/lib/wathaciSupabaseClient";
+import { Navigate } from "react-router-dom";
+
+interface AuthContextValue {
+  session: Session | null;
+  user: User | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const initSession = async () => {
+      const { data, error: sessionError } = await supabaseClient.auth.getSession();
+      if (!isMounted) return;
+      if (sessionError) {
+        setError(sessionError.message);
+      }
+      setSession(data.session ?? null);
+      setUser(data.session?.user ?? null);
+      setLoading(false);
+    };
+
+    initSession();
+
+    const { data: authListener } = supabaseClient.auth.onAuthStateChange((event, newSession) => {
+      if (!isMounted) return;
+      if (event === "TOKEN_REFRESHED" || event === "SIGNED_IN" || event === "SIGNED_OUT") {
+        setSession(newSession);
+        setUser(newSession?.user ?? null);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+      authListener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const value: AuthContextValue = {
+    session,
+    user,
+    loading,
+    error,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextValue => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return ctx;
+};
+
+export const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <p className="p-4 text-gray-600">Checking authentication...</p>;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default AuthProvider;

--- a/src/lib/wathaciSupabaseClient.ts
+++ b/src/lib/wathaciSupabaseClient.ts
@@ -1,0 +1,36 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+// Minimal Supabase client dedicated to the Wathaci auth/onboarding flow.
+// Ensure VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY are set in your
+// Vite environment (e.g., .env.local). We intentionally keep this lean so
+// it can be copied into standalone onboarding pages without the broader
+// application config dependencies.
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  // Early surface of misconfiguration for developers.
+  throw new Error(
+    "Missing Supabase configuration. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your environment."
+  );
+}
+
+export const supabaseClient: SupabaseClient = createClient(
+  supabaseUrl,
+  supabaseAnonKey
+);
+
+export type AccountType =
+  | "SME"
+  | "INVESTOR"
+  | "SERVICE_PROVIDER"
+  | "PARTNER"
+  | "ADMIN";
+
+export const accountTypePaths: Record<AccountType, string> = {
+  SME: "/dashboard/sme",
+  INVESTOR: "/dashboard/investor",
+  SERVICE_PROVIDER: "/dashboard/service-provider",
+  PARTNER: "/dashboard/partner",
+  ADMIN: "/dashboard/admin",
+};

--- a/src/pages/WathaciSignup.tsx
+++ b/src/pages/WathaciSignup.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { SignupFlow } from "@/components/auth/SignupFlow";
+
+const WathaciSignupPage: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-50 py-10">
+      <SignupFlow />
+    </div>
+  );
+};
+
+export default WathaciSignupPage;

--- a/supabase/migrations/20250501093000_wathaci_profiles_schema.sql
+++ b/supabase/migrations/20250501093000_wathaci_profiles_schema.sql
@@ -1,0 +1,156 @@
+BEGIN;
+
+-- Create the enum for account types. Using an enum gives tight validation
+-- and efficient indexing; if you prefer a lookup table only, drop this and
+-- rely on the account_types table below.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'account_type_enum') THEN
+    CREATE TYPE public.account_type_enum AS ENUM (
+      'SME',
+      'INVESTOR',
+      'SERVICE_PROVIDER',
+      'PARTNER',
+      'ADMIN'
+    );
+  END IF;
+END
+$$;
+
+-- Optional but recommended lookup for clearer labels and future metadata.
+CREATE TABLE IF NOT EXISTS public.account_types (
+  account_type public.account_type_enum PRIMARY KEY,
+  label text NOT NULL UNIQUE
+);
+
+INSERT INTO public.account_types (account_type, label)
+VALUES
+  ('SME', 'SME'),
+  ('INVESTOR', 'Investor'),
+  ('SERVICE_PROVIDER', 'Service Provider'),
+  ('PARTNER', 'Partner'),
+  ('ADMIN', 'Admin')
+ON CONFLICT (account_type) DO UPDATE SET label = EXCLUDED.label;
+
+-- Core profiles table. Kept id in sync with auth.users.id for 1:1 mapping.
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+  email text NOT NULL,
+  full_name text,
+  account_type public.account_type_enum NOT NULL DEFAULT 'SME',
+  company_name text,
+  phone text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Backfill/ensure columns exist when migrating an already-existing table.
+ALTER TABLE public.profiles
+  ALTER COLUMN email SET NOT NULL,
+  ALTER COLUMN account_type SET NOT NULL,
+  ALTER COLUMN account_type SET DEFAULT 'SME';
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS company_name text,
+  ADD COLUMN IF NOT EXISTS phone text,
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  ADD COLUMN IF NOT EXISTS account_type public.account_type_enum NOT NULL DEFAULT 'SME';
+
+-- Ensure email uniqueness and make account_type filter-friendly.
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_email_key ON public.profiles (email);
+CREATE INDEX IF NOT EXISTS profiles_account_type_idx ON public.profiles (account_type);
+
+-- updated_at trigger for automatic bookkeeping.
+CREATE OR REPLACE FUNCTION public.set_current_timestamp_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = timezone('utc', now());
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_profiles_updated_at ON public.profiles;
+CREATE TRIGGER set_profiles_updated_at
+BEFORE UPDATE ON public.profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.set_current_timestamp_updated_at();
+
+-- RLS configuration
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+-- Clean up existing policies to avoid duplicates/conflicts.
+DROP POLICY IF EXISTS profiles_select_owner ON public.profiles;
+DROP POLICY IF EXISTS profiles_update_owner ON public.profiles;
+DROP POLICY IF EXISTS profiles_insert_owner ON public.profiles;
+DROP POLICY IF EXISTS profiles_admin_all ON public.profiles;
+
+-- A user can view only their profile row.
+CREATE POLICY profiles_select_owner ON public.profiles
+  FOR SELECT
+  TO authenticated
+  USING (id = auth.uid());
+
+-- A user can insert only their own profile row.
+CREATE POLICY profiles_insert_owner ON public.profiles
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (id = auth.uid());
+
+-- A user can update only their own profile row.
+CREATE POLICY profiles_update_owner ON public.profiles
+  FOR UPDATE
+  TO authenticated
+  USING (id = auth.uid())
+  WITH CHECK (id = auth.uid());
+
+-- Admins (account_type = 'ADMIN') can access all rows.
+CREATE POLICY profiles_admin_all ON public.profiles
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p_admin
+      WHERE p_admin.id = auth.uid()
+        AND p_admin.account_type = 'ADMIN'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p_admin
+      WHERE p_admin.id = auth.uid()
+        AND p_admin.account_type = 'ADMIN'
+    )
+  );
+
+-- Optional: auto-create a profile for new auth.users rows so client-side
+-- signup flows don't require elevated keys. Use service role for insertion
+-- from server-side code, or rely on this trigger for automatic creation.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email text;
+BEGIN
+  v_email := NEW.email;
+  INSERT INTO public.profiles (id, email, account_type)
+  VALUES (NEW.id, v_email, 'SME')
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_new_user();
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add Supabase migration for account_type enum, account_types lookup, profiles shape, triggers, and RLS/admin policies
- document the schema and onboarding flow plus provide a minimal supabase client for Wathaci
- add React components for ZAQA-style signup/login flow with a lightweight auth context and signup page

## Testing
- npx eslint src/components/auth/*.tsx src/contexts/AuthContextLight.tsx src/lib/wathaciSupabaseClient.ts src/pages/WathaciSignup.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aeded2e5083289765a4ebb5847dea)