### PR TITLE
Improve signup observability and profile logging

### DIFF
--- a/docs/SIGNUP_PROFILE_MONITORING.md
+++ b/docs/SIGNUP_PROFILE_MONITORING.md
@@ -1,0 +1,91 @@
+# Signup & Profile Observability
+
+This repository now treats Supabase `auth.audit_log_entries` as informational only for signup flows. Recent payloads no longer include `traits.user_id`/`traits.user_email`, so reliable correlation now comes from the application-owned `public.user_events` table and the `public.signup_profile_mismatches` view.
+
+## Root-Cause Summary
+- Supabase signup-related audit events (`user_signedup`, `user_repeated_signup`, `user_confirmation_requested`) currently omit `traits.user_id` and `traits.user_email`, leaving joins to `auth.users`/`public.profiles` empty.
+- The new logging layer writes `user_id`, `email`, and `event_type` into `public.user_events` for every signup/profile bootstrap step. Audit logs remain useful for timing but cannot be the source of truth for identifiers.
+
+## Key Database Changes
+- `public.user_events` now has explicit `event_type`, `email`, and `metadata` columns (legacy `kind`/`payload` are still maintained for compatibility).
+- The `on_auth_user_created` trigger calls `public.handle_new_user()`, which:
+  - Creates/merges the profile via `ensure_profile_exists`.
+  - Logs `auth_user_created`, `profile_created`, and `signup_completed` events with the user’s email.
+  - Records `profile_creation_failed` if profile creation raises an error.
+- `public.signup_profile_mismatches` now monitors signup health using `user_events` instead of audit traits.
+
+## Investigative Queries
+- Inspect raw audit payloads (informational only):
+```sql
+SELECT id, payload, created_at
+FROM auth.audit_log_entries
+WHERE payload->>'action' IN ('user_signedup','user_repeated_signup','user_confirmation_requested')
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+- Compare auth users to profiles and capture the latest signup-related event:
+```sql
+SELECT
+  u.id AS auth_user_id,
+  u.email AS auth_email,
+  u.created_at AS auth_created_at,
+  p.id AS profile_id,
+  p.created_at AS profile_created_at,
+  spm.event_type,
+  spm.event_email,
+  spm.event_created_at,
+  spm.status
+FROM public.signup_profile_mismatches spm
+JOIN auth.users u ON u.id = spm.auth_user_id
+LEFT JOIN public.profiles p ON p.id = spm.auth_user_id
+ORDER BY u.created_at DESC
+LIMIT 200;
+```
+
+- List auth users missing profiles (for backfill/alerting):
+```sql
+SELECT u.id, u.email, u.created_at
+FROM auth.users u
+LEFT JOIN public.profiles p ON u.id = p.id
+WHERE p.id IS NULL
+ORDER BY u.created_at DESC;
+```
+
+## Backfill & Repair
+- Create missing profiles safely:
+```sql
+INSERT INTO public.profiles (id, email, created_at)
+SELECT u.id, COALESCE(u.email, 'missing-email-' || u.id || '@example.invalid'), now()
+FROM auth.users u
+LEFT JOIN public.profiles p ON u.id = p.id
+WHERE p.id IS NULL;
+```
+
+## Monitoring Queries
+- Profiles missing within 10 minutes of signup:
+```sql
+SELECT
+  u.id,
+  u.email,
+  u.created_at
+FROM auth.users u
+LEFT JOIN public.profiles p ON p.id = u.id
+WHERE p.id IS NULL
+  AND u.created_at > now() - interval '10 minutes';
+```
+
+- Users with profiles but no `signup_completed` event:
+```sql
+SELECT
+  u.id,
+  u.email,
+  u.created_at
+FROM auth.users u
+JOIN public.profiles p ON p.id = u.id
+LEFT JOIN public.user_events e ON e.user_id = u.id AND e.event_type = 'signup_completed'
+WHERE e.user_id IS NULL
+  AND u.created_at > now() - interval '10 minutes';
+```
+
+**Recommended cadence:** run the monitoring queries via cron every few minutes and alert if any rows are returned. An empty result indicates the signup → profile → logging pipeline is healthy.

--- a/supabase/migrations/20251126120000_signup_event_observability.sql
+++ b/supabase/migrations/20251126120000_signup_event_observability.sql
@@ -1,0 +1,151 @@
+BEGIN;
+
+-- Ensure user_events captures explicit identifiers and structured metadata.
+ALTER TABLE public.user_events
+  ADD COLUMN IF NOT EXISTS event_type text,
+  ADD COLUMN IF NOT EXISTS email text,
+  ADD COLUMN IF NOT EXISTS metadata jsonb;
+
+-- Backfill event_type and metadata from legacy columns where possible.
+UPDATE public.user_events
+SET event_type = COALESCE(event_type, kind, 'unknown');
+
+UPDATE public.user_events
+SET metadata = COALESCE(metadata, payload, '{}'::jsonb)
+WHERE metadata IS NULL;
+
+-- Backfill email from existing payloads or apply a deterministic placeholder.
+UPDATE public.user_events
+SET email = COALESCE(email, metadata->>'email', metadata->>'user_email', payload->>'email', payload->>'user_email')
+WHERE email IS NULL;
+
+UPDATE public.user_events
+SET email = 'missing-email-' || user_id::text || '@example.invalid'
+WHERE email IS NULL;
+
+-- Harden defaults and constraints so future inserts must include identifiers and metadata.
+ALTER TABLE public.user_events
+  ALTER COLUMN event_type SET DEFAULT 'unknown',
+  ALTER COLUMN event_type SET NOT NULL,
+  ALTER COLUMN metadata SET DEFAULT '{}'::jsonb,
+  ALTER COLUMN metadata SET NOT NULL,
+  ALTER COLUMN email SET NOT NULL;
+
+-- Maintain compatibility by keeping the legacy kind/payload columns populated alongside the new structure.
+CREATE OR REPLACE FUNCTION public.log_user_event(
+  p_user_id uuid,
+  p_event_type text,
+  p_email text,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_type text := COALESCE(NULLIF(p_event_type, ''), 'unknown');
+  v_email text := COALESCE(NULLIF(p_email, ''), 'missing-email-' || p_user_id::text || '@example.invalid');
+  v_metadata jsonb := COALESCE(p_metadata, '{}'::jsonb);
+BEGIN
+  INSERT INTO public.user_events (user_id, event_type, email, metadata, kind, payload)
+  VALUES (p_user_id, v_event_type, v_email, v_metadata, v_event_type, v_metadata);
+EXCEPTION WHEN OTHERS THEN
+  -- Never block the main transaction because of telemetry issues.
+  NULL;
+END;
+$$;
+
+-- Refresh the auth.users trigger to emit explicit identifiers and signup completion logging.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email text := COALESCE(NEW.email, NEW.raw_user_meta_data->>'email', NEW.raw_user_meta_data->>'user_email');
+  v_full_name text := COALESCE(NEW.raw_user_meta_data->>'full_name', '');
+  v_msisdn text := COALESCE(NEW.raw_user_meta_data->>'msisdn', NEW.phone);
+  v_profile_type text := COALESCE(NEW.raw_user_meta_data->>'profile_type', 'customer');
+BEGIN
+  PERFORM public.log_user_event(
+    NEW.id,
+    'auth_user_created',
+    v_email,
+    jsonb_build_object('source', 'auth_trigger')
+  );
+
+  BEGIN
+    PERFORM public.ensure_profile_exists(NEW.id, v_email, v_full_name, v_msisdn, v_profile_type);
+
+    PERFORM public.log_user_event(
+      NEW.id,
+      'profile_created',
+      v_email,
+      jsonb_build_object('source', 'trigger')
+    );
+
+    PERFORM public.log_user_event(
+      NEW.id,
+      'signup_completed',
+      v_email,
+      jsonb_build_object('profile_source', 'trigger')
+    );
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.log_user_event(
+      NEW.id,
+      'profile_creation_failed',
+      v_email,
+      jsonb_build_object('error', SQLERRM, 'code', SQLSTATE)
+    );
+    RETURN NEW;
+  END;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_new_user();
+
+-- Rework the monitoring view to lean on application-owned logging instead of audit traits.
+DROP VIEW IF EXISTS public.signup_profile_mismatches;
+CREATE OR REPLACE VIEW public.signup_profile_mismatches AS
+WITH recent_events AS (
+  SELECT
+    user_id,
+    email,
+    event_type,
+    created_at,
+    row_number() OVER (PARTITION BY user_id ORDER BY created_at DESC) AS rn
+  FROM public.user_events
+  WHERE event_type IN ('signup_completed', 'profile_created', 'auth_user_created')
+)
+SELECT
+  u.id AS auth_user_id,
+  u.email AS auth_email,
+  u.created_at AS auth_created_at,
+  p.id AS profile_id,
+  p.created_at AS profile_created_at,
+  e.event_type,
+  e.email AS event_email,
+  e.created_at AS event_created_at,
+  CASE
+    WHEN p.id IS NOT NULL AND e.user_id IS NOT NULL THEN 'healthy'
+    WHEN p.id IS NULL AND e.user_id IS NOT NULL THEN 'auth_without_profile'
+    WHEN p.id IS NOT NULL AND e.user_id IS NULL THEN 'profile_without_event'
+    ELSE 'no_event_and_profile_missing'
+  END AS status
+FROM auth.users u
+LEFT JOIN public.profiles p ON p.id = u.id
+LEFT JOIN recent_events e ON e.user_id = u.id AND e.rn = 1;
+
+GRANT SELECT ON public.signup_profile_mismatches TO authenticated;
+
+-- Lightweight index to keep monitoring queries fast.
+CREATE INDEX IF NOT EXISTS user_events_event_type_created_at_idx ON public.user_events (event_type, created_at DESC);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add structured signup logging with explicit user_id/email metadata in user_events and monitoring view
- refresh auth user trigger to log signup/profile lifecycle and keep compatibility with legacy columns
- document monitoring, investigation, and backfill queries for signup/profile consistency

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692450b9b5848328865e4c86d215fe1b)