### PR TITLE
Improve duplicate signup error handling

### DIFF
--- a/src/lib/__tests__/error-handling.test.ts
+++ b/src/lib/__tests__/error-handling.test.ts
@@ -7,31 +7,37 @@ import { describe, it, expect } from '@jest/globals';
 describe('Error Message Transformations', () => {
   // Simulate the error transformation logic from supabase-enhanced.ts and AppContext.tsx
   const transformAuthError = (errorMessage: string, context: 'signIn' | 'signUp'): string => {
+    const normalized = errorMessage.toLowerCase();
+
     // Network error detection
-    if (errorMessage.includes('network') || errorMessage.includes('fetch')) {
+    if (normalized.includes('network') || normalized.includes('fetch')) {
       return "We couldn't reach WATHACI servers right now. Please try again shortly.";
     }
-    
+
     // Sign-in specific errors
     if (context === 'signIn') {
-      if (errorMessage.includes('Invalid login credentials')) {
+      if (normalized.includes('invalid login credentials')) {
         return 'Invalid email or password. Please check your credentials and try again.';
       }
-      if (errorMessage.includes('Email not confirmed')) {
+      if (normalized.includes('email not confirmed')) {
         return 'Please verify your email address before signing in. Check your inbox for the verification link.';
       }
     }
-    
+
     // Sign-up specific errors
     if (context === 'signUp') {
-      if (errorMessage.includes('already exists') || errorMessage.includes('already registered')) {
+      if (
+        normalized.includes('already exists') ||
+        normalized.includes('already registered') ||
+        normalized.includes('database error saving new user')
+      ) {
         return 'An account with this email already exists. Please sign in instead or use a different email.';
       }
-      if (errorMessage.includes('password')) {
+      if (normalized.includes('password')) {
         return 'Password does not meet requirements. Please use a stronger password.';
       }
     }
-    
+
     return errorMessage;
   };
 
@@ -75,6 +81,11 @@ describe('Error Message Transformations', () => {
       expect(result).toBe('An account with this email already exists. Please sign in instead or use a different email.');
     });
 
+    it('should transform Supabase database error for duplicate signups', () => {
+      const result = transformAuthError('Database error saving new user', 'signUp');
+      expect(result).toBe('An account with this email already exists. Please sign in instead or use a different email.');
+    });
+
     it('should transform password requirement error', () => {
       const result = transformAuthError('password is too weak', 'signUp');
       expect(result).toBe('Password does not meet requirements. Please use a stronger password.');
@@ -100,28 +111,35 @@ describe('Error Handling Coverage', () => {
       'Email not confirmed',
       'User already registered',
       'Email already exists',
+      'Database error saving new user',
       'password is too weak'
     ];
 
     errorScenarios.forEach(scenario => {
       const context = scenario.includes('already') || scenario.includes('password') ? 'signUp' : 'signIn';
       const transformAuthError = (errorMessage: string, context: 'signIn' | 'signUp'): string => {
-        if (errorMessage.includes('network') || errorMessage.includes('fetch')) {
+        const normalized = errorMessage.toLowerCase();
+
+        if (normalized.includes('network') || normalized.includes('fetch')) {
           return "We couldn't reach WATHACI servers right now. Please try again shortly.";
         }
         if (context === 'signIn') {
-          if (errorMessage.includes('Invalid login credentials')) {
+          if (normalized.includes('invalid login credentials')) {
             return 'Invalid email or password. Please check your credentials and try again.';
           }
-          if (errorMessage.includes('Email not confirmed')) {
+          if (normalized.includes('email not confirmed')) {
             return 'Please verify your email address before signing in. Check your inbox for the verification link.';
           }
         }
         if (context === 'signUp') {
-          if (errorMessage.includes('already exists') || errorMessage.includes('already registered')) {
+          if (
+            normalized.includes('already exists') ||
+            normalized.includes('already registered') ||
+            normalized.includes('database error saving new user')
+          ) {
             return 'An account with this email already exists. Please sign in instead or use a different email.';
           }
-          if (errorMessage.includes('password')) {
+          if (normalized.includes('password')) {
             return 'Password does not meet requirements. Please use a stronger password.';
           }
         }


### PR DESCRIPTION
## Summary
- normalize Supabase error handling so duplicate sign-up failures (including "Database error saving new user") surface a friendly message
- extend the shared error handler to treat common network/configuration failures case-insensitively and cover weak password errors consistently
- update the error-handling Jest suite to cover the new messaging logic

## Testing
- npm run test:jest -- src/lib/__tests__/error-handling.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db07b6a0c832883066af3b315e9fa)