### PR TITLE
Add fetch-sources edge function and trigger consolidation runbook

### DIFF
--- a/docs/TRIGGER_CONSOLIDATION_RUNBOOK.md
+++ b/docs/TRIGGER_CONSOLIDATION_RUNBOOK.md
@@ -1,0 +1,92 @@
+# Trigger Consolidation Runbook
+
+This runbook covers how to back up trigger function sources, deploy the `fetch-sources` Edge Function, and safely consolidate overlapping triggers in the auth/profile flow.
+
+## Prerequisites
+- Supabase CLI installed and authenticated (`npm run supabase:login`).
+- Access to the project connection string (for `psql`) and service-role credentials (for Edge Functions).
+- psql available locally.
+
+## 1) Deploy the `fetch-sources` Edge Function
+1. Confirm you want to deploy now: **Yes – proceed.**
+2. Set Supabase environment in your shell (replace with project values):
+   ```bash
+   export SUPABASE_URL="https://<project>.supabase.co"
+   export SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+   ```
+3. Deploy only this function:
+   ```bash
+   supabase functions deploy fetch-sources
+   ```
+   - **Expected output:** `Finished deploying fetch-sources (d[-hash])` and HTTP endpoint printed.
+4. Smoke-test the deployment (service role bearer):
+   ```bash
+   curl -s "https://<project>.supabase.co/functions/v1/fetch-sources" \
+     -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" | jq '.count'
+   ```
+   - **Expected output:** a non-error JSON response such as `3` when the backup table has entries.
+
+## 2) Capture trigger function definitions to the backups table and disk
+Run from repository root.
+
+1. Populate/refresh the `backups.trigger_function_defs` table and write a snapshot file:
+   ```bash
+   psql "$SUPABASE_DB_URL" -f supabase/backups/capture_trigger_function_defs.sql
+   ```
+   - **Expected output:**
+     - Notices showing `CREATE SCHEMA`/`CREATE TABLE` (or "already exists").
+     - A `COPY 3` (or similar) line showing rows written to `supabase/backups/trigger_function_defs_snapshot.csv`.
+2. Verify the snapshot contents quickly:
+   ```bash
+   head -n 5 supabase/backups/trigger_function_defs_snapshot.csv
+   ```
+   - **Expected output:** CSV header followed by rows such as `autocreate_profile_on_user,"CREATE OR REPLACE FUNCTION..."`.
+3. Re-run the smoke test against the Edge Function to confirm it can read the refreshed table:
+   ```bash
+   curl -s "https://<project>.supabase.co/functions/v1/fetch-sources?names=handle_new_user" \
+     -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" | jq '.functions[0].name'
+   ```
+   - **Expected output:** `"handle_new_user -- public"`.
+
+## 3) Checklist for consolidating triggers
+- [ ] **Backup captured:** `trigger_function_defs_snapshot.csv` present and pushed to version control.
+- [ ] **Edge Function live:** `fetch-sources` responds with HTTP 200 and expected rows.
+- [ ] **Redundant triggers reviewed:** Results from `supabase/migrations/20251120120000_prepare_trigger_cleanup.sql` reviewed; keep `handle_new_user` as primary.
+- [ ] **Disable/Drop plan approved:** Team agrees on which triggers to disable/drop (`autocreate_profile_trigger`, `handle_auth_user_created_trigger`).
+- [ ] **Transactional test ready:** Insert/rollback test statement from the migration is prepared in a psql session.
+
+## 4) Execute consolidation (manual, after approvals)
+1. Open an interactive transaction for safety:
+   ```bash
+   psql "$SUPABASE_DB_URL"
+   BEGIN;
+   ```
+2. Disable or drop redundant triggers/functions (adjust per decision):
+   ```sql
+   ALTER TABLE auth.users DISABLE TRIGGER autocreate_profile_trigger;
+   ALTER TABLE auth.users DISABLE TRIGGER handle_auth_user_created_trigger;
+   -- Or drop once validated:
+   -- DROP TRIGGER IF EXISTS autocreate_profile_trigger ON auth.users;
+   -- DROP FUNCTION IF EXISTS autocreate_profile_on_user();
+   -- DROP TRIGGER IF EXISTS handle_auth_user_created_trigger ON auth.users;
+   -- DROP FUNCTION IF EXISTS handle_auth_user_created();
+   ```
+   - **Expected output:** `ALTER TABLE` or `DROP TRIGGER` confirmations.
+3. Run the transactional signup sanity test (from the migration file):
+   ```sql
+   INSERT INTO auth.users (id, email, raw_user_meta_data, aud)
+   VALUES ('00000000-0000-0000-0000-000000000099','test+verify@example.com','{}','authenticated');
+   SELECT id, email, account_type FROM public.profiles WHERE id = '00000000-0000-0000-0000-000000000099';
+   ROLLBACK;
+   ```
+   - **Expected output:** profile row appears with `account_type` populated, and the transaction rolls back cleanly.
+4. Commit changes only after validation:
+   ```sql
+   COMMIT;
+   ```
+   - **Expected output:** `COMMIT`.
+
+## 5) Post-change verification
+- Re-run the `fetch-sources` Edge Function to confirm definitions remain accessible.
+- Check `backups.trigger_function_defs` for updated timestamps (ensures capture ran after consolidation).
+- Review Supabase function/trigger logs for any errors during the change window.

--- a/supabase/backups/capture_trigger_function_defs.sql
+++ b/supabase/backups/capture_trigger_function_defs.sql
@@ -1,0 +1,46 @@
+-- Capture trigger function definitions into backups.trigger_function_defs and export a local snapshot.
+\set ON_ERROR_STOP on
+
+BEGIN;
+SET TRANSACTION READ WRITE;
+
+CREATE SCHEMA IF NOT EXISTS backups;
+
+CREATE TABLE IF NOT EXISTS backups.trigger_function_defs (
+  name text PRIMARY KEY,
+  definition text,
+  created_at timestamptz DEFAULT now()
+);
+
+DO $$
+DECLARE
+  rec RECORD;
+  funcname text;
+  fdef text;
+begin
+  FOR rec IN
+    SELECT p.oid, n.nspname AS schema, p.proname AS name
+    FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE p.proname IN ('autocreate_profile_on_user','handle_auth_user_created','handle_new_user')
+  LOOP
+    BEGIN
+      fdef := pg_get_functiondef(rec.oid);
+      funcname := rec.name || ' -- ' || rec.schema;
+      INSERT INTO backups.trigger_function_defs (name, definition)
+      VALUES (funcname, fdef)
+      ON CONFLICT (name) DO UPDATE SET definition = EXCLUDED.definition, created_at = now();
+    EXCEPTION WHEN others THEN
+      RAISE NOTICE 'Could not capture function %', rec.name;
+    END;
+  END LOOP;
+END$$;
+
+COMMIT;
+
+-- Export a CSV snapshot locally (when run via psql). Adjust the path if needed.
+\copy (
+  SELECT name, definition, created_at
+  FROM backups.trigger_function_defs
+  ORDER BY name
+) TO './supabase/backups/trigger_function_defs_snapshot.csv' CSV HEADER;

--- a/supabase/backups/trigger_function_defs_snapshot.sql
+++ b/supabase/backups/trigger_function_defs_snapshot.sql
@@ -1,0 +1,141 @@
+-- Snapshot of trigger function definitions captured for consolidation review.
+-- Source of truth should be refreshed with supabase/backups/capture_trigger_function_defs.sql against the target database.
+
+-- handle_new_user -- public
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email text;
+  v_full_name text;
+  v_account_type public.account_type_enum;
+  v_error_message text;
+  v_error_detail text;
+BEGIN
+  v_email := NEW.email;
+
+  BEGIN
+    v_full_name := COALESCE(NEW.raw_user_meta_data->>'full_name', '');
+    v_account_type := COALESCE((NEW.raw_user_meta_data->>'account_type')::public.account_type_enum, 'SME');
+  EXCEPTION
+    WHEN OTHERS THEN
+      v_full_name := '';
+      v_account_type := 'SME';
+  END;
+
+  BEGIN
+    INSERT INTO public.profiles (
+      id,
+      email,
+      full_name,
+      account_type,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      NEW.id,
+      v_email,
+      v_full_name,
+      v_account_type,
+      timezone('utc', now()),
+      timezone('utc', now())
+    )
+    ON CONFLICT (id) DO UPDATE
+    SET
+      email = COALESCE(NULLIF(public.profiles.email, ''), EXCLUDED.email),
+      full_name = CASE
+        WHEN public.profiles.full_name IS NULL OR public.profiles.full_name = ''
+        THEN EXCLUDED.full_name
+        ELSE public.profiles.full_name
+      END,
+      updated_at = timezone('utc', now());
+
+    RETURN NEW;
+
+  EXCEPTION
+    WHEN unique_violation THEN
+      v_error_message := 'Unique constraint violation: ' || SQLERRM;
+      v_error_detail := 'SQLSTATE: ' || SQLSTATE;
+
+      INSERT INTO public.profile_errors (user_id, error_message, error_detail, error_context)
+      VALUES (
+        NEW.id,
+        v_error_message,
+        v_error_detail,
+        'unique_violation in handle_new_user trigger'
+      );
+
+      RETURN NEW;
+
+    WHEN not_null_violation THEN
+      v_error_message := 'NOT NULL constraint violation: ' || SQLERRM;
+      v_error_detail := 'SQLSTATE: ' || SQLSTATE;
+
+      INSERT INTO public.profile_errors (user_id, error_message, error_detail, error_context)
+      VALUES (
+        NEW.id,
+        v_error_message,
+        v_error_detail,
+        'not_null_violation in handle_new_user trigger'
+      );
+
+      RETURN NEW;
+
+    WHEN check_violation THEN
+      v_error_message := 'CHECK constraint violation: ' || SQLERRM;
+      v_error_detail := 'SQLSTATE: ' || SQLSTATE;
+
+      INSERT INTO public.profile_errors (user_id, error_message, error_detail, error_context)
+      VALUES (
+        NEW.id,
+        v_error_message,
+        v_error_detail,
+        'check_violation in handle_new_user trigger'
+      );
+
+      RETURN NEW;
+
+    WHEN foreign_key_violation THEN
+      v_error_message := 'Foreign key violation: ' || SQLERRM;
+      v_error_detail := 'SQLSTATE: ' || SQLSTATE;
+
+      INSERT INTO public.profile_errors (user_id, error_message, error_detail, error_context)
+      VALUES (
+        NEW.id,
+        v_error_message,
+        v_error_detail,
+        'foreign_key_violation in handle_new_user trigger'
+      );
+
+      RETURN NEW;
+
+    WHEN OTHERS THEN
+      v_error_message := 'Unexpected error in handle_new_user: ' || SQLERRM;
+      v_error_detail := 'SQLSTATE: ' || SQLSTATE;
+
+      BEGIN
+        INSERT INTO public.profile_errors (user_id, error_message, error_detail, error_context)
+        VALUES (
+          NEW.id,
+          v_error_message,
+          v_error_detail,
+          'unexpected_error in handle_new_user trigger'
+        );
+      EXCEPTION
+        WHEN OTHERS THEN
+          NULL;
+      END;
+
+      RETURN NEW;
+  END;
+END;
+$$;
+
+-- autocreate_profile_on_user -- auth
+-- Definition not present in the codebase; capture from the live database via capture_trigger_function_defs.sql.
+
+-- handle_auth_user_created -- auth
+-- Definition not present in the codebase; capture from the live database via capture_trigger_function_defs.sql.

--- a/supabase/functions/fetch-sources/index.ts
+++ b/supabase/functions/fetch-sources/index.ts
@@ -1,0 +1,62 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+
+const supabase =
+  supabaseUrl && serviceRoleKey
+    ? createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } })
+    : null;
+
+const json = (body: Record<string, unknown>, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "GET") {
+    return json({ ok: false, error: "method_not_allowed" }, 405);
+  }
+
+  if (!supabase) {
+    console.error("fetch-sources: missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+    return json({ ok: false, error: "server_not_configured" }, 500);
+  }
+
+  const url = new URL(req.url);
+  const names = url.searchParams.get("names");
+  const targetNames = names
+    ?.split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+
+  const query = supabase
+    .from("backups.trigger_function_defs")
+    .select("name,definition,created_at")
+    .order("name");
+
+  if (targetNames && targetNames.length > 0) {
+    query.in("name", targetNames);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("fetch-sources: failed to read trigger_function_defs", error);
+    return json({ ok: false, error: "failed_to_read_sources", hint: error.message }, 500);
+  }
+
+  return json({ ok: true, count: data.length, functions: data });
+});


### PR DESCRIPTION
## Summary
- add fetch-sources Edge Function to expose backed-up trigger function definitions
- provide runbook and checklist for consolidating auth/profile triggers and deploying the function
- add SQL helpers and a snapshot file to capture trigger function definitions for review

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242b73aed88328aefb706e681ec05c)