### PR TITLE
Align profile account type handling with enum values

### DIFF
--- a/supabase/migrations/20251119164500_add_profile_errors_table.sql
+++ b/supabase/migrations/20251119164500_add_profile_errors_table.sql
@@ -41,7 +41,7 @@ CREATE POLICY profile_errors_admin_all ON public.profile_errors
       SELECT 1
       FROM public.profiles p_admin
       WHERE p_admin.id = auth.uid()
-        AND p_admin.account_type = 'ADMIN'
+        AND p_admin.account_type = 'government'
     )
   );
 

--- a/supabase/migrations/20251119164600_enhance_handle_new_user_trigger.sql
+++ b/supabase/migrations/20251119164600_enhance_handle_new_user_trigger.sql
@@ -27,12 +27,15 @@ BEGIN
   -- Extract metadata from raw_user_meta_data if available
   BEGIN
     v_full_name := COALESCE(NEW.raw_user_meta_data->>'full_name', '');
-    v_account_type := COALESCE((NEW.raw_user_meta_data->>'account_type')::public.account_type_enum, 'SME');
+    v_account_type := COALESCE(
+      (NEW.raw_user_meta_data->>'account_type')::public.account_type_enum,
+      'sme'::public.account_type_enum
+    );
   EXCEPTION
     WHEN OTHERS THEN
       -- If metadata extraction fails, use safe defaults
       v_full_name := '';
-      v_account_type := 'SME';
+      v_account_type := 'sme'::public.account_type_enum;
   END;
 
   -- Attempt to insert the profile

--- a/supabase/migrations/20251119180200_add_constraints.sql
+++ b/supabase/migrations/20251119180200_add_constraints.sql
@@ -26,8 +26,8 @@ BEGIN
   ALTER TABLE public.profiles
     ADD CONSTRAINT profiles_account_type_check
     CHECK (account_type IN (
-      'sole_proprietor', 'SME', 'investor', 'donor', 
-      'professional', 'government', 'NGO'
+      'sole_proprietor', 'professional', 'sme',
+      'investor', 'donor', 'government'
     ));
 END $$;
 


### PR DESCRIPTION
## Summary
- align the profile_errors policy with the current government account type instead of the removed ADMIN value
- update the handle_new_user trigger to default to the lowercase SME enum value
- correct the profiles account type check constraint to only allow the valid enum options

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242e5b8ee48328bcef0075b8a84d5f)