### PR TITLE
Add SMTP transporter verification endpoints and env updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,10 +98,16 @@ AUTH_BYPASS_MODE_ENABLED="false"
 # Used by Supabase for sending authentication and transactional emails
 SMTP_HOST="mail.privateemail.com"
 SMTP_PORT="465"
-SMTP_USER="support@wathaci.com"
+SMTP_SECURE="true" # true for port 465, false for 587
+SMTP_USERNAME="support@wathaci.com"
+SMTP_USER="support@wathaci.com" # Legacy compatibility
+SMTP_AUTH_METHOD="LOGIN"
 SMTP_PASSWORD="your-smtp-password-from-namecheap"
+FROM_EMAIL="support@wathaci.com"
+REPLY_TO_EMAIL="support@wathaci.com"
 SMTP_FROM_EMAIL="support@wathaci.com"
 SMTP_FROM_NAME="Wathaci"
+EMAIL_PROVIDER="SMTP"
 
 # Email configuration for Supabase
 SUPABASE_SMTP_ADMIN_EMAIL="support@wathaci.com"

--- a/.env.production.example
+++ b/.env.production.example
@@ -93,10 +93,16 @@ VITE_APP_NAME="WATHACI CONNECT"
 # Used by Supabase for sending authentication and transactional emails
 SMTP_HOST="mail.privateemail.com"
 SMTP_PORT="465"
-SMTP_USER="support@wathaci.com"
+SMTP_SECURE="true" # true for port 465, false for 587
+SMTP_USERNAME="support@wathaci.com"
+SMTP_USER="support@wathaci.com" # Legacy compatibility
+SMTP_AUTH_METHOD="LOGIN"
 SMTP_PASSWORD="your-smtp-password-from-namecheap"
+FROM_EMAIL="support@wathaci.com"
+REPLY_TO_EMAIL="support@wathaci.com"
 SMTP_FROM_EMAIL="support@wathaci.com"
 SMTP_FROM_NAME="Wathaci"
+EMAIL_PROVIDER="SMTP"
 
 # Email configuration for Supabase
 SUPABASE_SMTP_ADMIN_EMAIL="support@wathaci.com"

--- a/.env.template
+++ b/.env.template
@@ -84,16 +84,21 @@ VITE_API_BASE_URL="http://localhost:3000"
 # For local development only, you can use these variables with local Supabase:
 
 # SMTP Host (PrivateEmail/Namecheap)
-# Value: mail.privateemail.com
 SMTP_HOST="mail.privateemail.com"
 
-# SMTP Port
-# PrivateEmail uses port 465 (SSL/TLS)
+# SMTP Port (465 = TLS, 587 = STARTTLS)
 SMTP_PORT="465"
+
+# Set true for implicit TLS (465); false for STARTTLS (587)
+SMTP_SECURE="true"
 
 # SMTP Username (your platform email)
 # This is the email address that will send all emails
-SMTP_USER="support@wathaci.com"
+SMTP_USERNAME="support@wathaci.com"
+SMTP_USER="support@wathaci.com" # legacy compatibility
+
+# SMTP authentication method
+SMTP_AUTH_METHOD="LOGIN"
 
 # SMTP Password
 # SECURITY: This should ONLY be set in:
@@ -103,11 +108,14 @@ SMTP_USER="support@wathaci.com"
 SMTP_PASSWORD="your-privateemail-password-here"
 
 # Email "From" address
-# Must match SMTP_USER and be verified in PrivateEmail
+# Must match SMTP_USERNAME and be verified in PrivateEmail
+FROM_EMAIL="support@wathaci.com"
+REPLY_TO_EMAIL="support@wathaci.com"
 SMTP_FROM_EMAIL="support@wathaci.com"
 
 # Email "From" name (sender display name)
 SMTP_FROM_NAME="Wathaci"
+EMAIL_PROVIDER="SMTP"
 
 # Supabase SMTP admin email (same as from email)
 SUPABASE_SMTP_ADMIN_EMAIL="support@wathaci.com"

--- a/backend/index.js
+++ b/backend/index.js
@@ -71,6 +71,7 @@ const logRoutes = require('./routes/logs');
 const paymentRoutes = require('./routes/payment');
 const resolveRoutes = require('./routes/resolve');
 const otpRoutes = require('./routes/otp');
+const emailRoutes = require('./routes/email');
 
 // Health check endpoint
 app.get('/health', (req, res) => {
@@ -103,6 +104,7 @@ app.use('/api/logs', logRoutes);
 app.use('/api/payment', paymentRoutes);
 app.use('/resolve', resolveRoutes);
 app.use('/api/auth/otp', otpRoutes);
+app.use('/api/email', emailRoutes);
 
 const PORT = process.env.PORT || 3000;
 if (require.main === module) {

--- a/backend/lib/email-transporter.js
+++ b/backend/lib/email-transporter.js
@@ -1,0 +1,82 @@
+const nodemailer = require('nodemailer');
+
+const parseBoolean = (value, fallback = false) => {
+  if (value === undefined || value === null) return fallback;
+
+  if (typeof value === 'boolean') return value;
+
+  const normalized = String(value).trim().toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(normalized);
+};
+
+const smtpHost = process.env.SMTP_HOST;
+const smtpPort = Number(process.env.SMTP_PORT || process.env.SMTP_TLS_PORT || 465);
+const smtpUser = process.env.SMTP_USERNAME || process.env.SMTP_USER;
+const smtpPassword = process.env.SMTP_PASSWORD;
+
+const smtpSecure = parseBoolean(process.env.SMTP_SECURE, smtpPort === 465);
+const smtpAuthMethod = process.env.SMTP_AUTH_METHOD || 'LOGIN';
+const allowSelfSigned = !parseBoolean(process.env.SMTP_REJECT_UNAUTHORIZED, true);
+const enableLogging = parseBoolean(process.env.SMTP_LOGGER, true);
+const enableDebug = parseBoolean(process.env.SMTP_DEBUG, true);
+
+const missingRequiredFields = [smtpHost, smtpPort, smtpUser, smtpPassword].some(
+  value => value === undefined || value === ''
+);
+
+let transporter = null;
+
+if (missingRequiredFields) {
+  console.warn('[EmailTransporter] SMTP configuration is incomplete. Transporter not initialized.');
+} else {
+  transporter = nodemailer.createTransport({
+    host: smtpHost,
+    port: smtpPort,
+    secure: smtpSecure,
+    auth: {
+      user: smtpUser,
+      pass: smtpPassword,
+      method: smtpAuthMethod,
+    },
+    logger: enableLogging,
+    debug: enableDebug,
+    connectionTimeout: 15_000,
+    greetingTimeout: 10_000,
+    tls: {
+      rejectUnauthorized: !allowSelfSigned,
+    },
+  });
+
+  console.log(
+    `[EmailTransporter] Initialized (host=${smtpHost}, port=${smtpPort}, secure=${smtpSecure}, authMethod=${smtpAuthMethod})`
+  );
+}
+
+async function verifyTransporterConnection() {
+  if (!transporter) {
+    return {
+      ok: false,
+      message: 'SMTP transporter is not configured. Please set SMTP_* variables.',
+    };
+  }
+
+  try {
+    const verifyResult = await transporter.verify();
+    return {
+      ok: true,
+      message: 'SMTP connection verified successfully',
+      details: verifyResult,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error?.message || 'SMTP verification failed',
+      error,
+    };
+  }
+}
+
+module.exports = {
+  transporter,
+  verifyTransporterConnection,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "express-rate-limit": "^7.0.0",
     "helmet": "^7.0.0",
     "joi": "^17.9.2",
+    "nodemailer": "^6.9.15",
     "sanitize-html": "^2.11.0",
     "twilio": "^5.10.5"
   }

--- a/backend/routes/email.js
+++ b/backend/routes/email.js
@@ -1,0 +1,70 @@
+const express = require('express');
+const Joi = require('joi');
+const validate = require('../middleware/validate');
+const { sendEmail, verifyEmailTransport, defaultFromEmail, defaultReplyTo, emailProvider, smtpSecure } = require('../services/email-service');
+
+const router = express.Router();
+
+const sendEmailSchema = Joi.object({
+  to: Joi.string().email().required(),
+  subject: Joi.string().min(3).required(),
+  html: Joi.string().optional().allow('', null),
+  text: Joi.string().optional().allow('', null),
+  cc: Joi.string().email().optional(),
+  bcc: Joi.string().email().optional(),
+  template: Joi.string().optional(),
+});
+
+router.get('/verify', async (_req, res) => {
+  const result = await verifyEmailTransport();
+
+  if (!result.ok) {
+    return res.status(500).json({
+      ok: false,
+      error: result.message,
+    });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    message: result.message,
+    details: result.details,
+    config: {
+      provider: emailProvider,
+      from: defaultFromEmail,
+      replyTo: defaultReplyTo,
+      secure: smtpSecure,
+    },
+  });
+});
+
+router.post('/send-test', validate(sendEmailSchema), async (req, res) => {
+  const { to, subject, html, text, cc, bcc, template } = req.body;
+
+  const result = await sendEmail({
+    to,
+    subject,
+    html: html || text,
+    text: text || html,
+    cc,
+    bcc,
+    template: template || 'manual-test',
+    metadata: { route: 'send-test' },
+  });
+
+  if (!result.ok) {
+    return res.status(500).json({
+      ok: false,
+      error: result.message,
+    });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    message: result.message,
+    messageId: result.messageId,
+    envelope: result.envelope,
+  });
+});
+
+module.exports = router;

--- a/backend/services/email-service.js
+++ b/backend/services/email-service.js
@@ -1,0 +1,157 @@
+const { transporter, verifyTransporterConnection } = require('../lib/email-transporter');
+const { getSupabaseClient, isSupabaseConfigured } = require('../lib/supabaseAdmin');
+
+const parseBoolean = (value, fallback = false) => {
+  if (value === undefined || value === null) return fallback;
+  const normalized = String(value).trim().toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(normalized);
+};
+
+const defaultFromEmail =
+  process.env.FROM_EMAIL ||
+  process.env.SMTP_FROM_EMAIL ||
+  process.env.SMTP_USER ||
+  process.env.SMTP_USERNAME ||
+  'support@wathaci.com';
+
+const defaultFromName = process.env.SMTP_FROM_NAME || 'Wathaci';
+
+const defaultReplyTo =
+  process.env.REPLY_TO_EMAIL ||
+  process.env.SMTP_REPLY_TO ||
+  defaultFromEmail;
+
+/**
+ * Persist email delivery attempt to the email_logs table if configured.
+ */
+async function persistLog({ email, template, status, error, messageId, envelope, metadata }) {
+  if (!isSupabaseConfigured()) {
+    return;
+  }
+
+  const supabase = getSupabaseClient();
+  try {
+    const { error: dbError } = await supabase.from('email_logs').insert({
+      email,
+      template,
+      status,
+      error,
+      message_id: messageId,
+      envelope,
+      metadata,
+      created_at: new Date().toISOString(),
+    });
+
+    if (dbError) {
+      console.warn('[EmailService] Failed to persist email log:', dbError.message);
+    }
+  } catch (dbError) {
+    console.warn('[EmailService] Unexpected error persisting email log:', dbError.message);
+  }
+}
+
+/**
+ * Send an email using the shared SMTP transporter.
+ */
+async function sendEmail({ to, subject, html, text, cc, bcc, template = 'custom', metadata = {} }) {
+  if (!transporter) {
+    const message = 'SMTP transporter is not configured. Set SMTP_* variables to enable email sending.';
+    console.error('[EmailService] ' + message);
+    return { ok: false, message };
+  }
+
+  const from = `${defaultFromName} <${defaultFromEmail}>`;
+  const replyTo = metadata.replyTo || defaultReplyTo;
+
+  const mailOptions = {
+    from,
+    to,
+    subject,
+    html,
+    text,
+    cc,
+    bcc,
+    replyTo,
+    envelope: {
+      from: defaultFromEmail,
+      to,
+    },
+  };
+
+  try {
+    const info = await transporter.sendMail(mailOptions);
+
+    await persistLog({
+      email: to,
+      template,
+      status: 'sent',
+      messageId: info.messageId,
+      envelope: info.envelope,
+      metadata,
+    });
+
+    console.log('[EmailService] Email sent', {
+      to,
+      messageId: info.messageId,
+      response: info.response,
+      envelope: info.envelope,
+    });
+
+    return {
+      ok: true,
+      message: 'Email sent successfully',
+      messageId: info.messageId,
+      response: info.response,
+      envelope: info.envelope,
+    };
+  } catch (error) {
+    console.error('[EmailService] Failed to send email', {
+      to,
+      subject,
+      error: error?.message,
+    });
+
+    await persistLog({
+      email: to,
+      template,
+      status: 'failed',
+      error: error?.message,
+      metadata,
+    });
+
+    return {
+      ok: false,
+      message: error?.message || 'Failed to send email',
+    };
+  }
+}
+
+/**
+ * Verify the SMTP transporter connection, exposing a normalized response.
+ */
+async function verifyEmailTransport() {
+  const result = await verifyTransporterConnection();
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      message: result.message,
+      error: result.error,
+    };
+  }
+
+  return {
+    ok: true,
+    message: result.message,
+    details: result.details,
+  };
+}
+
+module.exports = {
+  sendEmail,
+  verifyEmailTransport,
+  defaultFromEmail,
+  defaultReplyTo,
+  emailProvider: process.env.EMAIL_PROVIDER || 'SMTP',
+  smtpSecure: parseBoolean(process.env.SMTP_SECURE, process.env.SMTP_PORT === '465'),
+};


### PR DESCRIPTION
## Summary
- add centralized Nodemailer SMTP transporter with verification helper and Supabase email logging hooks
- expose `/api/email/verify` and `/api/email/send-test` endpoints to validate SMTP connectivity and send test mail
- expand environment templates and validation script for new SMTP variables and secure port alignment

## Testing
- npm run config:validate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f1167a95c83288ea6a27555076b7d)