### PR TITLE
Add support contact details to user-facing errors

### DIFF
--- a/src/components/DonateButton.tsx
+++ b/src/components/DonateButton.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useMemo, useState } from "react";
 import { supabaseClient } from "@/lib/supabaseClient";
 import { supabaseConfigStatus } from "@/config/appConfig";
 import { MSISDN_REGEX, normalizeMsisdn } from "@/utils/phone";
+import { withSupportContact } from "@/lib/supportEmail";
 
 type PaymentMethod = "mobile_money" | "card";
 
@@ -128,23 +129,29 @@ export const DonateButton = ({ campaignId, source = "web" }: DonateButtonProps) 
     setPaymentInstructions(null);
 
     if (typeof amount !== "number") {
-      setError("Please select or enter a donation amount.");
+      setError(withSupportContact("Please select or enter a donation amount"));
       return;
     }
 
     if (amount < minAmount) {
-      setError(`Minimum donation is ${formatCurrency(minAmount)}.`);
+      setError(withSupportContact(`Minimum donation is ${formatCurrency(minAmount)}`));
       return;
     }
 
     if (amount > maxAmount) {
-      setError(`Maximum donation per transaction is ${formatCurrency(maxAmount)}.`);
+      setError(
+        withSupportContact(
+          `Maximum donation per transaction is ${formatCurrency(maxAmount)}`
+        )
+      );
       return;
     }
 
     if (!supabaseConfigStatus.hasValidConfig) {
       setError(
-        "Donations are temporarily unavailable while we finalise our Supabase configuration. Please try again shortly.",
+        withSupportContact(
+          "Donations are temporarily unavailable while we finalise our Supabase configuration. Please try again shortly"
+        ),
       );
       console.error("DonateButton: Missing Supabase configuration", supabaseConfigStatus);
       return;
@@ -152,7 +159,7 @@ export const DonateButton = ({ campaignId, source = "web" }: DonateButtonProps) 
 
     const functionsUrl = getSupabaseFunctionsUrl();
     if (!functionsUrl) {
-      setError("Supabase configuration missing. Please try again later.");
+      setError(withSupportContact("Supabase configuration missing. Please try again later"));
       return;
     }
 
@@ -161,7 +168,11 @@ export const DonateButton = ({ campaignId, source = "web" }: DonateButtonProps) 
 
     const normalizedMsisdn = normalizeMsisdn(msisdn);
     if (!normalizedMsisdn || !MSISDN_REGEX.test(normalizedMsisdn)) {
-      setError("Enter a valid mobile number including the country code (e.g. +2609XXXXXXX).");
+      setError(
+        withSupportContact(
+          "Enter a valid mobile number including the country code (e.g. +2609XXXXXXX)"
+        )
+      );
       return;
     }
 
@@ -228,9 +239,11 @@ export const DonateButton = ({ campaignId, source = "web" }: DonateButtonProps) 
     } catch (submitError) {
       console.error("DonateButton: Failed to create donation", submitError);
       setError(
-        submitError instanceof Error
-          ? submitError.message
-          : "Unable to start donation. Please try again."
+        withSupportContact(
+          submitError instanceof Error
+            ? submitError.message
+            : "Unable to start donation. Please try again"
+        )
       );
     } finally {
       setSubmitting(false);

--- a/src/components/OTPVerification.tsx
+++ b/src/components/OTPVerification.tsx
@@ -20,6 +20,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
 import { getApiEndpoint } from '@/config/api';
+import { withSupportContact } from '@/lib/supportEmail';
 
 interface OTPVerificationProps {
   onVerified?: (phone: string) => void;
@@ -67,10 +68,14 @@ export default function OTPVerification({
         setExpiresAt(new Date(data.expiresAt));
         setStep('code');
       } else {
-        setError(data.error || 'Failed to send verification code');
+        setError(
+          withSupportContact(data.error || 'Failed to send verification code')
+        );
       }
     } catch (err) {
-      setError('Network error. Please check your connection and try again.');
+      setError(
+        withSupportContact('Network error. Please check your connection and try again')
+      );
       console.error('[OTPVerification] Send error:', err);
     } finally {
       setLoading(false);
@@ -99,10 +104,10 @@ export default function OTPVerification({
         setSuccess('Phone number verified successfully!');
         onVerified?.(phone);
       } else {
-        setError(data.error || 'Verification failed');
+        setError(withSupportContact(data.error || 'Verification failed'));
       }
     } catch (err) {
-      setError('Network error. Please try again.');
+      setError(withSupportContact('Network error. Please try again'));
       console.error('[OTPVerification] Verify error:', err);
     } finally {
       setLoading(false);

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { supabaseClient, accountTypePaths, type AccountType } from "@/lib/wathaciSupabaseClient";
+import { withSupportContact } from "@/lib/supportEmail";
 
 export interface LoginFormProps {
   onLogin?: (accountType: AccountType) => void;
@@ -23,13 +24,13 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
       });
 
       if (signInError) {
-        setError(signInError.message);
+        setError(withSupportContact(signInError.message));
         return;
       }
 
       const userId = data.user?.id;
       if (!userId) {
-        setError("Login succeeded but no user data was returned.");
+        setError(withSupportContact("Login succeeded but no user data was returned"));
         return;
       }
 
@@ -41,7 +42,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
 
       if (profileError) {
         console.error(profileError);
-        setError(profileError.message);
+        setError(withSupportContact(profileError.message));
         return;
       }
 
@@ -51,7 +52,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
       window.location.href = destination;
     } catch (unknownError) {
       console.error(unknownError);
-      setError("Unable to login. Please try again.");
+      setError(withSupportContact("Unable to login. Please try again"));
     } finally {
       setLoading(false);
     }

--- a/src/contexts/AuthContextLight.tsx
+++ b/src/contexts/AuthContextLight.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 import { supabaseClient } from "@/lib/wathaciSupabaseClient";
 import { Navigate } from "react-router-dom";
+import { withSupportContact } from "@/lib/supportEmail";
 
 interface AuthContextValue {
   session: Session | null;
@@ -25,7 +26,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const { data, error: sessionError } = await supabaseClient.auth.getSession();
       if (!isMounted) return;
       if (sessionError) {
-        setError(sessionError.message);
+        setError(withSupportContact(sessionError.message));
       }
       setSession(data.session ?? null);
       setUser(data.session?.user ?? null);

--- a/src/features/compliance/AddComplianceTaskModal.tsx
+++ b/src/features/compliance/AddComplianceTaskModal.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
 import { toast } from 'sonner';
+import { withSupportContact } from '@/lib/supportEmail';
 
 interface AddComplianceTaskModalProps {
   open: boolean;
@@ -50,12 +51,12 @@ export const AddComplianceTaskModal = ({
     e.preventDefault();
 
     if (!formData.title.trim()) {
-      toast.error('Please enter a task title');
+      toast.error(withSupportContact('Please enter a task title'));
       return;
     }
 
     if (!formData.dueDate) {
-      toast.error('Please select a due date');
+      toast.error(withSupportContact('Please select a due date'));
       return;
     }
 
@@ -97,7 +98,7 @@ export const AddComplianceTaskModal = ({
       onTaskAdded();
     } catch (error) {
       console.error('Error adding task:', error);
-      toast.error('Failed to add compliance task');
+      toast.error(withSupportContact('Failed to add compliance task'));
     } finally {
       setLoading(false);
     }

--- a/src/features/compliance/AddStandardTasksDrawer.tsx
+++ b/src/features/compliance/AddStandardTasksDrawer.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
 import { Plus } from 'lucide-react';
+import { withSupportContact } from '@/lib/supportEmail';
 
 interface ComplianceTemplate {
   id: string;
@@ -62,7 +63,7 @@ export const AddStandardTasksDrawer = ({
       setTemplates(data || []);
     } catch (error) {
       console.error('Error fetching templates:', error);
-      toast.error('Failed to load compliance templates');
+      toast.error(withSupportContact('Failed to load compliance templates'));
     } finally {
       setLoading(false);
     }
@@ -148,7 +149,7 @@ export const AddStandardTasksDrawer = ({
       onTasksAdded();
     } catch (error) {
       console.error('Error adding task from template:', error);
-      toast.error('Failed to add task');
+      toast.error(withSupportContact('Failed to add task'));
     } finally {
       setAddingTaskId(null);
     }

--- a/src/features/compliance/ComplianceDashboard.tsx
+++ b/src/features/compliance/ComplianceDashboard.tsx
@@ -12,6 +12,7 @@ import { Calendar, CheckCircle, AlertCircle, Mail, MessageSquare, Phone } from '
 import { toast } from 'sonner';
 import { AddComplianceTaskModal } from './AddComplianceTaskModal';
 import { AddStandardTasksDrawer } from './AddStandardTasksDrawer';
+import { withSupportContact } from '@/lib/supportEmail';
 
 interface ComplianceTask {
   id: string;
@@ -72,7 +73,7 @@ export const ComplianceDashboard = () => {
       setTasks(updatedTasks);
     } catch (error) {
       console.error('Error fetching compliance tasks:', error);
-      toast.error('Failed to load compliance tasks');
+      toast.error(withSupportContact('Failed to load compliance tasks'));
     } finally {
       setLoading(false);
     }
@@ -91,7 +92,7 @@ export const ComplianceDashboard = () => {
       fetchTasks();
     } catch (error) {
       console.error('Error updating task:', error);
-      toast.error('Failed to update task');
+      toast.error(withSupportContact('Failed to update task'));
     }
   };
 

--- a/src/features/readiness/ReadinessCheck.tsx
+++ b/src/features/readiness/ReadinessCheck.tsx
@@ -9,6 +9,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { AppLayout } from '@/components/AppLayout';
+import { withSupportContact } from '@/lib/supportEmail';
 
 interface Question {
   id: string;
@@ -72,12 +73,12 @@ export const ReadinessCheck = () => {
     );
 
     if (unansweredQuestions.length > 0) {
-      toast.error('Please answer all questions before submitting.');
+      toast.error(withSupportContact('Please answer all questions before submitting'));
       return;
     }
 
     if (!user?.id) {
-      toast.error('You must be logged in to submit the readiness check.');
+      toast.error(withSupportContact('You must be logged in to submit the readiness check'));
       return;
     }
 
@@ -132,7 +133,9 @@ export const ReadinessCheck = () => {
       logger.error('Failed to submit readiness check', error, {
         userId: user?.id,
       });
-      toast.error('Failed to submit readiness check. Please try again.');
+      toast.error(
+        withSupportContact('Failed to submit readiness check. Please try again')
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/hooks/use-payment-status.ts
+++ b/src/hooks/use-payment-status.ts
@@ -6,6 +6,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/lib/supabase-enhanced';
 import { useToast } from '@/hooks/use-toast';
+import { withSupportContact } from '@/lib/supportEmail';
 
 export interface PaymentStatus {
   reference: string;
@@ -94,7 +95,9 @@ export const usePaymentStatus = (
         case 'failed':
           toast({
             title: "Payment Failed",
-            description: `Your payment of ${amount} failed. Please try again.`,
+            description: withSupportContact(
+              `Your payment of ${amount} failed. Please try again`
+            ),
             variant: "destructive",
           });
           break;
@@ -201,11 +204,11 @@ export const usePaymentStatus = (
           startPolling(reference);
         }
       } else {
-        setError('Payment not found');
+        setError(withSupportContact('Payment not found'));
       }
       setLoading(false);
     }).catch((err) => {
-      setError(err.message || 'Failed to fetch payment status');
+      setError(withSupportContact(err.message || 'Failed to fetch payment status'));
       setLoading(false);
     });
   }, [currentReference, fetchPaymentStatus, setupRealtimeSubscription, startPolling, stopTracking, updateStatus]);
@@ -221,7 +224,7 @@ export const usePaymentStatus = (
         setLastUpdated(Date.now());
       }
     } catch (err: any) {
-      setError(err.message || 'Failed to refresh payment status');
+      setError(withSupportContact(err.message || 'Failed to refresh payment status'));
     } finally {
       setLoading(false);
     }

--- a/src/hooks/useApiConnection.ts
+++ b/src/hooks/useApiConnection.ts
@@ -21,6 +21,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { checkApiHealth, type HealthStatus } from '@/lib/api/health-check';
+import { withSupportContact } from '@/lib/supportEmail';
 
 interface UseApiConnectionResult {
   isConnected: boolean | null;
@@ -72,11 +73,13 @@ export const useApiConnection = (
       setLastCheck(new Date());
       
       if (!status.isHealthy) {
-        setError(status.error || 'Backend is not healthy');
+        setError(withSupportContact(status.error || 'Backend is not healthy'));
       }
     } catch (err) {
       setIsConnected(false);
-      setError(err instanceof Error ? err.message : 'Unknown error');
+      setError(
+        withSupportContact(err instanceof Error ? err.message : 'Unknown error')
+      );
       setLastCheck(new Date());
     } finally {
       setIsChecking(false);

--- a/src/lib/supportEmail.ts
+++ b/src/lib/supportEmail.ts
@@ -1,2 +1,8 @@
 export const SUPPORT_EMAIL =
   import.meta.env.VITE_SUPPORT_EMAIL?.trim() || 'support@wathaci.com';
+
+export const withSupportContact = (message: string) => {
+  const trimmedMessage = message.trim();
+  const needsPeriod = trimmedMessage.endsWith('.') ? '' : '.';
+  return `${trimmedMessage}${needsPeriod} For assistance, contact ${SUPPORT_EMAIL}.`;
+};

--- a/src/pages/ZaqaSignup.tsx
+++ b/src/pages/ZaqaSignup.tsx
@@ -12,6 +12,7 @@ import { CheckCircle2 } from 'lucide-react';
 import { accountTypes, type AccountTypeValue } from '@/data/accountTypes';
 import { supabaseClient } from '@/lib/wathaciSupabaseClient';
 import { getEmailConfirmationRedirectUrl } from '@/lib/emailRedirect';
+import { withSupportContact } from '@/lib/supportEmail';
 
 /**
  * ZAQA-style Sign-Up Page for Wathaci
@@ -54,7 +55,9 @@ export const ZaqaSignup = () => {
    */
   const handleAccountTypeNext = () => {
     if (!selectedAccountType) {
-      setAccountTypeError('Please select an account type to continue.');
+      setAccountTypeError(
+        withSupportContact('Please select an account type to continue')
+      );
       return;
     }
     setAccountTypeError(null);
@@ -71,42 +74,44 @@ export const ZaqaSignup = () => {
 
     // Validation
     if (!selectedAccountType) {
-      setError('Account type is required.');
+      setError(withSupportContact('Account type is required'));
       return;
     }
 
     if (!email.trim()) {
-      setError('Email is required.');
+      setError(withSupportContact('Email is required'));
       return;
     }
 
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      setError('Please enter a valid email address.');
+      setError(withSupportContact('Please enter a valid email address'));
       return;
     }
 
     if (!password) {
-      setError('Password is required.');
+      setError(withSupportContact('Password is required'));
       return;
     }
 
     if (password.length < 8) {
-      setError('Password must be at least 8 characters long.');
+      setError(withSupportContact('Password must be at least 8 characters long'));
       return;
     }
 
     if (password !== confirmPassword) {
-      setError('Passwords do not match.');
+      setError(withSupportContact('Passwords do not match'));
       return;
     }
 
     if (!fullName.trim()) {
-      setError('Full name is required.');
+      setError(withSupportContact('Full name is required'));
       return;
     }
 
     if (!acceptedTerms) {
-      setError('You must accept the Terms & Conditions to sign up.');
+      setError(
+        withSupportContact('You must accept the Terms & Conditions to sign up')
+      );
       return;
     }
 
@@ -128,12 +133,16 @@ export const ZaqaSignup = () => {
 
       if (signUpError) {
         console.error('Sign-up error:', signUpError);
-        setError(signUpError.message);
+        setError(withSupportContact(signUpError.message));
         return;
       }
 
       if (!authData.user) {
-        setError('Sign-up succeeded but user data is missing. Please try logging in.');
+        setError(
+          withSupportContact(
+            'Sign-up succeeded but user data is missing. Please try logging in'
+          )
+        );
         return;
       }
 
@@ -172,7 +181,7 @@ export const ZaqaSignup = () => {
       setStep('success');
     } catch (err) {
       console.error('Unexpected error during signup:', err);
-      setError('An unexpected error occurred. Please try again.');
+      setError(withSupportContact('An unexpected error occurred. Please try again'));
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- add a helper to append the support email address to error messages
- update compliance, readiness, signup, auth, donation, and payment flows to show support contact info in user-visible errors
- ensure API connection and payment status hooks return errors with support details

## Testing
- npm run lint *(fails: existing lint violations in unrelated files, including no-empty-object-type and ban-ts-comment rules)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ece4c792c8328a000f75dc2f98f88)