### PR TITLE
Harden auth flows and configuration

### DIFF
--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,16 @@
+export const PASSWORD_MIN_LENGTH = 8;
+
+const passwordStrengthRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/;
+
+/**
+ * Validate that a password meets the minimum strength requirements.
+ * - At least 8 characters
+ * - Contains lowercase, uppercase, and numeric characters
+ */
+export const isStrongPassword = (value: string): boolean => {
+  if (!value) return false;
+  return passwordStrengthRegex.test(value);
+};
+
+export const passwordStrengthMessage =
+  'Use at least 8 characters with uppercase, lowercase, and a number for a strong password.';


### PR DESCRIPTION
## Summary
- add shared password strength helper and enforce stronger rules on sign-up inputs
- stop persisting passwords locally while improving auth form messaging and UX
- validate Supabase auth configuration before sign-in/sign-up and guard server-side password strength

## Testing
- npm run test:jest -- --runTestsByPath src/components/__tests__/AuthForm.test.tsx src/pages/__tests__/SignIn.test.tsx src/pages/__tests__/SignUp.test.tsx *(fails: existing Jest setup cannot parse import.meta in supabaseClient.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920069ba52c83289b276cd9a87a43d6)