### PR TITLE
Add health check endpoint

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -72,16 +72,10 @@ const paymentRoutes = require('./routes/payment');
 const resolveRoutes = require('./routes/resolve');
 const otpRoutes = require('./routes/otp');
 const emailRoutes = require('./routes/email');
+const healthRoutes = require('./routes/health');
 
 // Health check endpoint
-app.get('/health', (req, res) => {
-  res.status(200).json({
-    status: 'healthy',
-    timestamp: new Date().toISOString(),
-    uptime: process.uptime(),
-    environment: process.env.NODE_ENV || 'development',
-  });
-});
+app.use(['/health', '/api/health'], healthRoutes);
 
 // API info endpoint
 app.get('/api', (req, res) => {
@@ -89,7 +83,7 @@ app.get('/api', (req, res) => {
     name: 'WATHACI CONNECT API',
     version: '1.0.0',
     endpoints: {
-      health: 'GET /health',
+      health: 'GET /health, GET /api/health',
       users: 'POST /users, POST /api/users',
       logs: 'POST /api/logs, GET /api/logs',
       payment: 'GET /api/payment/readiness, POST /api/payment/webhook',

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const os = require('os');
+const { isSupabaseConfigured } = require('../lib/supabaseAdmin');
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  const health = {
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+    environment: process.env.NODE_ENV || 'development',
+    supabase: {
+      configured: isSupabaseConfigured(),
+    },
+    system: {
+      uptime: os.uptime(),
+      memory: {
+        free: os.freemem(),
+        total: os.totalmem(),
+      },
+    },
+  };
+
+  res.status(200).json(health);
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add dedicated health router that reports service uptime, environment, system metrics, and Supabase configuration status
- expose the health check at both /health and /api/health and document it in the API metadata

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692166bd73a483288cfbab42fe6d5e6c)