### PR TITLE
Normalize authentication email handling

### DIFF
--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -200,12 +200,14 @@ export const AuthForm = ({ mode, redirectTo, onSuccess, disabled = false, disabl
     setMaintenanceNotice(null);
 
     try {
+      const normalizedEmail = values.email.trim().toLowerCase();
+
       if (mode === 'signin') {
         const signInValues = values as SignInValues;
-        await signIn(signInValues.email, signInValues.password);
+        await signIn(normalizedEmail, signInValues.password);
 
         if (signInValues.rememberPassword) {
-          saveCredentials(signInValues.email, signInValues.password);
+          saveCredentials(normalizedEmail, signInValues.password);
         } else {
           clearStoredCredentials();
         }
@@ -213,7 +215,7 @@ export const AuthForm = ({ mode, redirectTo, onSuccess, disabled = false, disabl
         const typed = values as SignUpValues;
         const phone = normalizePhone(typed.phone) ?? typed.phone.trim();
         const fullName = typed.fullName.trim();
-        await signUp(typed.email, typed.password, {
+        await signUp(normalizedEmail, typed.password, {
           full_name: fullName,
           phone,
           msisdn: phone,

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -99,17 +99,20 @@ export const SignupForm = ({
     values: SignupFormValues,
     selectedAccountType: AccountTypeValue
   ) => {
+    const normalizedEmail = values.email.trim().toLowerCase();
+    const normalizedMobile = values.mobileNumber?.trim() || null;
+
     const { error: profileErrorResponse } = await supabase.from("profiles").upsert(
       {
         id: userId,
-        email: values.email,
+        email: normalizedEmail,
         full_name: values.fullName,
         account_type: selectedAccountType,
         accepted_terms: true,
         newsletter_opt_in: Boolean(values.newsletterOptIn),
         profile_completed: false,
-        phone: values.mobileNumber || null,
-        msisdn: values.mobileNumber || null,
+        phone: normalizedMobile,
+        msisdn: normalizedMobile,
       },
       {
         onConflict: "id",
@@ -131,6 +134,8 @@ export const SignupForm = ({
       return;
     }
 
+    const normalizedEmail = values.email.trim().toLowerCase();
+    const normalizedMobileNumber = values.mobileNumber?.trim() || '';
     const normalizedAccountType = accountType;
 
     // Validate SMS OTP option
@@ -143,18 +148,18 @@ export const SignupForm = ({
     if (values.useSmsOtp && values.mobileNumber) {
       // SMS-based signup with phone number
       const { data, error } = await supabase.auth.signUp({
-        email: values.email,
-        phone: values.mobileNumber,
+        email: normalizedEmail,
+        phone: normalizedMobileNumber || undefined,
         password: values.password,
         options: {
           channel: "sms",
           data: {
             full_name: values.fullName,
-            email: values.email,
+            email: normalizedEmail,
             account_type: normalizedAccountType,
             accepted_terms: true,
             newsletter_opt_in: Boolean(values.newsletterOptIn),
-            mobile_number: values.mobileNumber,
+            mobile_number: normalizedMobileNumber || undefined,
           },
         },
       });
@@ -176,11 +181,11 @@ export const SignupForm = ({
         );
       }
 
-      onSuccess(values.email, requiresConfirmation, values.mobileNumber);
+      onSuccess(normalizedEmail, requiresConfirmation, normalizedMobileNumber || undefined);
     } else {
       // Email-based signup (default)
       const { data, error } = await supabase.auth.signUp({
-        email: values.email,
+        email: normalizedEmail,
         password: values.password,
         options: {
           data: {
@@ -188,7 +193,7 @@ export const SignupForm = ({
             account_type: normalizedAccountType,
             accepted_terms: true,
             newsletter_opt_in: Boolean(values.newsletterOptIn),
-            mobile_number: values.mobileNumber || null,
+            mobile_number: normalizedMobileNumber || null,
           },
         },
       });
@@ -210,7 +215,7 @@ export const SignupForm = ({
         );
       }
 
-      onSuccess(values.email, requiresEmailConfirmation, values.mobileNumber);
+      onSuccess(normalizedEmail, requiresEmailConfirmation, normalizedMobileNumber || undefined);
     }
   };
 


### PR DESCRIPTION
## Summary
- Normalize email addresses before calling sign-in and sign-up flows to avoid case/whitespace issues
- Trim mobile numbers and reuse normalized contact data when creating profiles during signup

## Testing
- npm test -- src/components/__tests__/AuthForm.test.tsx src/pages/__tests__/SignIn.test.tsx --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cea017068832891939e503653d17d)