### PR TITLE
Enforce subscription access for diagnostics

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -94,6 +94,7 @@ const otpRoutes = require('./routes/otp');
 const emailRoutes = require('./routes/email');
 const healthRoutes = require('./routes/health');
 const auditRoutes = require('./routes/audit');
+const diagnosticsRoutes = require('./routes/diagnostics');
 
 // Health check endpoint
 app.use(['/health', '/api/health'], healthRoutes);
@@ -111,6 +112,7 @@ app.get('/api', (req, res) => {
       resolve: 'POST /resolve/lenco-merchant',
       otp: 'POST /api/auth/otp/send, POST /api/auth/otp/verify',
       email: 'GET /api/email/test, GET /api/email/status, POST /api/email/send, POST /api/email/send-otp, POST /api/email/send-verification, POST /api/email/send-password-reset',
+      diagnostics: 'POST /api/diagnostics/run, GET /api/diagnostics/:companyId/latest, GET /api/diagnostics/:companyId/history',
     },
   });
 });
@@ -122,6 +124,7 @@ app.use('/resolve', resolveRoutes);
 app.use('/api/auth/otp', otpRoutes);
 app.use('/api/email', emailRoutes);
 app.use('/api/audit', auditRoutes);
+app.use('/api/diagnostics', diagnosticsRoutes);
 
 
 // Global error handler

--- a/backend/lib/diagnostics-prompts.js
+++ b/backend/lib/diagnostics-prompts.js
@@ -1,0 +1,15 @@
+const buildLLMPrompt = ({ input, scores, swot, recommendations, bottlenecks }) => {
+  const basePrompt = `You are an experienced African SME consultant designing a concise diagnostic.
+Structured SME input: ${JSON.stringify(input)}
+Pre-computed scores (0-100): ${JSON.stringify(scores)}
+Rule-based SWOT: ${JSON.stringify(swot)}
+Rule-based recommendations: ${JSON.stringify(recommendations)}
+Rule-based bottlenecks: ${JSON.stringify(bottlenecks)}
+Output strict JSON with keys: swot_analysis, bottlenecks, recommendations, suggested_opportunities, recommended_partners, narrative (3 short paragraphs), and keep advice practical for SMEs in Sub-Saharan Africa. If data is missing, flag gaps explicitly.`;
+
+  return basePrompt;
+};
+
+module.exports = {
+  buildLLMPrompt,
+};

--- a/backend/middleware/require-subscription.js
+++ b/backend/middleware/require-subscription.js
@@ -1,0 +1,57 @@
+const { getSupabaseClient } = require('../lib/supabaseAdmin');
+
+const parseBearerToken = (req) => {
+  const authHeader = req.headers?.authorization || '';
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) return null;
+  return token.trim();
+};
+
+const requireSubscription = async (req, res, next) => {
+  try {
+    const supabase = getSupabaseClient();
+    if (!supabase) {
+      return res.status(503).json({ error: 'Supabase is required to verify subscriptions.' });
+    }
+
+    const accessToken = parseBearerToken(req);
+    if (!accessToken) {
+      return res.status(401).json({ error: 'Authorization bearer token is required.' });
+    }
+
+    const { data: userResult, error: userError } = await supabase.auth.getUser(accessToken);
+    const user = userResult?.user;
+
+    if (userError || !user) {
+      return res.status(401).json({ error: 'Invalid or expired session token.' });
+    }
+
+    const nowIso = new Date().toISOString();
+    const { data: subscriptions, error: subscriptionError } = await supabase
+      .from('user_subscriptions')
+      .select('id, status, end_date')
+      .eq('user_id', user.id)
+      .eq('status', 'active')
+      .or(`end_date.is.null,end_date.gt.${nowIso}`)
+      .order('end_date', { ascending: false })
+      .limit(1);
+
+    if (subscriptionError) {
+      console.error('[subscription] Failed to verify access', subscriptionError);
+      return res.status(500).json({ error: 'Unable to verify subscription access.' });
+    }
+
+    if (!subscriptions || subscriptions.length === 0) {
+      return res.status(403).json({ error: 'An active subscription is required to use diagnostics.' });
+    }
+
+    req.user = user;
+    req.subscription = subscriptions[0];
+    return next();
+  } catch (error) {
+    console.error('[subscription] Unexpected error verifying access', error);
+    return res.status(500).json({ error: 'Failed to verify subscription access.' });
+  }
+};
+
+module.exports = { requireSubscription };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,8 @@
         "joi": "^17.9.2",
         "nodemailer": "^7.0.10",
         "sanitize-html": "^2.11.0",
-        "twilio": "^5.10.5"
+        "twilio": "^5.10.5",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -1562,6 +1563,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/utils-merge": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "uuid": "^11.1.0",
     "@supabase/supabase-js": "^2.81.1",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/backend/routes/diagnostics.js
+++ b/backend/routes/diagnostics.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const crypto = require('crypto');
+const { runDiagnosis } = require('../services/diagnostics-engine');
+const { logRun, getLatestByCompany, getHistoryByCompany } = require('../services/diagnostics-store');
+const { requireSubscription } = require('../middleware/require-subscription');
+
+const router = express.Router();
+
+const hashInput = input => crypto
+  .createHash('sha256')
+  .update(JSON.stringify(input || {}))
+  .digest('hex');
+
+router.use(requireSubscription);
+
+router.post('/run', (req, res) => {
+  try {
+    const { companyId, input } = req.body || {};
+    if (!input || typeof input !== 'object') {
+      return res.status(400).json({ error: 'input is required' });
+    }
+
+    const diagnosis = runDiagnosis({ companyId, input });
+    logRun({ companyId, inputHash: hashInput(input), output: diagnosis });
+
+    return res.status(200).json({ diagnosis });
+  } catch (error) {
+    console.error('diagnostics run failed', error);
+    return res.status(500).json({ error: 'Failed to run diagnosis' });
+  }
+});
+
+router.get('/:companyId/latest', (req, res) => {
+  const { companyId } = req.params;
+  const latest = getLatestByCompany(companyId);
+  if (!latest) return res.status(404).json({ error: 'No diagnosis found for company' });
+  return res.status(200).json({ latest });
+});
+
+router.get('/:companyId/history', (req, res) => {
+  const { companyId } = req.params;
+  const history = getHistoryByCompany(companyId);
+  return res.status(200).json({ history });
+});
+
+module.exports = router;

--- a/backend/services/diagnostics-engine.js
+++ b/backend/services/diagnostics-engine.js
@@ -1,0 +1,407 @@
+const { v4: uuidv4 } = require('uuid');
+const { buildLLMPrompt } = require('../lib/diagnostics-prompts');
+
+const MODEL_VERSION = 'v1.0.0';
+
+const normalizeScore = (value, max = 100) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 0;
+  return Math.max(0, Math.min(max, value));
+};
+
+const scoreFromFactors = factors => {
+  const totalWeight = factors.reduce((sum, factor) => sum + factor.weight, 0);
+  if (totalWeight === 0) return 0;
+
+  const achieved = factors.reduce((sum, factor) => {
+    if (factor.met === true) return sum + factor.weight;
+    if (factor.met === 'partial') return sum + factor.weight * 0.5;
+    return sum;
+  }, 0);
+
+  return normalizeScore((achieved / totalWeight) * 100);
+};
+
+const evaluateFundingReadiness = input => {
+  const factors = [
+    { weight: 15, met: input?.registration?.is_registered },
+    { weight: 10, met: (input?.years_in_operation ?? 0) >= 3 },
+    { weight: 15, met: input?.financials?.revenue_history?.length >= 2 },
+    { weight: 10, met: input?.financials?.profit_trend === 'positive' },
+    { weight: 15, met: Boolean(input?.financials?.statements_available) },
+    { weight: 10, met: input?.financials?.debt_status === 'on_time' },
+    { weight: 10, met: input?.compliance?.tax_clearance === true },
+    { weight: 5, met: Boolean(input?.compliance?.licenses?.length) },
+    { weight: 10, met: input?.financials?.cashflow_visibility === true },
+  ];
+
+  return scoreFromFactors(factors);
+};
+
+const evaluateComplianceMaturity = input => {
+  const factors = [
+    { weight: 15, met: input?.compliance?.tax_registered },
+    { weight: 15, met: input?.compliance?.tax_clearance },
+    { weight: 10, met: input?.compliance?.returns_on_time },
+    { weight: 10, met: Boolean(input?.compliance?.licenses?.length) },
+    { weight: 10, met: input?.governance?.policies?.length >= 2 },
+    { weight: 10, met: input?.governance?.board_present },
+    { weight: 10, met: input?.compliance?.insurance_cover === true },
+    { weight: 10, met: Boolean(input?.documents?.registration_certificate) },
+    { weight: 10, met: Boolean(input?.documents?.tax_certificate) },
+  ];
+
+  return scoreFromFactors(factors);
+};
+
+const evaluateDigitalMaturity = input => {
+  const factors = [
+    { weight: 20, met: Boolean(input?.digital?.website) },
+    { weight: 15, met: Boolean(input?.digital?.social_links?.length) },
+    { weight: 15, met: Boolean(input?.digital?.online_store) },
+    { weight: 15, met: Boolean(input?.digital?.business_tools?.includes('accounting')) },
+    { weight: 15, met: Boolean(input?.digital?.business_tools?.includes('pos')) },
+    { weight: 10, met: input?.behaviour?.response_time === 'fast' },
+    { weight: 10, met: input?.behaviour?.profile_completion === 'high' },
+  ];
+
+  return scoreFromFactors(factors);
+};
+
+const evaluateGovernanceMaturity = input => {
+  const factors = [
+    { weight: 20, met: input?.governance?.board_present },
+    { weight: 15, met: input?.governance?.advisory_board },
+    { weight: 20, met: input?.governance?.policies?.includes('finance') },
+    { weight: 15, met: input?.governance?.policies?.includes('hr') },
+    { weight: 10, met: input?.governance?.segregation_of_roles },
+    { weight: 10, met: input?.governance?.risk_management === true },
+    { weight: 10, met: Boolean(input?.documents?.audited_financials) },
+  ];
+
+  return scoreFromFactors(factors);
+};
+
+const evaluateMarketReadiness = input => {
+  const factors = [
+    { weight: 20, met: Boolean(input?.profile?.sector) },
+    { weight: 15, met: Boolean(input?.profile?.sub_sector) },
+    { weight: 20, met: Boolean(input?.market?.top_clients?.length) },
+    { weight: 15, met: input?.market?.revenue_concentration === 'balanced' },
+    { weight: 10, met: Boolean(input?.market?.contracts_active) },
+    { weight: 10, met: input?.behaviour?.opportunities_engaged === 'high' },
+    { weight: 10, met: input?.behaviour?.course_completion === 'medium' || input?.behaviour?.course_completion === 'high' },
+  ];
+
+  return scoreFromFactors(factors);
+};
+
+const evaluateOperationalEfficiency = input => {
+  const factors = [
+    { weight: 20, met: Boolean(input?.operations?.documented_processes) },
+    { weight: 15, met: Boolean(input?.operations?.inventory_system) },
+    { weight: 15, met: Boolean(input?.operations?.erp_or_pos) },
+    { weight: 15, met: input?.operations?.delivery_on_time === true },
+    { weight: 15, met: input?.operations?.quality_control === true },
+    { weight: 10, met: input?.operations?.supplier_diversity === 'balanced' },
+    { weight: 10, met: input?.operations?.staff_training === true },
+  ];
+
+  return scoreFromFactors(factors);
+};
+
+const deriveCoverageLevel = input => {
+  const sections = ['profile', 'financials', 'compliance', 'governance', 'digital', 'market', 'operations', 'documents', 'behaviour'];
+  const provided = sections.filter(section => {
+    const value = input?.[section];
+    if (!value) return false;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return Boolean(value);
+  }).length;
+
+  const ratio = provided / sections.length;
+  if (ratio >= 0.8) return 'rich';
+  if (ratio >= 0.5) return 'moderate';
+  if (ratio >= 0.3) return 'basic';
+  return 'minimal';
+};
+
+const buildSwot = (input, scores) => {
+  const strengths = [];
+  const weaknesses = [];
+  const opportunities = [];
+  const threats = [];
+
+  if (scores.funding_readiness >= 70) strengths.push('Shows bankable traits with evidence of compliance and financial discipline.');
+  else weaknesses.push('Funding readiness is below bankable thresholds; improve financial documentation and compliance.');
+
+  if (scores.compliance_maturity >= 70) strengths.push('Compliance discipline reduces friction with lenders and corporate buyers.');
+  else weaknesses.push('Compliance documentation is light; tax clearance and statutory filings need attention.');
+
+  if (scores.digital_maturity >= 70) strengths.push('Strong digital presence can accelerate market reach and lead capture.');
+  else opportunities.push('Digitising sales channels and customer engagement can drive efficiency and visibility.');
+
+  if (input?.market?.revenue_concentration === 'balanced') strengths.push('Revenue is diversified across clients, lowering concentration risk.');
+  else threats.push('High customer concentration exposes the business to revenue shocks.');
+
+  if (input?.operations?.supplier_diversity !== 'balanced') threats.push('Operational dependencies on few suppliers can disrupt delivery.');
+
+  if (input?.profile?.country === 'Zambia') opportunities.push('Eligible for Zambian SME financing and tax incentives; optimise compliance to qualify.');
+
+  if (input?.profile?.sector) opportunities.push(`Sector: ${input.profile.sector}—tap into tailored funds and accelerators.`);
+
+  return { strengths, weaknesses, opportunities, threats };
+};
+
+const buildBottlenecks = scores => {
+  const items = [];
+
+  if (scores.compliance_maturity < 60) {
+    items.push({
+      area: 'Compliance',
+      severity: scores.compliance_maturity < 40 ? 'high' : 'medium',
+      description: 'Compliance evidence (tax clearance, licenses, returns) is incomplete or outdated.',
+      impact: 'Blocks access to formal financing and large procurement opportunities.',
+    });
+  }
+
+  if (scores.funding_readiness < 60) {
+    items.push({
+      area: 'Funding Readiness',
+      severity: scores.funding_readiness < 40 ? 'high' : 'medium',
+      description: 'Financial records and visibility are insufficient for lenders.',
+      impact: 'Delays or prevents approval for loans and grants.',
+    });
+  }
+
+  if (scores.digital_maturity < 60) {
+    items.push({
+      area: 'Digital',
+      severity: 'medium',
+      description: 'Limited digital presence and tooling reduce conversion and insight.',
+      impact: 'Leads, collections, and market data are not captured effectively.',
+    });
+  }
+
+  if (scores.operational_efficiency < 60) {
+    items.push({
+      area: 'Operations',
+      severity: 'medium',
+      description: 'Processes, quality control, or delivery tracking are not consistently documented.',
+      impact: 'Operational inconsistency can erode margins and customer trust.',
+    });
+  }
+
+  return items;
+};
+
+const buildRecommendations = scores => {
+  const recs = [];
+
+  if (scores.compliance_maturity < 80) {
+    recs.push({
+      priority: 1,
+      area: 'Compliance',
+      action: 'Obtain or renew tax clearance and submit pending statutory returns.',
+      why: 'Banks and corporate buyers require valid compliance evidence before onboarding suppliers or granting credit.',
+      how: [
+        'Confirm tax registrations (VAT, PAYE, turnover tax) on the revenue authority portal.',
+        'Submit outstanding monthly/annual returns and settle arrears.',
+        'Request a Tax Clearance Certificate and store it in the Wathaci vault.',
+      ],
+      estimated_time: '2–4 weeks',
+      difficulty: 'medium',
+    });
+  }
+
+  if (scores.funding_readiness < 80) {
+    recs.push({
+      priority: recs.length + 1,
+      area: 'Finance',
+      action: 'Produce last 12 months management accounts and a cashflow forecast.',
+      why: 'Lenders and donors need visibility on revenue trends, margins, and repayment capacity.',
+      how: [
+        'Export transactions from bank/POS into accounting software (e.g., Zoho, Xero, or Wave).',
+        'Prepare income statement, balance sheet, and cashflow for the last financial year.',
+        'Highlight recurring revenue, top customers, and any arrears resolutions.',
+      ],
+      estimated_time: '2–3 weeks',
+      difficulty: 'medium',
+    });
+  }
+
+  if (scores.digital_maturity < 80) {
+    recs.push({
+      priority: recs.length + 1,
+      area: 'Digital',
+      action: 'Strengthen digital presence and lead capture.',
+      why: 'SMEs with active online channels convert more opportunities and build trust.',
+      how: [
+        'Launch or update a lightweight website with products/services and contact flows.',
+        'Integrate WhatsApp or web chat with response-time SLAs.',
+        'Enable digital invoicing and receipt tracking to improve collections.',
+      ],
+      estimated_time: '1–2 weeks',
+      difficulty: 'low',
+    });
+  }
+
+  if (scores.operational_efficiency < 80) {
+    recs.push({
+      priority: recs.length + 1,
+      area: 'Operations',
+      action: 'Document core processes and assign owners.',
+      why: 'Clear SOPs and metrics reduce errors and increase consistency for corporate buyers.',
+      how: [
+        'Document procurement-to-delivery workflows with quality checks.',
+        'Track on-time delivery and defect rates weekly.',
+        'Introduce supplier backups to de-risk supply chain interruptions.',
+      ],
+      estimated_time: '2–4 weeks',
+      difficulty: 'medium',
+    });
+  }
+
+  return recs.map((rec, index) => ({ ...rec, priority: index + 1 }));
+};
+
+const buildRecommendedPartners = (scores, profile) => {
+  const partners = [];
+
+  if (scores.funding_readiness >= 60) {
+    partners.push({
+      partner_type: 'Bank',
+      partner_id: 'bank_working_capital',
+      name: 'ZamBank SME Unit',
+      reason: 'Active SME working capital facility aligned to your revenue band.',
+      suggested_product: 'Working Capital Facility',
+      fit_score: scores.funding_readiness,
+    });
+  }
+
+  if (scores.compliance_maturity < 80) {
+    partners.push({
+      partner_type: 'Consultant',
+      partner_id: 'compliance_partner',
+      name: 'Compliance & Tax Desk (Wathaci)',
+      reason: 'Can regularise filings and secure a tax clearance quickly.',
+      suggested_product: 'Fast-track Tax Clearance',
+      fit_score: 85,
+    });
+  }
+
+  partners.push({
+    partner_type: 'Training',
+    partner_id: 'digital_sales_bootcamp',
+    name: 'Digital Sales Bootcamp',
+    reason: 'Improve digital lead generation and conversion.',
+    suggested_product: '2-week cohort',
+    fit_score: 75,
+  });
+
+  if (profile?.sector) {
+    partners.push({
+      partner_type: 'Corporate Procurement',
+      partner_id: `${profile.sector.toLowerCase().replace(/\s+/g, '-')}-anchor`,
+      name: `${profile.sector} Anchor Buyer`,
+      reason: 'Active procurement programmes seeking vetted SMEs in your sector.',
+      suggested_product: 'Onboarding & RFP notifications',
+      fit_score: 70,
+    });
+  }
+
+  return partners;
+};
+
+const buildSuggestedOpportunities = profile => {
+  const opportunities = [
+    {
+      opportunity_id: 'grant_early_growth',
+      title: 'Early Growth Grant Window',
+      type: 'Grant',
+      reason: 'Supports SMEs formalising compliance and building systems.',
+    },
+    {
+      opportunity_id: 'market_linkage',
+      title: 'Corporate Supplier Readiness Challenge',
+      type: 'Market',
+      reason: 'Preparation track for anchor buyer onboarding.',
+    },
+  ];
+
+  if (profile?.country === 'Zambia') {
+    opportunities.push({
+      opportunity_id: 'zed_zambia_sme_finance',
+      title: 'Zambia SME Blended Finance',
+      type: 'Debt',
+      reason: 'Local currency facility with technical assistance for Zambian SMEs.',
+    });
+  }
+
+  return opportunities;
+};
+
+const buildNarrative = (scores, swot) => {
+  const paragraphs = [];
+
+  const stage = scores.funding_readiness >= 80
+    ? 'scale-ready SME with strong compliance discipline'
+    : scores.funding_readiness >= 60
+      ? 'growth-stage SME showing bankable traits'
+      : 'emerging SME that needs compliance and financial visibility to unlock growth';
+
+  paragraphs.push(`Your business is positioned as a ${stage}. Funding readiness is ${Math.round(scores.funding_readiness)} / 100 and compliance maturity is ${Math.round(scores.compliance_maturity)} / 100.`);
+  paragraphs.push(`Key strengths: ${(swot.strengths[0] || 'Strong customer understanding')} and ${(swot.strengths[1] || 'evidence of market traction')}.`);
+  paragraphs.push('Top gaps to close in the next quarter: focus on compliance evidence, reliable management accounts, and a sharper digital presence to engage buyers and lenders.');
+
+  return paragraphs.join(' ');
+};
+
+const runDiagnosis = ({ companyId, input }) => {
+  const scores = {
+    funding_readiness: evaluateFundingReadiness(input),
+    compliance_maturity: evaluateComplianceMaturity(input),
+    governance_maturity: evaluateGovernanceMaturity(input),
+    digital_maturity: evaluateDigitalMaturity(input),
+    market_readiness: evaluateMarketReadiness(input),
+    operational_efficiency: evaluateOperationalEfficiency(input),
+  };
+
+  const swot = buildSwot(input, scores);
+  const bottlenecks = buildBottlenecks(scores);
+  const recommendations = buildRecommendations(scores);
+  const recommended_partners = buildRecommendedPartners(scores, input?.profile);
+  const suggested_opportunities = buildSuggestedOpportunities(input?.profile);
+  const data_coverage_level = deriveCoverageLevel(input);
+  const llmPrompt = buildLLMPrompt({ input, scores, swot, recommendations, bottlenecks });
+  const narrative = buildNarrative(scores, swot);
+
+  const diagnosis = {
+    id: uuidv4(),
+    company_id: companyId || null,
+    overall_summary: {
+      summary_text: narrative,
+      stage: scores.funding_readiness >= 80 ? 'scale' : scores.funding_readiness >= 60 ? 'growth' : 'early',
+      key_strengths: swot.strengths.slice(0, 3),
+      top_gaps: bottlenecks.slice(0, 3).map(item => item.description),
+    },
+    swot_analysis: swot,
+    scores,
+    bottlenecks,
+    recommendations,
+    recommended_partners,
+    suggested_opportunities,
+    meta: {
+      last_updated: new Date().toISOString(),
+      data_coverage_level,
+      model_version: MODEL_VERSION,
+      llm_prompt: llmPrompt,
+    },
+  };
+
+  return diagnosis;
+};
+
+module.exports = {
+  runDiagnosis,
+  MODEL_VERSION,
+};

--- a/backend/services/diagnostics-store.js
+++ b/backend/services/diagnostics-store.js
@@ -1,0 +1,32 @@
+const { MODEL_VERSION } = require('./diagnostics-engine');
+
+const runs = [];
+
+const logRun = ({ companyId, inputHash, output }) => {
+  const record = {
+    id: output.id,
+    company_id: companyId || null,
+    input_hash: inputHash || null,
+    scores: output.scores,
+    model_version: MODEL_VERSION,
+    created_at: new Date().toISOString(),
+    meta: output.meta,
+    summary: output.overall_summary,
+  };
+  runs.push(record);
+  return record;
+};
+
+const getLatestByCompany = companyId => runs
+  .filter(item => item.company_id === companyId)
+  .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+
+const getHistoryByCompany = companyId => runs
+  .filter(item => item.company_id === companyId)
+  .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+module.exports = {
+  logRun,
+  getLatestByCompany,
+  getHistoryByCompany,
+};

--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -1,0 +1,240 @@
+# Wathaci AI SME Auto-Diagnosis & Growth Recommendation Engine
+
+This document describes the architecture, scoring logic, prompts, API design, and experience for the SME auto-diagnosis engine. The goal is to give any SME a structured health check, narrative insights, and tailored partner recommendations that improve as more data is supplied.
+
+## Objectives
+
+- Deliver explainable 360° diagnostics that work with partial or rich data.
+- Produce structured JSON for the platform plus human-friendly narratives for reports/PDFs.
+- Keep the engine modular so new sectors, metrics, and AI models can be added without breaking existing consumers.
+- Capture every run with version metadata for auditability and regression testing.
+
+## Data Model & Schemas
+
+### `diagnostics_runs` (Supabase or relational table)
+
+| column | type | description |
+| --- | --- | --- |
+| `id` | uuid (pk) | Run identifier. |
+| `company_id` | uuid | SME foreign key. |
+| `input_hash` | text | SHA-256 hash of normalized input payload for idempotency. |
+| `scores` | jsonb | Calculated scores (see `scores` object). |
+| `model_version` | text | Semantic version of scoring/prompt pack. |
+| `created_at` | timestamptz | Run timestamp. |
+| `meta` | jsonb | Includes data coverage, llm prompt, failures. |
+| `summary` | jsonb | Cached `overall_summary` block for quick rendering. |
+
+### `diagnostics_outputs`
+
+| column | type | description |
+| --- | --- | --- |
+| `diagnostic_id` | uuid (pk/fk) | Links to `diagnostics_runs.id`. |
+| `payload` | jsonb | Full JSON output returned to clients (SWOT, scores, recommendations, partners, opportunities). |
+
+### Sector Benchmarks (extensible lookup)
+
+`sector_benchmarks` (optional table used by future model versions):
+- `sector`, `sub_sector`
+- `median_margin`, `payment_terms_days`, `customer_concentration_thresholds`, `license_requirements`
+
+## JSON Output Contract
+
+```json
+{
+  "overall_summary": {
+    "summary_text": "... narrative paragraphs ...",
+    "stage": "early|growth|scale",
+    "key_strengths": ["..."],
+    "top_gaps": ["..."]
+  },
+  "swot_analysis": {
+    "strengths": [],
+    "weaknesses": [],
+    "opportunities": [],
+    "threats": []
+  },
+  "scores": {
+    "funding_readiness": 0,
+    "compliance_maturity": 0,
+    "governance_maturity": 0,
+    "digital_maturity": 0,
+    "market_readiness": 0,
+    "operational_efficiency": 0
+  },
+  "bottlenecks": [
+    {
+      "area": "Financial Management",
+      "severity": "high",
+      "description": "...",
+      "impact": "..."
+    }
+  ],
+  "recommendations": [
+    {
+      "priority": 1,
+      "area": "Compliance",
+      "action": "...",
+      "why": "...",
+      "how": ["..."],
+      "estimated_time": "2–4 weeks",
+      "difficulty": "medium"
+    }
+  ],
+  "recommended_partners": [
+    {
+      "partner_type": "Bank",
+      "partner_id": "partner_123",
+      "name": "XYZ Bank SME Unit",
+      "reason": "...",
+      "suggested_product": "Working Capital Facility",
+      "fit_score": 87
+    }
+  ],
+  "suggested_opportunities": [
+    {
+      "opportunity_id": "...",
+      "title": "...",
+      "type": "Grant|Debt|Equity|Market",
+      "reason": "..."
+    }
+  ],
+  "meta": {
+    "last_updated": "ISO string",
+    "data_coverage_level": "minimal|basic|moderate|rich",
+    "model_version": "v1.0.0",
+    "llm_prompt": "rendered prompt for audit"
+  }
+}
+```
+
+## Scoring Logic (v1.0.0)
+
+Scores are 0–100 based on weighted factors. Missing data is treated as false; providing more data improves accuracy but never breaks the run.
+
+### Funding Readiness
+- Registration status (15%)
+- Years in business ≥3 (10%)
+- Revenue history ≥2 years (15%)
+- Positive profit trend (10%)
+- Financial statements available (15%)
+- Debt repayment on time (10%)
+- Tax clearance (10%)
+- Industry licenses (5%)
+- Cashflow visibility (10%)
+
+Bands: 0–30 Not ready, 31–60 Emerging, 61–80 Bankable with support, 81–100 Strongly bankable.
+
+### Compliance Maturity
+- Tax registration (15%)
+- Tax clearance (15%)
+- Returns on time (10%)
+- Industry licenses (10%)
+- Governance policies present (10%)
+- Board/advisory (10%)
+- Insurance cover (10%)
+- Registration certificate on file (10%)
+- Tax certificate on file (10%)
+
+### Digital Maturity
+- Website (20%)
+- Social presence (15%)
+- Online store (15%)
+- Accounting tool (15%)
+- POS/ERP (15%)
+- Fast response to leads (10%)
+- High profile completion (10%)
+
+### Governance Maturity
+- Board (20%)
+- Advisory board (15%)
+- Finance policy (20%)
+- HR policy (15%)
+- Segregation of roles (10%)
+- Risk management practice (10%)
+- Audited financials (10%)
+
+### Market Readiness
+- Sector/sub-sector present (35%)
+- Top clients listed (20%)
+- Balanced revenue concentration (15%)
+- Active contracts (10%)
+- Engagement with opportunities (10%)
+- Training/course completion (10%)
+
+### Operational Efficiency
+- Documented processes (20%)
+- Inventory system (15%)
+- ERP/POS (15%)
+- On-time delivery (15%)
+- Quality control (15%)
+- Supplier diversity (10%)
+- Staff training (10%)
+
+## Backend Service/API
+
+### Endpoints
+- `POST /api/diagnostics/run` – accepts `{ companyId?, input }` and returns the full diagnosis JSON. Idempotency is supported by hashing the input for logging.
+- `GET /api/diagnostics/:companyId/latest` – fetches the most recent run for an SME.
+- `GET /api/diagnostics/:companyId/history` – returns all runs ordered by recency.
+
+> **Access control**: All diagnostics endpoints require a valid Supabase session bearer token **and** an active subscription (`user_subscriptions.status = 'active'` with a non-expired `end_date`). Requests without a token or subscription are rejected with 401/403 so only subscribed accounts can generate or read diagnoses.
+
+### Execution Flow
+1. **Normalize input** and compute coverage level (minimal/basic/moderate/rich).
+2. **Score** funding, compliance, governance, digital, market, and operations via deterministic weights.
+3. **Generate rule-based SWOT, bottlenecks, and recommendations** (guaranteed even with partial data).
+4. **Build LLM prompt** with structured context; LLM can refine narratives or extend recommendations.
+5. **Log run** with `model_version`, `input_hash`, and `meta` so future reruns can be compared.
+
+### Extensibility Hooks
+- Add sector-specific weights or factors by appending to factor arrays in `diagnostics-engine.js`.
+- Swap/upgrade LLMs by adjusting the prompt builder and adding a `model_version` bump.
+- Persist runs to Supabase by replacing the in-memory store with Supabase client calls that write to `diagnostics_runs` and `diagnostics_outputs`.
+
+## AI Prompt Specs
+
+System guidance (see `backend/lib/diagnostics-prompts.js`):
+- Role: *Experienced African SME consultant*.
+- Inputs: structured SME object, pre-computed scores, rule-based SWOT, bottlenecks, and recommendations.
+- Output: strict JSON with keys `swot_analysis`, `bottlenecks`, `recommendations`, `suggested_opportunities`, `recommended_partners`, plus a 3-paragraph `narrative`.
+- Behaviour: If data is missing, clearly flag gaps, never fail. Keep advice practical for Sub-Saharan Africa (forex, load-shedding, import dependencies, etc.).
+
+## Frontend UX Flows
+
+### Business Health Check Dashboard
+- **Summary cards:** Overall health stage, Funding Readiness, Compliance Maturity, Digital Maturity with score and colour badges.
+- **SWOT quadrants:** Strengths, Weaknesses, Opportunities, Threats as bullet lists.
+- **Bottlenecks & Actions timeline:** Grouped into Now (0–3 months), Next (3–12 months), Later (12+ months); each item shows area, action, effort, impact, and a “Find Support” CTA.
+- **Find Support:** Surfaces consultants, training, funding, and procurement calls matching each recommendation.
+- **Download PDF:** “Wathaci_Business_Health_Report_<SMEName>_<YYYYMMDD>.pdf”.
+
+### PDF Contents
+- Cover page: SME name, logo, date, Wathaci branding.
+- Executive summary narrative + scorecards.
+- SWOT grid.
+- Recommendations with how/why, effort, timelines.
+- Suggested partners and opportunities.
+
+## Example Outputs
+
+### Micro SME (informal, minimal data)
+- Scores: Funding 28, Compliance 22, Digital 30.
+- Bottlenecks: Missing tax registration, no financial statements, no website.
+- Recommendations: Register for tax, set up simple bookkeeping, launch basic website and WhatsApp ordering.
+- Partners: Compliance desk, micro-grant programme.
+
+### Growing SME (formalised, uneven systems)
+- Scores: Funding 62, Compliance 68, Digital 55, Operations 58.
+- Bottlenecks: Thin management accounts, weak digital presence, incomplete SOPs.
+- Recommendations: Prepare 12-month management accounts, digitise invoicing, document core processes, pursue working capital line.
+- Partners: SME bank unit, digital sales bootcamp, process improvement consultant.
+
+### Mature SME (seeking scale capital)
+- Scores: Funding 82, Compliance 85, Digital 78, Governance 80.
+- Bottlenecks: Customer concentration risk, supplier redundancy.
+- Recommendations: Diversify customer base, negotiate better payment terms, invest in redundancy for key suppliers, prep for debt/equity raise.
+- Partners: Local bank for capex facility, sector anchor buyers, export advisor.
+
+---
+
+✅ Wathaci AI SME Auto-Diagnosis Engine implemented: SMEs can now generate a comprehensive business health report, get scores, identify bottlenecks, and discover relevant support and finance options through a single integrated experience.


### PR DESCRIPTION
## Summary
- add middleware to verify Supabase-authenticated users have an active subscription before using diagnostics endpoints
- secure all diagnostics routes behind the subscription gate and document the access requirement

## Testing
- npm --prefix backend test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c4c1df048328abc5be1ae2ccef76)