### PR TITLE
Add Twilio SMS/WhatsApp OTP endpoints and storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,30 @@ After creating the files, update them with your actual credentials:
 - `SMTP_PASSWORD` – SMTP password for email delivery (see [Email Configuration Guide](EMAIL_CONFIGURATION_GUIDE.md)).
 - `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_MESSAGE_SERVICE_SID` – Twilio credentials for SMS OTP (see [SMS OTP Setup Guide](SMS_OTP_SETUP_GUIDE.md)).
 
+## SMS & WhatsApp OTP (Twilio)
+
+The backend now exposes OTP endpoints backed by Twilio. Configure the following environment variables at runtime:
+
+```
+TWILIO_ACCOUNT_SID=<twilio-account-sid>
+TWILIO_AUTH_TOKEN=<twilio-auth-token>
+TWILIO_MESSAGE_SERVICE_SID=<preferred messaging service>
+# Optional fallbacks
+TWILIO_PHONE_NUMBER=+1234567890
+TWILIO_WHATSAPP_FROM=whatsapp:+1234567890
+
+# Enable Supabase-backed persistence (recommended)
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+```
+
+API contracts (JSON):
+
+- `POST /api/auth/otp/send` with `{ "phone": "+260...", "channel": "sms" | "whatsapp" }` → `200 { ok: true }` when dispatched.
+- `POST /api/auth/otp/verify` with `{ "phone": "+260...", "channel": "sms" | "whatsapp", "code": "123456" }` → `200 { ok: true, result: { phone_verified: boolean } }` when valid.
+
+Codes are 6 digits, expire after 10 minutes, and allow up to 5 attempts. When Supabase credentials are present, OTPs are stored in `public.otp_challenges` and successful verifications stamp `profiles.phone_verified_at`.
+
 **Validate your configuration:**
 
 ```bash

--- a/backend/index.js
+++ b/backend/index.js
@@ -70,11 +70,13 @@ const userRoutes = require('./routes/users');
 const logRoutes = require('./routes/logs');
 const paymentRoutes = require('./routes/payment');
 const resolveRoutes = require('./routes/resolve');
+const otpRoutes = require('./routes/otp');
 
 app.use(['/users', '/api/users'], userRoutes);
 app.use('/api/logs', logRoutes);
 app.use('/api/payment', paymentRoutes);
 app.use('/resolve', resolveRoutes);
+app.use(['/api/auth/otp', '/auth/otp'], otpRoutes);
 
 const PORT = process.env.PORT || 3000;
 if (require.main === module) {

--- a/backend/lib/twilioClient.js
+++ b/backend/lib/twilioClient.js
@@ -1,0 +1,67 @@
+const createAuthHeader = (accountSid, authToken) => {
+  const credentials = Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+  return `Basic ${credentials}`;
+};
+
+const getTwilioCredentials = () => {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID || '';
+  const authToken = process.env.TWILIO_AUTH_TOKEN || '';
+
+  if (!accountSid || !authToken) {
+    throw new Error('Twilio credentials are missing. Set TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN.');
+  }
+
+  return { accountSid, authToken };
+};
+
+const sendTwilioMessage = async ({ to, body, messagingServiceSid, from }) => {
+  const { accountSid, authToken } = getTwilioCredentials();
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
+
+  const payload = new URLSearchParams();
+  payload.append('To', to);
+  payload.append('Body', body);
+
+  if (messagingServiceSid) {
+    payload.append('MessagingServiceSid', messagingServiceSid);
+  } else if (from) {
+    payload.append('From', from);
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: createAuthHeader(accountSid, authToken),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: payload.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    const error = new Error('Twilio message request failed');
+    error.status = response.status;
+    error.response = errorText;
+    throw error;
+  }
+
+  return response.json();
+};
+
+const twilioConfig = {
+  get messagingServiceSid() {
+    return process.env.TWILIO_MESSAGE_SERVICE_SID || process.env.TWILIO_MESSAGING_SERVICE_SID || '';
+  },
+  get phoneNumber() {
+    return process.env.TWILIO_PHONE_NUMBER || '';
+  },
+  get whatsappFrom() {
+    return process.env.TWILIO_WHATSAPP_FROM || '';
+  },
+};
+
+module.exports = {
+  sendTwilioMessage,
+  twilioConfig,
+  getTwilioCredentials,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node --test ../test/backend-response.test.js"
+    "test": "node --test ../test/backend-response.test.js ../test/otp.test.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/routes/otp.js
+++ b/backend/routes/otp.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const Joi = require('joi');
+const validate = require('../middleware/validate');
+const { sendOtp, verifyOtp } = require('../services/otp-service');
+const { MAX_ATTEMPTS } = require('../services/otp-store');
+
+const router = express.Router();
+
+const sendSchema = Joi.object({
+  phone: Joi.string().trim().min(5).required(),
+  channel: Joi.string().valid('sms', 'whatsapp').default('sms'),
+});
+
+const verifySchema = Joi.object({
+  phone: Joi.string().trim().min(5).required(),
+  channel: Joi.string().valid('sms', 'whatsapp').default('sms'),
+  code: Joi.string()
+    .trim()
+    .pattern(/^\d{6}$/)
+    .required()
+    .messages({ 'string.pattern.base': 'Code must be a 6-digit number' }),
+});
+
+router.post('/send', validate(sendSchema), async (req, res) => {
+  const { phone, channel } = req.body;
+
+  try {
+    await sendOtp({ phone, channel });
+    return res.json({ ok: true, message: 'OTP sent successfully.' });
+  } catch (error) {
+    console.error('[routes/otp] Failed to send OTP', { message: error?.message, status: error?.status });
+    return res.status(500).json({ ok: false, error: 'Failed to send verification code.' });
+  }
+});
+
+router.post('/verify', validate(verifySchema), async (req, res) => {
+  const { phone, channel, code } = req.body;
+
+  try {
+    const result = await verifyOtp({ phone, channel, code });
+
+    if (!result.ok) {
+      const status = result.reason === 'locked' ? 429 : 400;
+      return res.status(status).json({ ok: false, error: 'Invalid or expired code.' });
+    }
+
+    return res.json({
+      ok: true,
+      message: 'OTP verified.',
+      result: {
+        phone_verified: Boolean(result.verification?.updated),
+        reason: result.verification?.reason,
+        max_attempts: MAX_ATTEMPTS,
+      },
+    });
+  } catch (error) {
+    console.error('[routes/otp] Verification error', { message: error?.message, status: error?.status });
+    return res.status(500).json({ ok: false, error: 'Unable to verify code at this time.' });
+  }
+});
+
+module.exports = router;

--- a/backend/services/otp-service.js
+++ b/backend/services/otp-service.js
@@ -1,0 +1,142 @@
+/**
+ * OTP delivery and verification via Twilio SMS & WhatsApp.
+ *
+ * API contracts (Express routes):
+ *  • POST /api/auth/otp/send
+ *      Body: { phone: string, channel: 'sms' | 'whatsapp' }
+ *      Response: { ok: true, message: string }
+ *  • POST /api/auth/otp/verify
+ *      Body: { phone: string, channel?: 'sms' | 'whatsapp', code: string }
+ *      Response: { ok: true, message: string, result: { phone_verified: boolean } }
+ *
+ * Behaviour:
+ *  • Generates a 6-digit OTP, stores a hashed copy with 10-minute expiry and a
+ *    5-attempt limit (Supabase-backed with in-memory fallback for tests).
+ *  • Sends OTP via Twilio using TWILIO_MESSAGE_SERVICE_SID (or TWILIO_PHONE_NUMBER / TWILIO_WHATSAPP_FROM).
+ *  • Verifies codes, increments attempt counters, and marks the phone as verified in Supabase profiles when available.
+ *
+ * Required environment variables:
+ *  - TWILIO_ACCOUNT_SID
+ *  - TWILIO_AUTH_TOKEN
+ *  - TWILIO_MESSAGE_SERVICE_SID (preferred) or TWILIO_MESSAGING_SERVICE_SID
+ *  - TWILIO_PHONE_NUMBER (fallback for SMS)
+ *  - TWILIO_WHATSAPP_FROM (fallback for WhatsApp)
+ *  - SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (optional; enables persistence)
+ */
+
+const { randomInt } = require('crypto');
+const twilioClient = require('../lib/twilioClient');
+const {
+  persistOtp,
+  loadActiveOtp,
+  incrementAttempt,
+  markOtpUsed,
+  hashOtpCode,
+  OTP_EXPIRY_MS,
+  MAX_ATTEMPTS,
+} = require('./otp-store');
+const { markPhoneVerified, normalizePhone } = require('./phone-verification');
+
+const generateOtp = () => String(randomInt(0, 1_000_000)).padStart(6, '0');
+
+const normalizeChannel = (channel = 'sms') => (channel || 'sms').toLowerCase();
+
+const formatDestination = (phone, channel) => {
+  if (channel === 'whatsapp') {
+    return phone.startsWith('whatsapp:') ? phone : `whatsapp:${phone}`;
+  }
+  return phone;
+};
+
+const resolveMessagingConfig = (channel) => {
+  const messagingServiceSid = twilioClient.twilioConfig.messagingServiceSid;
+  const whatsappFrom = twilioClient.twilioConfig.whatsappFrom;
+  const phoneNumber = twilioClient.twilioConfig.phoneNumber;
+
+  if (!messagingServiceSid && channel === 'sms' && !phoneNumber) {
+    throw new Error('Missing Twilio SMS sender configuration');
+  }
+
+  if (channel === 'whatsapp' && !messagingServiceSid && !whatsappFrom && !phoneNumber) {
+    throw new Error('Missing Twilio WhatsApp sender configuration');
+  }
+
+  if (channel === 'whatsapp') {
+    return {
+      messagingServiceSid,
+      from: whatsappFrom || phoneNumber || undefined,
+    };
+  }
+
+  return {
+    messagingServiceSid,
+    from: phoneNumber || undefined,
+  };
+};
+
+const sendOtp = async ({ phone, channel = 'sms' }) => {
+  const normalizedChannel = normalizeChannel(channel);
+  const normalizedPhone = normalizePhone(phone);
+  const destination = formatDestination(normalizedPhone, normalizedChannel);
+
+  const code = generateOtp();
+  const { expiresAt } = await persistOtp({ phone: normalizedPhone, channel: normalizedChannel, code });
+
+  const senderConfig = resolveMessagingConfig(normalizedChannel);
+  const messageBody = `Your Wathaci verification code is ${code}. It expires in ${Math.floor(
+    OTP_EXPIRY_MS / 60000,
+  )} minutes.`;
+
+  await twilioClient.sendTwilioMessage({
+    to: destination,
+    body: messageBody,
+    messagingServiceSid: senderConfig.messagingServiceSid,
+    from: senderConfig.from,
+  });
+
+  const maskedCode = `${code.slice(0, 2)}****`;
+  console.info('[otp-service] OTP dispatched', {
+    channel: normalizedChannel,
+    phone: normalizedPhone ? `${normalizedPhone.slice(0, 4)}***` : 'unknown',
+    code_hint: maskedCode,
+    expires_at: expiresAt,
+  });
+
+  return { expiresAt };
+};
+
+const verifyOtp = async ({ phone, channel = 'sms', code }) => {
+  const normalizedChannel = normalizeChannel(channel);
+  const normalizedPhone = normalizePhone(phone);
+  const challenge = await loadActiveOtp(normalizedPhone, normalizedChannel);
+
+  if (!challenge) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  if (new Date(challenge.expires_at).getTime() < Date.now()) {
+    await markOtpUsed(challenge);
+    return { ok: false, reason: 'expired' };
+  }
+
+  if ((challenge.attempt_count || 0) >= (challenge.max_attempts || MAX_ATTEMPTS)) {
+    return { ok: false, reason: 'locked' };
+  }
+
+  await incrementAttempt(challenge);
+
+  const submittedHash = hashOtpCode(code);
+  if (submittedHash !== challenge.hashed_code) {
+    return { ok: false, reason: 'mismatch' };
+  }
+
+  await markOtpUsed(challenge);
+  const verification = await markPhoneVerified(normalizedPhone);
+
+  return { ok: true, reason: 'approved', verification };
+};
+
+module.exports = {
+  sendOtp,
+  verifyOtp,
+};

--- a/backend/services/otp-store.js
+++ b/backend/services/otp-store.js
@@ -1,0 +1,143 @@
+const crypto = require('crypto');
+const {
+  isSupabaseConfigured,
+  supabaseRequest,
+} = require('../lib/supabaseClient');
+
+const OTP_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_ATTEMPTS = 5;
+
+const isFallbackAllowed = () => {
+  if (process.env.ALLOW_IN_MEMORY_OTP === 'false') return false;
+  if (process.env.ALLOW_IN_MEMORY_OTP === 'true') return true;
+  return process.env.NODE_ENV === 'test' || !isSupabaseConfigured();
+};
+
+const fallbackStore = new Map(); // key => { hashedCode, expiresAt, attemptCount, maxAttempts }
+
+const hashOtpCode = (code) => {
+  const salt = process.env.OTP_HASH_SECRET || '';
+  return crypto.createHash('sha256').update(`${code}:${salt}`).digest('hex');
+};
+
+const buildKey = (phone, channel) => `${channel}:${phone}`;
+
+const persistOtp = async ({ phone, channel, code }) => {
+  const hashedCode = hashOtpCode(code);
+  const expiresAt = new Date(Date.now() + OTP_EXPIRY_MS).toISOString();
+
+  if (!isSupabaseConfigured()) {
+    if (!isFallbackAllowed()) {
+      throw new Error('Supabase configuration is required for OTP persistence');
+    }
+
+    fallbackStore.set(buildKey(phone, channel), {
+      hashedCode,
+      expiresAt,
+      attemptCount: 0,
+      maxAttempts: MAX_ATTEMPTS,
+    });
+
+    return { expiresAt, maxAttempts: MAX_ATTEMPTS };
+  }
+
+  await supabaseRequest('otp_challenges', {
+    method: 'POST',
+    headers: { Prefer: 'return=representation' },
+    body: {
+      phone,
+      channel,
+      hashed_code: hashedCode,
+      expires_at: expiresAt,
+      max_attempts: MAX_ATTEMPTS,
+    },
+  });
+
+  return { expiresAt, maxAttempts: MAX_ATTEMPTS };
+};
+
+const loadActiveOtp = async (phone, channel) => {
+  if (!isSupabaseConfigured()) {
+    const fallback = fallbackStore.get(buildKey(phone, channel));
+    if (!fallback) return null;
+    return {
+      hashed_code: fallback.hashedCode,
+      expires_at: fallback.expiresAt,
+      attempt_count: fallback.attemptCount,
+      max_attempts: fallback.maxAttempts,
+      id: buildKey(phone, channel),
+    };
+  }
+
+  const searchParams = {
+    select: '*',
+    phone: `eq.${phone}`,
+    channel: `eq.${channel}`,
+    used_at: 'is.null',
+    order: 'created_at.desc',
+    limit: '1',
+    expires_at: `gt.${new Date().toISOString()}`,
+  };
+
+  const data = await supabaseRequest('otp_challenges', { searchParams });
+  if (Array.isArray(data) && data.length > 0) {
+    return data[0];
+  }
+  return null;
+};
+
+const incrementAttempt = async (otpRecord) => {
+  if (!otpRecord) return null;
+
+  if (!isSupabaseConfigured()) {
+    const fallback = fallbackStore.get(otpRecord.id);
+    if (fallback) {
+      fallback.attemptCount += 1;
+      fallbackStore.set(otpRecord.id, fallback);
+    }
+    return {
+      ...otpRecord,
+      attempt_count: (otpRecord.attempt_count || 0) + 1,
+    };
+  }
+
+  const response = await supabaseRequest('otp_challenges', {
+    method: 'PATCH',
+    headers: { Prefer: 'return=representation' },
+    searchParams: { id: `eq.${otpRecord.id}` },
+    body: {
+      attempt_count: (otpRecord.attempt_count || 0) + 1,
+      last_attempt_at: new Date().toISOString(),
+    },
+  });
+
+  return Array.isArray(response) && response.length ? response[0] : otpRecord;
+};
+
+const markOtpUsed = async (otpRecord) => {
+  if (!otpRecord) return;
+
+  if (!isSupabaseConfigured()) {
+    fallbackStore.delete(otpRecord.id);
+    return;
+  }
+
+  await supabaseRequest('otp_challenges', {
+    method: 'PATCH',
+    headers: { Prefer: 'return=representation' },
+    searchParams: { id: `eq.${otpRecord.id}` },
+    body: {
+      used_at: new Date().toISOString(),
+    },
+  });
+};
+
+module.exports = {
+  persistOtp,
+  loadActiveOtp,
+  incrementAttempt,
+  markOtpUsed,
+  hashOtpCode,
+  OTP_EXPIRY_MS,
+  MAX_ATTEMPTS,
+};

--- a/backend/services/phone-verification.js
+++ b/backend/services/phone-verification.js
@@ -1,0 +1,43 @@
+const { isSupabaseConfigured, supabaseRequest } = require('../lib/supabaseClient');
+
+const normalizePhone = (phone) => (phone || '').trim();
+
+const markPhoneVerified = async (phone) => {
+  const normalized = normalizePhone(phone);
+
+  if (!normalized) {
+    return { updated: false, reason: 'missing_phone' };
+  }
+
+  if (!isSupabaseConfigured()) {
+    console.info('[phone-verification] Supabase not configured; skipping profile update');
+    return { updated: false, reason: 'supabase_not_configured' };
+  }
+
+  try {
+    const response = await supabaseRequest('profiles', {
+      method: 'PATCH',
+      headers: { Prefer: 'return=representation' },
+      searchParams: { phone: `eq.${normalized}` },
+      body: {
+        phone: normalized,
+        phone_verified_at: new Date().toISOString(),
+      },
+    });
+
+    const updated = Array.isArray(response) && response.length > 0;
+    return { updated, reason: updated ? 'updated' : 'not_found' };
+  } catch (error) {
+    console.error('[phone-verification] Failed to mark phone verified', {
+      message: error?.message,
+      status: error?.status,
+      code: error?.code,
+    });
+    return { updated: false, reason: 'error' };
+  }
+};
+
+module.exports = {
+  markPhoneVerified,
+  normalizePhone,
+};

--- a/supabase/migrations/20251117093000_add_otp_challenges.sql
+++ b/supabase/migrations/20251117093000_add_otp_challenges.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+-- One-time password storage for SMS/WhatsApp login and phone verification
+CREATE TABLE IF NOT EXISTS public.otp_challenges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  phone text NOT NULL,
+  channel text NOT NULL CHECK (channel IN ('sms', 'whatsapp')),
+  hashed_code text NOT NULL,
+  attempt_count integer NOT NULL DEFAULT 0,
+  max_attempts integer NOT NULL DEFAULT 5,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  used_at timestamptz,
+  last_attempt_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS otp_challenges_phone_channel_idx ON public.otp_challenges (phone, channel);
+CREATE INDEX IF NOT EXISTS otp_challenges_expires_idx ON public.otp_challenges (expires_at);
+CREATE INDEX IF NOT EXISTS otp_challenges_used_idx ON public.otp_challenges (used_at);
+
+-- Track phone verification timestamps alongside the existing phone field
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS phone_verified_at timestamptz;
+
+COMMIT;

--- a/test/backend-response.test.js
+++ b/test/backend-response.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert';
 import crypto from 'node:crypto';
 
 process.env.ALLOW_IN_MEMORY_REGISTRATION = 'true';
+process.env.ALLOW_IN_MEMORY_OTP = 'true';
 
 import app from '../backend/index.js';
 

--- a/test/otp.test.js
+++ b/test/otp.test.js
@@ -1,0 +1,127 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert';
+
+process.env.ALLOW_IN_MEMORY_OTP = 'true';
+process.env.TWILIO_ACCOUNT_SID = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+process.env.TWILIO_AUTH_TOKEN = 'test_token';
+process.env.TWILIO_MESSAGE_SERVICE_SID = 'MGxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+
+import app from '../backend/index.js';
+import * as twilioModule from '../backend/lib/twilioClient.js';
+import { loadActiveOtp, OTP_EXPIRY_MS } from '../backend/services/otp-store.js';
+
+test('POST /api/auth/otp/send dispatches via Twilio client', async () => {
+  const server = app.listen(0);
+  const { port } = server.address();
+
+  const sentMessages = [];
+  const twilioClient = twilioModule.default || twilioModule;
+  const originalSend = twilioClient.sendTwilioMessage;
+  twilioClient.sendTwilioMessage = mock.fn(async (payload) => {
+    sentMessages.push(payload);
+    return { sid: 'SM123' };
+  });
+
+  try {
+    const res = await fetch(`http://localhost:${port}/api/auth/otp/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phone: '+260961234567', channel: 'sms' }),
+    });
+
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.deepStrictEqual(body, { ok: true, message: 'OTP sent successfully.' });
+
+    assert.strictEqual(sentMessages.length, 1);
+    assert.strictEqual(sentMessages[0].to, '+260961234567');
+    assert.ok(sentMessages[0].body.includes('verification code'));
+  } finally {
+    twilioClient.sendTwilioMessage = originalSend;
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('POST /api/auth/otp/verify approves valid codes and rejects invalid ones', async () => {
+  const server = app.listen(0);
+  const { port } = server.address();
+
+  const sentMessages = [];
+  const twilioClient = twilioModule.default || twilioModule;
+  const originalSend = twilioClient.sendTwilioMessage;
+  twilioClient.sendTwilioMessage = mock.fn(async (payload) => {
+    sentMessages.push(payload);
+    return { sid: 'SM234' };
+  });
+
+  try {
+    const sendRes = await fetch(`http://localhost:${port}/api/auth/otp/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phone: '+260971234567', channel: 'whatsapp' }),
+    });
+    assert.strictEqual(sendRes.status, 200);
+
+    const codeMatch = sentMessages[0].body.match(/(\d{6})/);
+    const code = codeMatch ? codeMatch[1] : '000000';
+
+    const invalidRes = await fetch(`http://localhost:${port}/api/auth/otp/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phone: '+260971234567', channel: 'whatsapp', code: '999999' }),
+    });
+    assert.strictEqual(invalidRes.status, 400);
+    const invalidBody = await invalidRes.json();
+    assert.strictEqual(invalidBody.ok, false);
+
+    const verifyRes = await fetch(`http://localhost:${port}/api/auth/otp/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phone: '+260971234567', channel: 'whatsapp', code }),
+    });
+
+    assert.strictEqual(verifyRes.status, 200);
+    const verifyBody = await verifyRes.json();
+    assert.strictEqual(verifyBody.ok, true);
+    assert.strictEqual(verifyBody.result.max_attempts > 0, true);
+
+    const challenge = await loadActiveOtp('+260971234567', 'whatsapp');
+    assert.strictEqual(challenge, null); // used codes are cleared
+
+    const lateRes = await fetch(`http://localhost:${port}/api/auth/otp/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phone: '+260971234567', channel: 'whatsapp', code }),
+    });
+    assert.strictEqual(lateRes.status, 400);
+  } finally {
+    twilioClient.sendTwilioMessage = originalSend;
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('POST /api/auth/otp/send rejects missing input quickly', async () => {
+  const server = app.listen(0);
+  const { port } = server.address();
+
+  try {
+    const res = await fetch(`http://localhost:${port}/api/auth/otp/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phone: '' }),
+    });
+
+    assert.strictEqual(res.status, 400);
+    const body = await res.json();
+    assert.strictEqual(body.ok, undefined);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('OTP expiry metadata matches expectation', async () => {
+  const now = Date.now();
+  assert.strictEqual(Math.round(OTP_EXPIRY_MS / 60000), 10);
+  assert.ok(OTP_EXPIRY_MS > 0 && OTP_EXPIRY_MS <= 10 * 60 * 1000);
+  assert.ok(Date.now() >= now);
+});


### PR DESCRIPTION
## Summary
- add Twilio-powered OTP send and verify routes with SMS and WhatsApp channels plus Supabase-backed persistence with safe fallbacks
- add Supabase migration for otp_challenges storage and phone verification timestamp support
- document OTP API usage and extend backend tests to cover the new flows

## Testing
- npm --prefix backend test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b844d4778832883ef9b97d3852e38)