### PR TITLE
Implement professional onboarding profile flows and supporting schemas

### DIFF
--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -519,6 +519,90 @@ export interface SMEReadinessScore {
   updated_at: string;
 }
 
+// ================================
+// Onboarding profile tables
+// ================================
+
+export interface ProfessionalProfileRow {
+  id: string;
+  user_id: string;
+  entity_type: 'individual' | 'firm' | 'company';
+  full_name: string;
+  organisation_name?: string | null;
+  bio?: string | null;
+  primary_expertise: string[];
+  secondary_skills: string[];
+  years_of_experience?: number | null;
+  current_organisation?: string | null;
+  qualifications?: string | null;
+  top_sectors: string[];
+  notable_projects?: string | null;
+  services_offered: string[];
+  expected_rates?: string | null;
+  location_city?: string | null;
+  location_country?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  linkedin_url?: string | null;
+  website_url?: string | null;
+  portfolio_url?: string | null;
+  availability?: 'part_time' | 'full_time' | 'occasional' | null;
+  notes?: string | null;
+  profile_photo_url?: string | null;
+  logo_url?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface SmeProfileRow {
+  id: string;
+  user_id: string;
+  business_name: string;
+  registration_number?: string | null;
+  registration_type?: string | null;
+  sector?: string | null;
+  subsector?: string | null;
+  years_in_operation?: number | null;
+  employee_count?: number | null;
+  turnover_bracket?: string | null;
+  products_overview?: string | null;
+  target_market?: string | null;
+  location_city?: string | null;
+  location_country?: string | null;
+  contact_name?: string | null;
+  contact_phone?: string | null;
+  business_email?: string | null;
+  website_url?: string | null;
+  social_links: string[];
+  main_challenges: string[];
+  support_needs: string[];
+  logo_url?: string | null;
+  photos: string[];
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface InvestorProfileRow {
+  id: string;
+  user_id: string;
+  organisation_name: string;
+  investor_type?: string | null;
+  ticket_size_min?: number | null;
+  ticket_size_max?: number | null;
+  preferred_sectors: string[];
+  country_focus: string[];
+  stage_preference: string[];
+  instruments: string[];
+  impact_focus: string[];
+  contact_person?: string | null;
+  contact_role?: string | null;
+  website_url?: string | null;
+  linkedin_url?: string | null;
+  logo_url?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
 export interface SMEReadinessAnswers {
   q1?: 'yes' | 'no'; // Registered with PACRA
   q2?: 'yes' | 'no'; // Issue receipts/invoices
@@ -538,6 +622,21 @@ export interface Database {
         Row: Profile;
         Insert: Partial<Profile>;
         Update: Partial<Profile>;
+      };
+      professional_profiles: {
+        Row: ProfessionalProfileRow;
+        Insert: Partial<ProfessionalProfileRow>;
+        Update: Partial<ProfessionalProfileRow>;
+      };
+      sme_profiles: {
+        Row: SmeProfileRow;
+        Insert: Partial<SmeProfileRow>;
+        Update: Partial<SmeProfileRow>;
+      };
+      investor_profiles: {
+        Row: InvestorProfileRow;
+        Insert: Partial<InvestorProfileRow>;
+        Update: Partial<InvestorProfileRow>;
       };
       sme_readiness_scores: {
         Row: SMEReadinessScore;

--- a/src/@types/supabase.types.ts
+++ b/src/@types/supabase.types.ts
@@ -488,6 +488,109 @@ export interface GovernmentAssessment {
 }
 
 // ============================================================================
+// ONBOARDING PROFILE TABLES
+// ============================================================================
+
+export interface ProfessionalProfileRecord {
+  id: string;
+  user_id: string;
+  entity_type: 'individual' | 'firm' | 'company';
+  full_name: string;
+  organisation_name: string | null;
+  bio: string | null;
+  primary_expertise: string[];
+  secondary_skills: string[];
+  years_of_experience: number | null;
+  current_organisation: string | null;
+  qualifications: string | null;
+  top_sectors: string[];
+  notable_projects: string | null;
+  services_offered: string[];
+  expected_rates: string | null;
+  location_city: string | null;
+  location_country: string | null;
+  phone: string | null;
+  email: string | null;
+  linkedin_url: string | null;
+  website_url: string | null;
+  portfolio_url: string | null;
+  availability: 'part_time' | 'full_time' | 'occasional' | null;
+  notes: string | null;
+  profile_photo_url: string | null;
+  logo_url: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export type ProfessionalProfileInsert = Omit<
+  ProfessionalProfileRecord,
+  'id' | 'created_at' | 'updated_at'
+>;
+export type ProfessionalProfileUpdate = Partial<
+  Omit<ProfessionalProfileRecord, 'id' | 'created_at' | 'updated_at'>
+>;
+
+export interface SmeProfileRecord {
+  id: string;
+  user_id: string;
+  business_name: string;
+  registration_number: string | null;
+  registration_type: string | null;
+  sector: string | null;
+  subsector: string | null;
+  years_in_operation: number | null;
+  employee_count: number | null;
+  turnover_bracket: string | null;
+  products_overview: string | null;
+  target_market: string | null;
+  location_city: string | null;
+  location_country: string | null;
+  contact_name: string | null;
+  contact_phone: string | null;
+  business_email: string | null;
+  website_url: string | null;
+  social_links: string[];
+  main_challenges: string[];
+  support_needs: string[];
+  logo_url: string | null;
+  photos: string[];
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export type SmeProfileInsert = Omit<SmeProfileRecord, 'id' | 'created_at' | 'updated_at'>;
+export type SmeProfileUpdate = Partial<Omit<SmeProfileRecord, 'id' | 'created_at' | 'updated_at'>>;
+
+export interface InvestorProfileRecord {
+  id: string;
+  user_id: string;
+  organisation_name: string;
+  investor_type: string | null;
+  ticket_size_min: number | null;
+  ticket_size_max: number | null;
+  preferred_sectors: string[];
+  country_focus: string[];
+  stage_preference: string[];
+  instruments: string[];
+  impact_focus: string[];
+  contact_person: string | null;
+  contact_role: string | null;
+  website_url: string | null;
+  linkedin_url: string | null;
+  logo_url: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export type InvestorProfileInsert = Omit<
+  InvestorProfileRecord,
+  'id' | 'created_at' | 'updated_at'
+>;
+export type InvestorProfileUpdate = Partial<
+  Omit<InvestorProfileRecord, 'id' | 'created_at' | 'updated_at'>
+>;
+
+// ============================================================================
 // AUTH TYPES
 // ============================================================================
 
@@ -593,6 +696,21 @@ export interface Database {
         Row: Payment;
         Insert: PaymentInsert;
         Update: PaymentUpdate;
+      };
+      professional_profiles: {
+        Row: ProfessionalProfileRecord;
+        Insert: ProfessionalProfileInsert;
+        Update: ProfessionalProfileUpdate;
+      };
+      sme_profiles: {
+        Row: SmeProfileRecord;
+        Insert: SmeProfileInsert;
+        Update: SmeProfileUpdate;
+      };
+      investor_profiles: {
+        Row: InvestorProfileRecord;
+        Insert: InvestorProfileInsert;
+        Update: InvestorProfileUpdate;
       };
       webhook_logs: {
         Row: WebhookLog;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { AppProvider } from "@/contexts/AppContext";
 import { LoadingScreen } from "@/components/LoadingScreen";
 import { PrivateRoute } from "./components/PrivateRoute";
+import { AccountTypeRoute } from "./components/AccountTypeRoute";
 import { ConfigurationError } from "@/components/ConfigurationError";
 import { RouteChangeDebugger } from "@/components/RouteChangeDebugger";
 import { supabaseConfigStatus } from "@/config/appConfig";
@@ -96,6 +97,11 @@ const ProfessionalNeedsAssessmentPage = lazy(() =>
     default: module.ProfessionalNeedsAssessmentPage,
   }))
 );
+const ProfessionalOnboardingPage = lazy(() =>
+  import("./pages/onboarding/ProfessionalOnboardingPage").then((module) => ({
+    default: module.ProfessionalOnboardingPage,
+  }))
+);
 const DonorNeedsAssessmentPage = lazy(() =>
   import("./pages/onboarding/DonorNeedsAssessmentPage").then((module) => ({
     default: module.DonorNeedsAssessmentPage,
@@ -109,6 +115,16 @@ const InvestorNeedsAssessmentPage = lazy(() =>
 const GovernmentNeedsAssessmentPage = lazy(() =>
   import("./pages/onboarding/GovernmentNeedsAssessmentPage").then((module) => ({
     default: module.GovernmentNeedsAssessmentPage,
+  }))
+);
+const SmeOnboardingPage = lazy(() =>
+  import("./pages/onboarding/SmeOnboardingPage").then((module) => ({
+    default: module.SmeOnboardingPage,
+  }))
+);
+const InvestorOnboardingPage = lazy(() =>
+  import("./pages/onboarding/InvestorOnboardingPage").then((module) => ({
+    default: module.InvestorOnboardingPage,
   }))
 );
 
@@ -220,10 +236,30 @@ export const AppRoutes = () => (
         }
       />
       <Route
+        path="/onboarding/sme"
+        element={
+          <PrivateRoute>
+            <AccountTypeRoute allowed={["sme"]}>
+              <SmeOnboardingPage />
+            </AccountTypeRoute>
+          </PrivateRoute>
+        }
+      />
+      <Route
         path="/onboarding/professional/needs-assessment"
         element={
           <PrivateRoute>
             <ProfessionalNeedsAssessmentPage />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/onboarding/professional"
+        element={
+          <PrivateRoute>
+            <AccountTypeRoute allowed={["professional"]}>
+              <ProfessionalOnboardingPage />
+            </AccountTypeRoute>
           </PrivateRoute>
         }
       />
@@ -240,6 +276,16 @@ export const AppRoutes = () => (
         element={
           <PrivateRoute>
             <InvestorNeedsAssessmentPage />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/onboarding/investor"
+        element={
+          <PrivateRoute>
+            <AccountTypeRoute allowed={["investor", "donor"]}>
+              <InvestorOnboardingPage />
+            </AccountTypeRoute>
           </PrivateRoute>
         }
       />

--- a/src/components/AccountTypeRoute.tsx
+++ b/src/components/AccountTypeRoute.tsx
@@ -1,0 +1,33 @@
+import { ReactNode, useMemo } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAppContext } from '@/contexts/AppContext';
+import { LoadingScreen } from './LoadingScreen';
+
+interface AccountTypeRouteProps {
+  allowed: Array<string>;
+  children: ReactNode;
+}
+
+export const AccountTypeRoute = ({ allowed, children }: AccountTypeRouteProps) => {
+  const { profile, user, loading } = useAppContext();
+
+  const accountType = useMemo(() => {
+    if (profile?.account_type) return profile.account_type;
+    if ((user as any)?.account_type) return (user as any).account_type;
+    if (user?.user_metadata?.account_type) return user.user_metadata.account_type;
+    return null;
+  }, [profile?.account_type, user]);
+
+  if (loading) {
+    return <LoadingScreen />;
+  }
+
+  const normalizedType = typeof accountType === 'string' ? accountType.toLowerCase() : null;
+  const normalizedAllowed = allowed.map((value) => value.toLowerCase());
+
+  if (!normalizedType || !normalizedAllowed.includes(normalizedType)) {
+    return <Navigate to="/get-started" replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/lib/api/profile-onboarding.ts
+++ b/src/lib/api/profile-onboarding.ts
@@ -1,0 +1,251 @@
+import { supabaseClient } from "@/lib/supabaseClient";
+
+export type EntityType = "individual" | "firm" | "company";
+
+export interface ProfessionalProfilePayload {
+  entity_type: EntityType;
+  full_name: string;
+  organisation_name?: string | null;
+  bio?: string | null;
+  primary_expertise: string[];
+  secondary_skills?: string[];
+  years_of_experience: number;
+  current_organisation?: string | null;
+  qualifications?: string | null;
+  top_sectors: string[];
+  notable_projects?: string | null;
+  services_offered: string[];
+  expected_rates?: string | null;
+  location_city: string;
+  location_country: string;
+  phone: string;
+  email: string;
+  linkedin_url?: string | null;
+  website_url?: string | null;
+  portfolio_url?: string | null;
+  availability: "part_time" | "full_time" | "occasional";
+  notes?: string | null;
+  profile_photo_url?: string | null;
+  logo_url?: string | null;
+}
+
+export interface SmeProfilePayload {
+  business_name: string;
+  registration_number?: string | null;
+  registration_type?: string | null;
+  sector?: string | null;
+  subsector?: string | null;
+  years_in_operation?: number | null;
+  employee_count?: number | null;
+  turnover_bracket?: string | null;
+  products_overview?: string | null;
+  target_market?: string | null;
+  location_city?: string | null;
+  location_country?: string | null;
+  contact_name?: string | null;
+  contact_phone?: string | null;
+  business_email?: string | null;
+  website_url?: string | null;
+  social_links?: string[];
+  main_challenges?: string[];
+  support_needs?: string[];
+  logo_url?: string | null;
+  photos?: string[];
+}
+
+export interface InvestorProfilePayload {
+  organisation_name: string;
+  investor_type?: string | null;
+  ticket_size_min?: number | null;
+  ticket_size_max?: number | null;
+  preferred_sectors?: string[];
+  country_focus?: string[];
+  stage_preference?: string[];
+  instruments?: string[];
+  impact_focus?: string[];
+  contact_person?: string | null;
+  contact_role?: string | null;
+  website_url?: string | null;
+  linkedin_url?: string | null;
+  logo_url?: string | null;
+}
+
+const BUCKET_ID = "profile-media";
+
+async function requireUser() {
+  const {
+    data: { user },
+    error,
+  } = await supabaseClient.auth.getUser();
+
+  if (error || !user) {
+    throw new Error("You need to be signed in to continue onboarding.");
+  }
+
+  return user;
+}
+
+export async function uploadProfileMedia(
+  file: File,
+  userId: string,
+  pathPrefix: string,
+  label: string
+) {
+  if (!userId) {
+    throw new Error('User ID is required to upload profile media');
+  }
+  const extension = file.name.split(".").pop();
+  const fileName = `${label}-${Date.now()}.${extension}`;
+  const path = `${pathPrefix}/${fileName}`;
+
+  const { error: uploadError } = await supabaseClient.storage
+    .from(BUCKET_ID)
+    .upload(path, file, {
+      cacheControl: "3600",
+      upsert: true,
+    });
+
+  if (uploadError) {
+    throw new Error(uploadError.message || "Failed to upload file");
+  }
+
+  const { data: signedUrl, error: signedError } = await supabaseClient.storage
+    .from(BUCKET_ID)
+    .createSignedUrl(path, 60 * 60 * 24 * 7);
+
+  if (signedError) {
+    throw new Error(signedError.message || "Failed to prepare uploaded file preview");
+  }
+
+  return {
+    path: `${BUCKET_ID}/${path}`,
+    signedUrl: signedUrl?.signedUrl,
+  };
+}
+
+export async function getProfessionalProfile() {
+  const user = await requireUser();
+  const { data, error } = await supabaseClient
+    .from("professional_profiles")
+    .select("*")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error && error.code !== "PGRST116") {
+    throw new Error(error.message);
+  }
+
+  return data ?? null;
+}
+
+export async function upsertProfessionalProfile(payload: ProfessionalProfilePayload) {
+  const user = await requireUser();
+  const sanitizedPayload = {
+    ...payload,
+    organisation_name: payload.organisation_name || null,
+    bio: payload.bio?.trim() || null,
+    current_organisation: payload.current_organisation || null,
+    qualifications: payload.qualifications?.trim() || null,
+    notable_projects: payload.notable_projects?.trim() || null,
+    expected_rates: payload.expected_rates?.trim() || null,
+    linkedin_url: payload.linkedin_url?.trim() || null,
+    website_url: payload.website_url?.trim() || null,
+    portfolio_url: payload.portfolio_url?.trim() || null,
+    notes: payload.notes?.trim() || null,
+    profile_photo_url: payload.profile_photo_url || null,
+    logo_url: payload.logo_url || null,
+  };
+
+  const { data, error } = await supabaseClient
+    .from("professional_profiles")
+    .upsert({
+      ...sanitizedPayload,
+      user_id: user.id,
+      updated_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(error.message || "Unable to save professional profile.");
+  }
+
+  return data;
+}
+
+export async function getSmeProfile() {
+  const user = await requireUser();
+  const { data, error } = await supabaseClient
+    .from("sme_profiles")
+    .select("*")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error && error.code !== "PGRST116") {
+    throw new Error(error.message);
+  }
+
+  return data ?? null;
+}
+
+export async function upsertSmeProfile(payload: SmeProfilePayload) {
+  const user = await requireUser();
+  const { data, error } = await supabaseClient
+    .from("sme_profiles")
+    .upsert({
+      ...payload,
+      social_links: payload.social_links ?? [],
+      main_challenges: payload.main_challenges ?? [],
+      support_needs: payload.support_needs ?? [],
+      photos: payload.photos ?? [],
+      user_id: user.id,
+      updated_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(error.message || "Unable to save SME profile");
+  }
+
+  return data;
+}
+
+export async function getInvestorProfile() {
+  const user = await requireUser();
+  const { data, error } = await supabaseClient
+    .from("investor_profiles")
+    .select("*")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error && error.code !== "PGRST116") {
+    throw new Error(error.message);
+  }
+
+  return data ?? null;
+}
+
+export async function upsertInvestorProfile(payload: InvestorProfilePayload) {
+  const user = await requireUser();
+  const { data, error } = await supabaseClient
+    .from("investor_profiles")
+    .upsert({
+      ...payload,
+      preferred_sectors: payload.preferred_sectors ?? [],
+      country_focus: payload.country_focus ?? [],
+      stage_preference: payload.stage_preference ?? [],
+      instruments: payload.instruments ?? [],
+      impact_focus: payload.impact_focus ?? [],
+      user_id: user.id,
+      updated_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(error.message || "Unable to save investor profile");
+  }
+
+  return data;
+}

--- a/src/pages/GetStartedPage.tsx
+++ b/src/pages/GetStartedPage.tsx
@@ -82,10 +82,10 @@ const getStartedSchema = z
 export type GetStartedFormValues = z.infer<typeof getStartedSchema>;
 
 const accountTypeRoutes: Record<AccountType, string> = {
-  sme: '/onboarding/sme/needs-assessment',
-  professional: '/onboarding/professional/needs-assessment',
-  donor: '/onboarding/donor/needs-assessment',
-  investor: '/onboarding/investor/needs-assessment',
+  sme: '/onboarding/sme',
+  professional: '/onboarding/professional',
+  donor: '/onboarding/investor',
+  investor: '/onboarding/investor',
 };
 
 const identityFieldConfig: Record<

--- a/src/pages/ProfessionalAssessment.tsx
+++ b/src/pages/ProfessionalAssessment.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { supabase } from '@/lib/supabase-enhanced';
+import { getProfessionalProfile } from '@/lib/api/profile-onboarding';
 
 interface AssessmentData {
   assessment: any;
@@ -112,6 +113,23 @@ export const ProfessionalAssessment = () => {
       setCurrentView('results');
     }
   };
+
+  useEffect(() => {
+    if (!user) return;
+
+    const ensureProfile = async () => {
+      try {
+        const profileRecord = await getProfessionalProfile();
+        if (!profileRecord) {
+          navigate('/onboarding/professional');
+        }
+      } catch (error) {
+        console.error('Unable to verify professional profile', error);
+      }
+    };
+
+    void ensureProfile();
+  }, [navigate, user]);
 
   const handleContactProfessional = (professionalId: string) => {
     // Navigate to messaging or contact functionality

--- a/src/pages/__tests__/GetStartedPage.test.tsx
+++ b/src/pages/__tests__/GetStartedPage.test.tsx
@@ -98,7 +98,7 @@ describe('GetStartedPage', () => {
         full_name: 'Ama Mensah Consulting',
         business_name: 'Ama Mensah Consulting',
       },
-      expectedRoute: '/onboarding/professional/needs-assessment',
+      expectedRoute: '/onboarding/professional',
     },
     {
       accountType: /donor/i,
@@ -111,7 +111,7 @@ describe('GetStartedPage', () => {
         business_name: 'Impact Builders Foundation',
         full_name: 'Impact Builders Foundation',
       },
-      expectedRoute: '/onboarding/donor/needs-assessment',
+      expectedRoute: '/onboarding/investor',
     },
     {
       accountType: /investor/i,
@@ -124,7 +124,7 @@ describe('GetStartedPage', () => {
         business_name: 'Growth Catalyst Partners',
         full_name: 'Growth Catalyst Partners',
       },
-      expectedRoute: '/onboarding/investor/needs-assessment',
+      expectedRoute: '/onboarding/investor',
     },
     {
       accountType: /sme/i,
@@ -136,7 +136,7 @@ describe('GetStartedPage', () => {
         msisdn: '+233301122334',
         business_name: 'BrightFuture Enterprises',
       },
-      expectedRoute: '/onboarding/sme/needs-assessment',
+      expectedRoute: '/onboarding/sme',
     },
   ])('submits profile details for $accountType accounts', async ({
     accountType,

--- a/src/pages/onboarding/InvestorOnboardingPage.tsx
+++ b/src/pages/onboarding/InvestorOnboardingPage.tsx
@@ -1,0 +1,390 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { useAppContext } from '@/contexts/AppContext';
+import { getInvestorProfile, upsertInvestorProfile, uploadProfileMedia } from '@/lib/api/profile-onboarding';
+import { ArrowLeft, Loader2, Upload, Check } from 'lucide-react';
+import { supabaseClient } from '@/lib/supabaseClient';
+
+const investorTypes = ['Angel', 'VC', 'Bank', 'Donor', 'Foundation', 'Development Finance'];
+const sectors = ['Agriculture', 'Retail', 'Manufacturing', 'Tech & Digital', 'Healthcare', 'Education', 'Logistics'];
+const stages = ['Startup', 'Growth', 'Mature'];
+const instruments = ['Equity', 'Debt', 'Grant', 'Revenue Share', 'Convertible'];
+const impactFocus = ['Gender', 'Climate', 'Youth', 'SME Inclusion', 'Rural Impact'];
+
+const investorSchema = z.object({
+  organisation_name: z.string().min(2, 'Organisation name is required'),
+  investor_type: z.string().optional(),
+  ticket_size_min: z.number().int().min(0).optional(),
+  ticket_size_max: z.number().int().min(0).optional(),
+  preferred_sectors: z.array(z.string()).optional(),
+  country_focus: z.array(z.string()).optional(),
+  stage_preference: z.array(z.string()).optional(),
+  instruments: z.array(z.string()).optional(),
+  impact_focus: z.array(z.string()).optional(),
+  contact_person: z.string().min(1, 'Contact person is required'),
+  contact_role: z.string().optional(),
+  website_url: z.string().url('Enter a valid URL').optional().or(z.literal('')).transform((val) => val || undefined),
+  linkedin_url: z.string().url('Enter a valid URL').optional().or(z.literal('')).transform((val) => val || undefined),
+  logo_url: z.string().optional(),
+});
+
+type InvestorFormValues = z.infer<typeof investorSchema>;
+
+export const InvestorOnboardingPage = () => {
+  const { user } = useAppContext();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [initializing, setInitializing] = useState(true);
+  const [logoPreview, setLogoPreview] = useState<string | undefined>();
+
+  const form = useForm<InvestorFormValues>({
+    resolver: zodResolver(investorSchema),
+    defaultValues: {
+      organisation_name: '',
+      investor_type: '',
+      ticket_size_min: undefined,
+      ticket_size_max: undefined,
+      preferred_sectors: [],
+      country_focus: [],
+      stage_preference: [],
+      instruments: [],
+      impact_focus: [],
+      contact_person: '',
+      contact_role: '',
+      website_url: '',
+      linkedin_url: '',
+      logo_url: '',
+    },
+  });
+
+  const { register, setValue, watch, handleSubmit, reset, formState } = form;
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      try {
+        const existing = await getInvestorProfile();
+        if (existing) {
+          reset({
+            organisation_name: existing.organisation_name,
+            investor_type: existing.investor_type || '',
+            ticket_size_min: existing.ticket_size_min ?? undefined,
+            ticket_size_max: existing.ticket_size_max ?? undefined,
+            preferred_sectors: existing.preferred_sectors || [],
+            country_focus: existing.country_focus || [],
+            stage_preference: existing.stage_preference || [],
+            instruments: existing.instruments || [],
+            impact_focus: existing.impact_focus || [],
+            contact_person: existing.contact_person || '',
+            contact_role: existing.contact_role || '',
+            website_url: existing.website_url || '',
+            linkedin_url: existing.linkedin_url || '',
+            logo_url: existing.logo_url || '',
+          });
+
+          if (existing.logo_url) {
+            const signed = await createSignedPreview(existing.logo_url);
+            setLogoPreview(signed || undefined);
+          }
+        }
+      } catch (error: any) {
+        toast({ title: 'Unable to load investor profile', description: error.message, variant: 'destructive' });
+      } finally {
+        setInitializing(false);
+      }
+    };
+
+    loadProfile();
+  }, [reset, toast]);
+
+  const createSignedPreview = async (storedPath: string) => {
+    const cleanedPath = storedPath.replace(/^profile-media\//, '');
+    const { data } = await supabaseClient.storage
+      .from('profile-media')
+      .createSignedUrl(cleanedPath, 60 * 60 * 24);
+    return data?.signedUrl;
+  };
+
+  const toggleArrayValue = (
+    field: 'preferred_sectors' | 'country_focus' | 'stage_preference' | 'instruments' | 'impact_focus',
+    value: string
+  ) => {
+    const current = (watch(field) || []) as string[];
+    const next = current.includes(value) ? current.filter((item) => item !== value) : [...current, value];
+    setValue(field, next, { shouldValidate: true });
+  };
+
+  const handleLogoUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file || !user?.id) return;
+
+    try {
+      const { path, signedUrl } = await uploadProfileMedia(
+        file,
+        user.id,
+        `profiles/investors/${user.id}`,
+        'logo'
+      );
+      setValue('logo_url', path, { shouldValidate: true });
+      setLogoPreview(signedUrl || path);
+      toast({ title: 'Logo uploaded' });
+    } catch (error: any) {
+      toast({ title: 'Upload failed', description: error.message, variant: 'destructive' });
+    }
+  };
+
+  const onSubmit = async (data: InvestorFormValues, stayOnPage?: boolean) => {
+    setLoading(true);
+    try {
+      await upsertInvestorProfile(data);
+      toast({ title: 'Profile saved', description: 'Your investment preferences have been updated.' });
+      if (!stayOnPage) {
+        navigate('/onboarding/investor/needs-assessment');
+      }
+    } catch (error: any) {
+      toast({ title: 'Save failed', description: error.message, variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (initializing) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <Loader2 className="h-5 w-5 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-green-50 py-10">
+      <div className="max-w-4xl mx-auto px-4">
+        <Button variant="ghost" className="mb-4" onClick={() => navigate(-1)}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Complete your Investor/Donor Profile</h1>
+          <p className="text-gray-700">Tell us about your mandate so we can match you with the right opportunities.</p>
+        </div>
+
+        <form onSubmit={handleSubmit((values) => onSubmit(values, false))} className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Organisation details</CardTitle>
+              <CardDescription>Basic profile and ticket sizes</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="organisation_name">Organisation / Fund Name</Label>
+                  <Input id="organisation_name" {...register('organisation_name')} />
+                  {formState.errors.organisation_name && (
+                    <p className="text-sm text-red-600 mt-1">{formState.errors.organisation_name.message}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="investor_type">Investor Type</Label>
+                  <Input id="investor_type" list="investor-types" {...register('investor_type')} />
+                  <datalist id="investor-types">
+                    {investorTypes.map((type) => (
+                      <option key={type} value={type} />
+                    ))}
+                  </datalist>
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="ticket_size_min">Ticket Size Range (Min)</Label>
+                  <Input
+                    id="ticket_size_min"
+                    type="number"
+                    min={0}
+                    {...register('ticket_size_min', {
+                      setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                    })}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="ticket_size_max">Ticket Size Range (Max)</Label>
+                  <Input
+                    id="ticket_size_max"
+                    type="number"
+                    min={0}
+                    {...register('ticket_size_max', {
+                      setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                    })}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <Label>Preferred Sectors</Label>
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {sectors.map((sector) => {
+                    const selected = (watch('preferred_sectors') || []).includes(sector);
+                    return (
+                      <Badge
+                        key={sector}
+                        variant={selected ? 'default' : 'outline'}
+                        className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                        onClick={() => toggleArrayValue('preferred_sectors', sector)}
+                      >
+                        {selected && <Check className="h-3 w-3 mr-1" />} {sector}
+                      </Badge>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label>Country/Region Focus</Label>
+                  <Input
+                    placeholder="Add countries separated by commas"
+                    value={(watch('country_focus') || []).join(', ')}
+                    onChange={(e) =>
+                      setValue(
+                        'country_focus',
+                        e.target.value
+                          .split(',')
+                          .map((item) => item.trim())
+                          .filter(Boolean),
+                        { shouldValidate: true }
+                      )
+                    }
+                  />
+                </div>
+                <div>
+                  <Label>Stage Preference</Label>
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {stages.map((stage) => {
+                      const selected = (watch('stage_preference') || []).includes(stage);
+                      return (
+                        <Badge
+                          key={stage}
+                          variant={selected ? 'default' : 'outline'}
+                          className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                          onClick={() => toggleArrayValue('stage_preference', stage)}
+                        >
+                          {selected && <Check className="h-3 w-3 mr-1" />} {stage}
+                        </Badge>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label>Instruments</Label>
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {instruments.map((instrument) => {
+                      const selected = (watch('instruments') || []).includes(instrument);
+                      return (
+                        <Badge
+                          key={instrument}
+                          variant={selected ? 'default' : 'outline'}
+                          className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                          onClick={() => toggleArrayValue('instruments', instrument)}
+                        >
+                          {selected && <Check className="h-3 w-3 mr-1" />} {instrument}
+                        </Badge>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div>
+                  <Label>Impact Focus</Label>
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {impactFocus.map((impact) => {
+                      const selected = (watch('impact_focus') || []).includes(impact);
+                      return (
+                        <Badge
+                          key={impact}
+                          variant={selected ? 'default' : 'outline'}
+                          className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                          onClick={() => toggleArrayValue('impact_focus', impact)}
+                        >
+                          {selected && <Check className="h-3 w-3 mr-1" />} {impact}
+                        </Badge>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="contact_person">Contact Person & Role</Label>
+                  <Input id="contact_person" placeholder="Name" {...register('contact_person')} />
+                  {formState.errors.contact_person && (
+                    <p className="text-sm text-red-600 mt-1">{formState.errors.contact_person.message}</p>
+                  )}
+                  <Input id="contact_role" placeholder="Role" className="mt-2" {...register('contact_role')} />
+                </div>
+                <div>
+                  <Label htmlFor="website_url">Website & LinkedIn</Label>
+                  <Input id="website_url" placeholder="Website" {...register('website_url')} />
+                  <Input id="linkedin_url" placeholder="LinkedIn" className="mt-2" {...register('linkedin_url')} />
+                  {(formState.errors.website_url || formState.errors.linkedin_url) && (
+                    <p className="text-sm text-red-600 mt-1">
+                      {formState.errors.website_url?.message || formState.errors.linkedin_url?.message}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div>
+                <Label htmlFor="logo_upload">Upload logo (optional)</Label>
+                <div className="flex items-center gap-3">
+                  <Button type="button" variant="outline" asChild>
+                    <label htmlFor="logo_upload" className="cursor-pointer flex items-center gap-2">
+                      <Upload className="h-4 w-4" />
+                      {logoPreview ? 'Change logo' : 'Upload logo'}
+                    </label>
+                  </Button>
+                  {logoPreview && <img src={logoPreview} alt="Logo preview" className="h-12 w-12 rounded border object-cover" />}
+                </div>
+                <Input
+                  id="logo_upload"
+                  type="file"
+                  accept=".jpg,.jpeg,.png"
+                  className="hidden"
+                  onChange={handleLogoUpload}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex gap-3 justify-end">
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={loading}
+              onClick={handleSubmit((values) => onSubmit(values, true))}
+            >
+              {loading ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : 'Save & Continue Later'}
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : 'Save and continue'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default InvestorOnboardingPage;

--- a/src/pages/onboarding/ProfessionalNeedsAssessmentPage.tsx
+++ b/src/pages/onboarding/ProfessionalNeedsAssessmentPage.tsx
@@ -13,6 +13,7 @@ import { Progress } from '@/components/ui/progress';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { upsertProfile, saveProfessionalNeedsAssessment } from '@/lib/onboarding';
+import { getProfessionalProfile } from '@/lib/api/profile-onboarding';
 import { ArrowLeft, ArrowRight, CheckCircle } from 'lucide-react';
 
 const professionalAssessmentSchema = z.object({
@@ -52,6 +53,19 @@ export const ProfessionalNeedsAssessmentPage = () => {
     if (!user) {
       navigate('/signin');
     }
+  }, [user, navigate]);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const checkProfile = async () => {
+      const profileRecord = await getProfessionalProfile();
+      if (!profileRecord) {
+        navigate('/onboarding/professional');
+      }
+    };
+
+    void checkProfile();
   }, [user, navigate]);
 
   const totalSteps = 3;

--- a/src/pages/onboarding/ProfessionalOnboardingPage.tsx
+++ b/src/pages/onboarding/ProfessionalOnboardingPage.tsx
@@ -1,0 +1,787 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { useAppContext } from '@/contexts/AppContext';
+import {
+  getProfessionalProfile,
+  upsertProfessionalProfile,
+  uploadProfileMedia,
+} from '@/lib/api/profile-onboarding';
+import { supabaseClient } from '@/lib/supabaseClient';
+import { ArrowLeft, ArrowRight, Check, Loader2, Upload } from 'lucide-react';
+
+const primaryExpertiseOptions = [
+  'Financial Modelling',
+  'Grants & Proposal Writing',
+  'Legal & Compliance',
+  'Marketing Strategy',
+  'HR & Organisation Design',
+  'Digital Transformation',
+  'Tax & Compliance Advisory',
+  'Investment Readiness Coaching',
+  'Business Strategy',
+  'Operational Excellence',
+];
+
+const sectorOptions = [
+  'Agriculture',
+  'Retail',
+  'Manufacturing',
+  'Tech & Digital',
+  'Logistics',
+  'Hospitality',
+  'Healthcare',
+  'Education',
+];
+
+const servicesOptions = [
+  'Business Strategy',
+  'Financial Modelling & Projections',
+  'Grant/Proposal Writing',
+  'Investment Readiness Coaching',
+  'Tax & Compliance Advisory',
+  'HR & Organisation Design',
+  'Marketing & Branding',
+  'Digital Systems / ERP Setup',
+  'Legal Documentation',
+];
+
+const yearsOptions = [
+  { label: '0-2 years', value: 2 },
+  { label: '3-5 years', value: 5 },
+  { label: '6-10 years', value: 10 },
+  { label: '11-15 years', value: 15 },
+  { label: '16+ years', value: 16 },
+];
+
+const availabilityOptions = [
+  { value: 'part_time', label: 'Part-time' },
+  { value: 'full_time', label: 'Full-time' },
+  { value: 'occasional', label: 'Occasional' },
+];
+
+const professionalSchema = z
+  .object({
+    entity_type: z.enum(['individual', 'firm', 'company']),
+    full_name: z.string().min(2, 'Full name is required'),
+    organisation_name: z.string().optional(),
+    bio: z
+      .string()
+      .min(1, 'Professional bio is required')
+      .refine((val) => {
+        const words = val.trim().split(/\s+/).filter(Boolean).length;
+        return words >= 100 && words <= 250;
+      }, 'Bio should be between 100 and 250 words'),
+    primary_expertise: z.array(z.string()).min(3, 'Select at least 3 primary areas').max(5, 'Choose up to 5 areas'),
+    secondary_skills: z.array(z.string()).optional(),
+    years_of_experience: z.number().min(0, 'Years of experience is required'),
+    current_organisation: z.string().optional(),
+    qualifications: z.string().optional(),
+    top_sectors: z.array(z.string()).min(1, 'Choose at least one sector').max(3, 'Choose up to 3 sectors'),
+    notable_projects: z.string().optional(),
+    services_offered: z.array(z.string()).min(1, 'Select at least one service you offer'),
+    other_services: z.string().optional(),
+    expected_rates: z.string().optional(),
+    location_city: z.string().min(1, 'City is required'),
+    location_country: z.string().min(1, 'Country is required'),
+    phone: z.string().min(4, 'Phone number is required'),
+    email: z.string().email('Provide a valid email'),
+    linkedin_url: z.string().url('Enter a valid URL').optional().or(z.literal('')).transform((val) => val || undefined),
+    website_url: z.string().url('Enter a valid URL').optional().or(z.literal('')).transform((val) => val || undefined),
+    portfolio_url: z.string().url('Enter a valid URL').optional().or(z.literal('')).transform((val) => val || undefined),
+    availability: z.enum(['part_time', 'full_time', 'occasional']),
+    notes: z.string().optional(),
+    profile_photo_url: z.string().optional(),
+    logo_url: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.entity_type !== 'individual' && !data.organisation_name?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['organisation_name'],
+        message: 'Please provide the firm or company name.',
+      });
+    }
+  });
+
+const wordCount = (text?: string) => text?.trim().split(/\s+/).filter(Boolean).length ?? 0;
+
+type ProfessionalFormValues = z.infer<typeof professionalSchema>;
+
+export const ProfessionalOnboardingPage = () => {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { user, profile } = useAppContext();
+
+  const [currentStep, setCurrentStep] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [initializing, setInitializing] = useState(true);
+  const [photoPreview, setPhotoPreview] = useState<string | undefined>();
+  const [logoPreview, setLogoPreview] = useState<string | undefined>();
+
+  const form = useForm<ProfessionalFormValues>({
+    resolver: zodResolver(professionalSchema),
+    defaultValues: {
+      entity_type: 'individual',
+      full_name: profile?.full_name ?? '',
+      organisation_name: '',
+      bio: '',
+      primary_expertise: [],
+      secondary_skills: [],
+      years_of_experience: 2,
+      current_organisation: '',
+      qualifications: '',
+      top_sectors: [],
+      notable_projects: '',
+      services_offered: [],
+      other_services: '',
+      expected_rates: '',
+      location_city: '',
+      location_country: 'Zambia',
+      phone: profile?.phone ?? '',
+      email: user?.email ?? '',
+      linkedin_url: '',
+      website_url: '',
+      portfolio_url: '',
+      availability: 'part_time',
+      notes: '',
+      profile_photo_url: '',
+      logo_url: '',
+    },
+    mode: 'onChange',
+  });
+
+  const { watch, setValue, handleSubmit, reset, trigger, formState } = form;
+
+  const watchedEntityType = watch('entity_type');
+  const watchedBio = watch('bio');
+
+  const expertiseSelection = watch('primary_expertise') || [];
+  const secondarySelection = watch('secondary_skills') || [];
+  const sectorSelection = watch('top_sectors') || [];
+  const servicesSelection = watch('services_offered') || [];
+
+  const totalSteps = 4;
+  const progress = useMemo(() => Math.round((currentStep / totalSteps) * 100), [currentStep]);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      try {
+        const existing = await getProfessionalProfile();
+        if (existing) {
+          reset({
+            entity_type: (existing.entity_type as ProfessionalFormValues['entity_type']) || 'individual',
+            full_name: existing.full_name || '',
+            organisation_name: existing.organisation_name || '',
+            bio: existing.bio || '',
+            primary_expertise: existing.primary_expertise || [],
+            secondary_skills: existing.secondary_skills || [],
+            years_of_experience: existing.years_of_experience ?? 2,
+            current_organisation: existing.current_organisation || '',
+            qualifications: existing.qualifications || '',
+            top_sectors: existing.top_sectors || [],
+            notable_projects: existing.notable_projects || '',
+            services_offered: existing.services_offered || [],
+            other_services: '',
+            expected_rates: existing.expected_rates || '',
+            location_city: existing.location_city || '',
+            location_country: existing.location_country || 'Zambia',
+            phone: existing.phone || profile?.phone || '',
+            email: existing.email || user?.email || '',
+            linkedin_url: existing.linkedin_url || '',
+            website_url: existing.website_url || '',
+            portfolio_url: existing.portfolio_url || '',
+            availability: (existing.availability as ProfessionalFormValues['availability']) || 'part_time',
+            notes: existing.notes || '',
+            profile_photo_url: existing.profile_photo_url || '',
+            logo_url: existing.logo_url || '',
+          });
+
+          if (existing.profile_photo_url) {
+            const signed = await createSignedPreview(existing.profile_photo_url);
+            setPhotoPreview(signed || undefined);
+          }
+          if (existing.logo_url) {
+            const signed = await createSignedPreview(existing.logo_url);
+            setLogoPreview(signed || undefined);
+          }
+        }
+      } catch (error: any) {
+        console.error('Failed to load professional profile', error);
+        toast({
+          title: 'Unable to load profile',
+          description: error.message || 'Please try again shortly.',
+          variant: 'destructive',
+        });
+      } finally {
+        setInitializing(false);
+      }
+    };
+
+    loadProfile();
+  }, [profile?.phone, reset, toast, user?.email]);
+
+  const createSignedPreview = async (storedPath: string) => {
+    const cleanedPath = storedPath.replace(/^profile-media\//, '');
+    const { data, error } = await supabaseClient.storage
+      .from('profile-media')
+      .createSignedUrl(cleanedPath, 60 * 60 * 24);
+    if (error) {
+      return null;
+    }
+    return data?.signedUrl ?? null;
+  };
+
+  const toggleValue = (
+    field: 'primary_expertise' | 'secondary_skills' | 'top_sectors' | 'services_offered',
+    value: string,
+    max?: number
+  ) => {
+    const current = (watch(field) || []) as string[];
+    const exists = current.includes(value);
+    let next = exists ? current.filter((item) => item !== value) : [...current, value];
+
+    if (!exists && max && next.length > max) {
+      toast({
+        title: 'Selection limit reached',
+        description: `You can select up to ${max} options here.`,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setValue(field, next, { shouldValidate: true });
+  };
+
+  const handleUpload = async (event: React.ChangeEvent<HTMLInputElement>, type: 'photo' | 'logo') => {
+    const file = event.target.files?.[0];
+    if (!file || !user?.id) return;
+
+    try {
+      const label = type === 'photo' ? 'profile-photo' : 'logo';
+      const { path, signedUrl } = await uploadProfileMedia(
+        file,
+        user.id,
+        `profiles/professionals/${user.id}`,
+        label
+      );
+
+      if (type === 'photo') {
+        setValue('profile_photo_url', path, { shouldValidate: true });
+        setPhotoPreview(signedUrl || path);
+      } else {
+        setValue('logo_url', path, { shouldValidate: true });
+        setLogoPreview(signedUrl || path);
+      }
+
+      toast({
+        title: 'Upload successful',
+        description: 'Your media has been uploaded securely.',
+      });
+    } catch (error: any) {
+      toast({
+        title: 'Upload failed',
+        description: error.message || 'Please try again.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleNext = async () => {
+    const stepFields: Record<number, Array<keyof ProfessionalFormValues>> = {
+      1: ['entity_type', 'full_name', 'organisation_name', 'bio'],
+      2: ['primary_expertise', 'top_sectors', 'years_of_experience'],
+      3: ['services_offered', 'location_city', 'location_country', 'phone', 'email'],
+      4: ['availability'],
+    };
+    const fieldsToValidate = stepFields[currentStep] || [];
+    const isValid = await trigger(fieldsToValidate as any);
+    if (isValid && currentStep < totalSteps) {
+      setCurrentStep((prev) => prev + 1);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
+
+  const handleBack = () => {
+    if (currentStep > 1) {
+      setCurrentStep((prev) => prev - 1);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
+
+  const saveProfile = async (data: ProfessionalFormValues, stayOnPage?: boolean) => {
+    setLoading(true);
+    try {
+      const services = data.other_services?.trim()
+        ? [...data.services_offered, data.other_services.trim()]
+        : data.services_offered;
+
+      await upsertProfessionalProfile({
+        ...data,
+        services_offered: services,
+        organisation_name: data.entity_type === 'individual' ? data.organisation_name || null : data.organisation_name || data.full_name,
+        current_organisation: data.entity_type === 'individual' ? data.current_organisation || null : data.current_organisation || data.organisation_name || null,
+      });
+
+      toast({
+        title: 'Your professional profile has been saved.',
+        description: 'SMEs will soon be able to discover and work with you.',
+      });
+
+      if (!stayOnPage) {
+        navigate('/professional-assessment?view=results');
+      }
+    } catch (error: any) {
+      toast({
+        title: 'Unable to save profile',
+        description: error.message || 'Please check your details and try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = handleSubmit((data) => saveProfile(data, false));
+  const handleSaveForLater = handleSubmit((data) => saveProfile(data, true));
+
+  const bioWords = useMemo(() => wordCount(watchedBio), [watchedBio]);
+
+  const entityOrganisationLabel =
+    watchedEntityType === 'individual' ? 'Current Organisation (optional)' : 'Firm / Company Name';
+
+  if (initializing) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" aria-label="Loading profile" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-green-50 py-10">
+      <div className="max-w-5xl mx-auto px-4">
+        <Button variant="ghost" className="mb-4" onClick={() => navigate(-1)}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Complete your Professional Profile</h1>
+          <p className="text-gray-700">
+            This helps SMEs and partners understand your expertise and how to work with you.
+          </p>
+        </div>
+
+        <div className="mb-6 space-y-2">
+          <Progress value={progress} />
+          <p className="text-sm text-gray-600">Step {currentStep} of {totalSteps}</p>
+        </div>
+
+        <form onSubmit={handleSave} className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                {currentStep === 1 && 'Basic information'}
+                {currentStep === 2 && 'Expertise & sectors'}
+                {currentStep === 3 && 'Services, rates & location'}
+                {currentStep === 4 && 'Links, availability & branding'}
+              </CardTitle>
+              <CardDescription>
+                {currentStep === 1 && 'Tell us who you are and how to present your profile.'}
+                {currentStep === 2 && 'Highlight the areas you excel in.'}
+                {currentStep === 3 && 'Describe what you offer and where you work from.'}
+                {currentStep === 4 && 'Share your availability and public links.'}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              {currentStep === 1 && (
+                <div className="space-y-4">
+                  <div>
+                    <Label className="mb-2 block">What type of professional entity are you?</Label>
+                    <RadioGroup
+                      value={watchedEntityType}
+                      onValueChange={(value) => setValue('entity_type', value as ProfessionalFormValues['entity_type'], { shouldValidate: true })}
+                      className="grid grid-cols-1 gap-3 sm:grid-cols-3"
+                    >
+                      {['individual', 'firm', 'company'].map((option) => (
+                        <Label
+                          key={option}
+                          className={`border rounded-lg px-4 py-3 cursor-pointer flex items-center gap-3 ${watchedEntityType === option ? 'border-primary bg-orange-50' : ''}`}
+                        >
+                          <RadioGroupItem value={option} />
+                          <span className="capitalize">{option}</span>
+                        </Label>
+                      ))}
+                    </RadioGroup>
+                  </div>
+
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="full_name">Full Name</Label>
+                      <Input id="full_name" placeholder="e.g. Thandiwe Phiri" {...form.register('full_name')} />
+                      {formState.errors.full_name && (
+                        <p className="text-sm text-red-600 mt-1">{formState.errors.full_name.message}</p>
+                      )}
+                    </div>
+                    <div>
+                      <Label htmlFor="organisation_name">{entityOrganisationLabel}</Label>
+                      <Input id="organisation_name" placeholder="e.g. Ama Mensah Consulting" {...form.register('organisation_name')} />
+                      {formState.errors.organisation_name && (
+                        <p className="text-sm text-red-600 mt-1">{formState.errors.organisation_name.message}</p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div>
+                    <div className="flex items-center justify-between">
+                      <Label htmlFor="bio">Professional Bio (100–200 words)</Label>
+                      <span className="text-xs text-gray-500">{bioWords} words</span>
+                    </div>
+                    <Textarea
+                      id="bio"
+                      rows={6}
+                      placeholder="Summarise who you are, your experience, and the type of work you do with SMEs (100–200 words)."
+                      {...form.register('bio')}
+                    />
+                    {formState.errors.bio && <p className="text-sm text-red-600 mt-1">{formState.errors.bio.message as string}</p>}
+                  </div>
+
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="profile_photo">Upload Photo (Profile Picture)</Label>
+                      <div className="flex items-center gap-3">
+                        <Button type="button" variant="outline" className="flex items-center gap-2" asChild>
+                          <label htmlFor="profile_photo_input" className="cursor-pointer flex items-center gap-2">
+                            <Upload className="h-4 w-4" />
+                            {photoPreview ? 'Change photo' : 'Upload photo'}
+                          </label>
+                        </Button>
+                        {photoPreview && <img src={photoPreview} alt="Profile preview" className="h-12 w-12 rounded-full object-cover" />}
+                      </div>
+                      <Input
+                        id="profile_photo_input"
+                        type="file"
+                        accept=".jpg,.jpeg,.png"
+                        className="hidden"
+                        onChange={(e) => handleUpload(e, 'photo')}
+                      />
+                    </div>
+                    {watchedEntityType !== 'individual' && (
+                      <div>
+                        <Label htmlFor="logo_upload">Upload Logo</Label>
+                        <div className="flex items-center gap-3">
+                          <Button type="button" variant="outline" className="flex items-center gap-2" asChild>
+                            <label htmlFor="logo_upload_input" className="cursor-pointer flex items-center gap-2">
+                              <Upload className="h-4 w-4" />
+                              {logoPreview ? 'Change logo' : 'Upload logo'}
+                            </label>
+                          </Button>
+                          {logoPreview && <img src={logoPreview} alt="Logo preview" className="h-12 w-12 rounded object-cover border" />}
+                        </div>
+                        <Input
+                          id="logo_upload_input"
+                          type="file"
+                          accept=".jpg,.jpeg,.png"
+                          className="hidden"
+                          onChange={(e) => handleUpload(e, 'logo')}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {currentStep === 2 && (
+                <div className="space-y-4">
+                  <div>
+                    <Label>Primary Expertise Areas (3–5)</Label>
+                    <p className="text-sm text-gray-500 mb-2">Select your strongest areas.</p>
+                    <div className="flex flex-wrap gap-2">
+                      {primaryExpertiseOptions.map((option) => {
+                        const selected = expertiseSelection.includes(option);
+                        return (
+                          <Badge
+                            key={option}
+                            variant={selected ? 'default' : 'outline'}
+                            className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                            onClick={() => toggleValue('primary_expertise', option, 5)}
+                          >
+                            {selected && <Check className="h-3 w-3 mr-1" />} {option}
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                    {formState.errors.primary_expertise && (
+                      <p className="text-sm text-red-600 mt-1">{formState.errors.primary_expertise.message as string}</p>
+                    )}
+                  </div>
+
+                  <div>
+                    <Label>Secondary Skills (optional)</Label>
+                    <div className="flex flex-wrap gap-2">
+                      {primaryExpertiseOptions.map((option) => {
+                        const selected = secondarySelection.includes(option);
+                        return (
+                          <Badge
+                            key={option}
+                            variant={selected ? 'default' : 'outline'}
+                            className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                            onClick={() => toggleValue('secondary_skills', option)}
+                          >
+                            {selected && <Check className="h-3 w-3 mr-1" />} {option}
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="years_of_experience">Years of Experience</Label>
+                      <Select
+                        value={String(watch('years_of_experience'))}
+                        onValueChange={(value) => setValue('years_of_experience', Number(value), { shouldValidate: true })}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select range" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {yearsOptions.map((opt) => (
+                            <SelectItem key={opt.value} value={String(opt.value)}>
+                              {opt.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      {formState.errors.years_of_experience && (
+                        <p className="text-sm text-red-600 mt-1">{formState.errors.years_of_experience.message}</p>
+                      )}
+                    </div>
+                    <div>
+                      <Label>Top 3 Sectors Served</Label>
+                      <div className="flex flex-wrap gap-2 mt-2">
+                        {sectorOptions.map((sector) => {
+                          const selected = sectorSelection.includes(sector);
+                          return (
+                            <Badge
+                              key={sector}
+                              variant={selected ? 'default' : 'outline'}
+                              className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                              onClick={() => toggleValue('top_sectors', sector, 3)}
+                            >
+                              {selected && <Check className="h-3 w-3 mr-1" />} {sector}
+                            </Badge>
+                          );
+                        })}
+                      </div>
+                      {formState.errors.top_sectors && (
+                        <p className="text-sm text-red-600 mt-1">{formState.errors.top_sectors.message as string}</p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="qualifications">Professional Qualifications / Certifications</Label>
+                    <Textarea
+                      id="qualifications"
+                      rows={3}
+                      placeholder="e.g. ACCA, MBA, PMP"
+                      {...form.register('qualifications')}
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="current_organisation">Current Organisation (if applicable)</Label>
+                    <Input
+                      id="current_organisation"
+                      placeholder="Employer or brand name"
+                      {...form.register('current_organisation')}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {currentStep === 3 && (
+                <div className="space-y-4">
+                  <div>
+                    <Label>Services You Can Offer to SMEs</Label>
+                    <div className="flex flex-wrap gap-2 mt-2">
+                      {servicesOptions.map((service) => {
+                        const selected = servicesSelection.includes(service);
+                        return (
+                          <Badge
+                            key={service}
+                            variant={selected ? 'default' : 'outline'}
+                            className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                            onClick={() => toggleValue('services_offered', service)}
+                          >
+                            {selected && <Check className="h-3 w-3 mr-1" />} {service}
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                    {formState.errors.services_offered && (
+                      <p className="text-sm text-red-600 mt-1">{formState.errors.services_offered.message as string}</p>
+                    )}
+                  </div>
+
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="other_services">Other services (optional)</Label>
+                      <Input
+                        id="other_services"
+                        placeholder="Add any additional services"
+                        {...form.register('other_services')}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="expected_rates">Expected Hourly/Project Rates (optional)</Label>
+                      <Input id="expected_rates" placeholder="e.g. ZMW 500/hr" {...form.register('expected_rates')} />
+                    </div>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="notable_projects">Notable Achievements / Projects</Label>
+                    <Textarea
+                      id="notable_projects"
+                      rows={4}
+                      placeholder="Mention 2–3 key achievements or projects (e.g. helped an SME secure ZMW X in funding)"
+                      {...form.register('notable_projects')}
+                    />
+                  </div>
+
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="location_city">Location (City)</Label>
+                      <Input id="location_city" placeholder="e.g. Lusaka" {...form.register('location_city')} />
+                      {formState.errors.location_city && (
+                        <p className="text-sm text-red-600 mt-1">{formState.errors.location_city.message}</p>
+                      )}
+                    </div>
+                    <div>
+                      <Label htmlFor="location_country">Location (Country)</Label>
+                      <Input id="location_country" placeholder="Zambia" {...form.register('location_country')} />
+                      {formState.errors.location_country && (
+                        <p className="text-sm text-red-600 mt-1">{formState.errors.location_country.message}</p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="phone">Phone Number</Label>
+                      <Input id="phone" placeholder="e.g. +260..." {...form.register('phone')} />
+                      {formState.errors.phone && <p className="text-sm text-red-600 mt-1">{formState.errors.phone.message}</p>}
+                    </div>
+                    <div>
+                      <Label htmlFor="email">Email Address</Label>
+                      <Input id="email" type="email" {...form.register('email')} />
+                      {formState.errors.email && <p className="text-sm text-red-600 mt-1">{formState.errors.email.message}</p>}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {currentStep === 4 && (
+                <div className="space-y-4">
+                  <div>
+                    <Label>Availability</Label>
+                    <Select
+                      value={watch('availability')}
+                      onValueChange={(value) => setValue('availability', value as ProfessionalFormValues['availability'], { shouldValidate: true })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select availability" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {availabilityOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {formState.errors.availability && (
+                      <p className="text-sm text-red-600 mt-1">{formState.errors.availability.message}</p>
+                    )}
+                  </div>
+
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="linkedin_url">LinkedIn URL</Label>
+                      <Input id="linkedin_url" placeholder="https://linkedin.com/in/username" {...form.register('linkedin_url')} />
+                      {formState.errors.linkedin_url && (
+                        <p className="text-sm text-red-600 mt-1">{formState.errors.linkedin_url.message as string}</p>
+                      )}
+                    </div>
+                    <div>
+                      <Label htmlFor="website_url">Website URL</Label>
+                      <Input id="website_url" placeholder="https://" {...form.register('website_url')} />
+                      {formState.errors.website_url && (
+                        <p className="text-sm text-red-600 mt-1">{formState.errors.website_url.message as string}</p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="portfolio_url">Portfolio URL</Label>
+                      <Input id="portfolio_url" placeholder="https://" {...form.register('portfolio_url')} />
+                      {formState.errors.portfolio_url && (
+                        <p className="text-sm text-red-600 mt-1">{formState.errors.portfolio_url.message as string}</p>
+                      )}
+                    </div>
+                    <div>
+                      <Label htmlFor="notes">Any Additional Notes</Label>
+                      <Textarea id="notes" rows={3} placeholder="Preferences or SME types you enjoy working with" {...form.register('notes')} />
+                    </div>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+            <div className="flex items-center justify-between">
+              <div>
+                {currentStep > 1 && (
+                  <Button type="button" variant="outline" onClick={handleBack}>
+                    <ArrowLeft className="h-4 w-4 mr-2" /> Previous
+                  </Button>
+                )}
+              </div>
+              <div className="flex gap-3">
+                <Button type="button" variant="secondary" disabled={loading} onClick={handleSaveForLater}>
+                  {loading ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : 'Save & Continue Later'}
+                </Button>
+                {currentStep < totalSteps && (
+                  <Button type="button" onClick={handleNext}>
+                    Next <ArrowRight className="h-4 w-4 ml-2" />
+                  </Button>
+                )}
+                {currentStep === totalSteps && (
+                  <Button type="submit" disabled={loading}>
+                    {loading ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : 'Save profile'}
+                  </Button>
+                )}
+              </div>
+            </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProfessionalOnboardingPage;

--- a/src/pages/onboarding/SmeOnboardingPage.tsx
+++ b/src/pages/onboarding/SmeOnboardingPage.tsx
@@ -1,0 +1,423 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { useAppContext } from '@/contexts/AppContext';
+import { getSmeProfile, upsertSmeProfile, uploadProfileMedia } from '@/lib/api/profile-onboarding';
+import { ArrowLeft, Loader2, Upload, Check } from 'lucide-react';
+import { supabaseClient } from '@/lib/supabaseClient';
+
+const challenges = [
+  'Access to finance',
+  'Marketing and sales',
+  'Hiring and HR',
+  'Systems and processes',
+  'Compliance and legal',
+  'Technology and automation',
+];
+
+const supportAreas = [
+  'Investment readiness',
+  'Grant applications',
+  'Financial modelling',
+  'Market expansion',
+  'Digital transformation',
+  'People and culture',
+];
+
+const smeSchema = z.object({
+  business_name: z.string().min(2, 'Business name is required'),
+  registration_number: z.string().optional(),
+  registration_type: z.string().optional(),
+  sector: z.string().optional(),
+  subsector: z.string().optional(),
+  years_in_operation: z.number().int().min(0).optional(),
+  employee_count: z.number().int().min(0).optional(),
+  turnover_bracket: z.string().optional(),
+  products_overview: z.string().optional(),
+  target_market: z.string().optional(),
+  location_city: z.string().min(1, 'City is required'),
+  location_country: z.string().min(1, 'Country is required'),
+  contact_name: z.string().min(1, 'Contact person is required'),
+  contact_phone: z.string().min(4, 'Phone number is required'),
+  business_email: z.string().email('Enter a valid email'),
+  website_url: z.string().url('Enter a valid URL').optional().or(z.literal('')).transform((val) => val || undefined),
+  social_links: z.string().optional(),
+  main_challenges: z.array(z.string()).optional(),
+  support_needs: z.array(z.string()).optional(),
+  logo_url: z.string().optional(),
+});
+
+type SmeFormValues = z.infer<typeof smeSchema>;
+
+export const SmeOnboardingPage = () => {
+  const { user } = useAppContext();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [initializing, setInitializing] = useState(true);
+  const [logoPreview, setLogoPreview] = useState<string | undefined>();
+
+  const form = useForm<SmeFormValues>({
+    resolver: zodResolver(smeSchema),
+    defaultValues: {
+      business_name: '',
+      registration_number: '',
+      registration_type: '',
+      sector: '',
+      subsector: '',
+      years_in_operation: undefined,
+      employee_count: undefined,
+      turnover_bracket: '',
+      products_overview: '',
+      target_market: '',
+      location_city: '',
+      location_country: 'Zambia',
+      contact_name: '',
+      contact_phone: '',
+      business_email: user?.email || '',
+      website_url: '',
+      social_links: '',
+      main_challenges: [],
+      support_needs: [],
+      logo_url: '',
+    },
+    mode: 'onChange',
+  });
+
+  const { register, setValue, watch, formState, handleSubmit, reset } = form;
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      try {
+        const existing = await getSmeProfile();
+        if (existing) {
+          reset({
+            business_name: existing.business_name,
+            registration_number: existing.registration_number || '',
+            registration_type: existing.registration_type || '',
+            sector: existing.sector || '',
+            subsector: existing.subsector || '',
+            years_in_operation: existing.years_in_operation ?? undefined,
+            employee_count: existing.employee_count ?? undefined,
+            turnover_bracket: existing.turnover_bracket || '',
+            products_overview: existing.products_overview || '',
+            target_market: existing.target_market || '',
+            location_city: existing.location_city || '',
+            location_country: existing.location_country || 'Zambia',
+            contact_name: existing.contact_name || '',
+            contact_phone: existing.contact_phone || '',
+            business_email: existing.business_email || user?.email || '',
+            website_url: existing.website_url || '',
+            social_links: existing.social_links?.join(', ') || '',
+            main_challenges: existing.main_challenges || [],
+            support_needs: existing.support_needs || [],
+            logo_url: existing.logo_url || '',
+          });
+
+          if (existing.logo_url) {
+            const signed = await createSignedPreview(existing.logo_url);
+            setLogoPreview(signed || undefined);
+          }
+        }
+      } catch (error: any) {
+        toast({
+          title: 'Unable to load SME profile',
+          description: error.message,
+          variant: 'destructive',
+        });
+      } finally {
+        setInitializing(false);
+      }
+    };
+
+    loadProfile();
+  }, [reset, toast, user?.email]);
+
+  const createSignedPreview = async (storedPath: string) => {
+    const cleanedPath = storedPath.replace(/^profile-media\//, '');
+    const { data } = await supabaseClient.storage
+      .from('profile-media')
+      .createSignedUrl(cleanedPath, 60 * 60 * 24);
+    return data?.signedUrl;
+  };
+
+  const toggleArrayValue = (field: 'main_challenges' | 'support_needs', value: string) => {
+    const current = (watch(field) || []) as string[];
+    const next = current.includes(value) ? current.filter((item) => item !== value) : [...current, value];
+    setValue(field, next, { shouldValidate: true });
+  };
+
+  const handleLogoUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file || !user?.id) return;
+
+    try {
+      const { path, signedUrl } = await uploadProfileMedia(file, user.id, `profiles/smes/${user.id}`, 'logo');
+      setValue('logo_url', path, { shouldValidate: true });
+      setLogoPreview(signedUrl || path);
+      toast({ title: 'Logo uploaded' });
+    } catch (error: any) {
+      toast({ title: 'Upload failed', description: error.message, variant: 'destructive' });
+    }
+  };
+
+  const onSubmit = async (data: SmeFormValues, stayOnPage?: boolean) => {
+    setLoading(true);
+    try {
+      await upsertSmeProfile({
+        ...data,
+        social_links: data.social_links?.split(',').map((link) => link.trim()).filter(Boolean),
+      });
+
+      toast({ title: 'SME profile saved', description: 'Your business details have been recorded.' });
+      if (!stayOnPage) {
+        navigate('/onboarding/sme/needs-assessment');
+      }
+    } catch (error: any) {
+      toast({ title: 'Save failed', description: error.message, variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (initializing) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <Loader2 className="h-5 w-5 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-green-50 py-10">
+      <div className="max-w-4xl mx-auto px-4">
+        <Button variant="ghost" className="mb-4" onClick={() => navigate(-1)}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Complete your SME Profile</h1>
+          <p className="text-gray-700">Share your business details to unlock tailored support and services.</p>
+        </div>
+
+        <form onSubmit={handleSubmit((values) => onSubmit(values, false))} className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Business Overview</CardTitle>
+              <CardDescription>Core details about your organisation</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="business_name">Business Name</Label>
+                  <Input id="business_name" {...register('business_name')} />
+                  {formState.errors.business_name && (
+                    <p className="text-sm text-red-600 mt-1">{formState.errors.business_name.message}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="registration_number">Registration Number & Type</Label>
+                  <Input id="registration_number" placeholder="Registration number" {...register('registration_number')} />
+                  <Input id="registration_type" placeholder="Type (e.g. LLC)" className="mt-2" {...register('registration_type')} />
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="sector">Sector & Subsector</Label>
+                  <Input id="sector" placeholder="Sector" {...register('sector')} />
+                  <Input id="subsector" placeholder="Subsector" className="mt-2" {...register('subsector')} />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                  <Label htmlFor="years_in_operation">Years in Operation</Label>
+                    <Input
+                      id="years_in_operation"
+                      type="number"
+                      min={0}
+                      {...register('years_in_operation', {
+                        setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                      })}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="employee_count">Number of Employees</Label>
+                    <Input
+                      id="employee_count"
+                      type="number"
+                      min={0}
+                      {...register('employee_count', {
+                        setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                      })}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <Label htmlFor="turnover_bracket">Turnover Bracket</Label>
+                <Input id="turnover_bracket" placeholder="e.g. ZMW 500k - 1M" {...register('turnover_bracket')} />
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="products_overview">Products/Services Overview</Label>
+                  <Textarea id="products_overview" rows={3} {...register('products_overview')} />
+                </div>
+                <div>
+                  <Label htmlFor="target_market">Target market (local/regional/export)</Label>
+                  <Textarea id="target_market" rows={3} {...register('target_market')} />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Operations & Contact</CardTitle>
+              <CardDescription>How to reach your business</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="location_city">City</Label>
+                  <Input id="location_city" {...register('location_city')} />
+                  {formState.errors.location_city && (
+                    <p className="text-sm text-red-600 mt-1">{formState.errors.location_city.message}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="location_country">Country</Label>
+                  <Input id="location_country" {...register('location_country')} />
+                  {formState.errors.location_country && (
+                    <p className="text-sm text-red-600 mt-1">{formState.errors.location_country.message}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="contact_name">Contact Person Name</Label>
+                  <Input id="contact_name" {...register('contact_name')} />
+                  {formState.errors.contact_name && (
+                    <p className="text-sm text-red-600 mt-1">{formState.errors.contact_name.message}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="contact_phone">Contact Phone</Label>
+                  <Input id="contact_phone" {...register('contact_phone')} />
+                  {formState.errors.contact_phone && (
+                    <p className="text-sm text-red-600 mt-1">{formState.errors.contact_phone.message}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="business_email">Business Email</Label>
+                  <Input id="business_email" type="email" {...register('business_email')} />
+                  {formState.errors.business_email && (
+                    <p className="text-sm text-red-600 mt-1">{formState.errors.business_email.message}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="website_url">Website / Social Links</Label>
+                  <Input id="website_url" placeholder="Website URL" {...register('website_url')} />
+                  <Input
+                    id="social_links"
+                    placeholder="Other links separated by commas"
+                    className="mt-2"
+                    {...register('social_links')}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <Label>Main challenges</Label>
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {challenges.map((item) => {
+                    const selected = (watch('main_challenges') || []).includes(item);
+                    return (
+                      <Badge
+                        key={item}
+                        variant={selected ? 'default' : 'outline'}
+                        className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                        onClick={() => toggleArrayValue('main_challenges', item)}
+                      >
+                        {selected && <Check className="h-3 w-3 mr-1" />} {item}
+                      </Badge>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <Label>Support areas you are seeking</Label>
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {supportAreas.map((item) => {
+                    const selected = (watch('support_needs') || []).includes(item);
+                    return (
+                      <Badge
+                        key={item}
+                        variant={selected ? 'default' : 'outline'}
+                        className={`cursor-pointer px-3 py-2 text-sm ${selected ? 'bg-primary text-white' : ''}`}
+                        onClick={() => toggleArrayValue('support_needs', item)}
+                      >
+                        {selected && <Check className="h-3 w-3 mr-1" />} {item}
+                      </Badge>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <Label htmlFor="logo_upload">Business Logo (optional)</Label>
+                <div className="flex items-center gap-3">
+                  <Button type="button" variant="outline" asChild>
+                    <label htmlFor="logo_upload" className="cursor-pointer flex items-center gap-2">
+                      <Upload className="h-4 w-4" />
+                      {logoPreview ? 'Change logo' : 'Upload logo'}
+                    </label>
+                  </Button>
+                  {logoPreview && <img src={logoPreview} alt="Logo preview" className="h-12 w-12 rounded border object-cover" />}
+                </div>
+                <Input
+                  id="logo_upload"
+                  type="file"
+                  accept=".jpg,.jpeg,.png"
+                  className="hidden"
+                  onChange={handleLogoUpload}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex gap-3 justify-end">
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={loading}
+              onClick={handleSubmit((values) => onSubmit(values, true))}
+            >
+              {loading ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : 'Save & Continue Later'}
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : 'Save and continue'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SmeOnboardingPage;

--- a/supabase/migrations/20251212120000_create_professional_profiles.sql
+++ b/supabase/migrations/20251212120000_create_professional_profiles.sql
@@ -1,0 +1,322 @@
+-- Create professional_profiles table and supporting onboarding tables
+-- Generated to align frontend onboarding flows for professional, SME, and investor/donor accounts
+
+BEGIN;
+
+-- Professional profiles core table
+CREATE TABLE IF NOT EXISTS public.professional_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  entity_type text NOT NULL,
+  full_name text NOT NULL,
+  organisation_name text,
+  bio text,
+  primary_expertise text[] NOT NULL DEFAULT '{}',
+  secondary_skills text[] DEFAULT '{}',
+  years_of_experience int,
+  current_organisation text,
+  qualifications text,
+  top_sectors text[] DEFAULT '{}',
+  notable_projects text,
+  services_offered text[] DEFAULT '{}',
+  expected_rates text,
+  location_city text,
+  location_country text,
+  phone text,
+  email text,
+  linkedin_url text,
+  website_url text,
+  portfolio_url text,
+  availability text,
+  notes text,
+  profile_photo_url text,
+  logo_url text,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Ensure additive columns exist if table was pre-created
+DO $$
+DECLARE
+  col RECORD;
+BEGIN
+  FOR col IN
+    SELECT column_name, data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'professional_profiles'
+  LOOP
+    -- placeholder to satisfy DO block structure
+    NULL;
+  END LOOP;
+END $$;
+
+-- Add missing columns defensively
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'professional_profiles' AND column_name = 'entity_type') THEN
+    ALTER TABLE public.professional_profiles ADD COLUMN entity_type text NOT NULL DEFAULT 'individual';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'professional_profiles' AND column_name = 'services_offered') THEN
+    ALTER TABLE public.professional_profiles ADD COLUMN services_offered text[] DEFAULT '{}';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'professional_profiles' AND column_name = 'primary_expertise') THEN
+    ALTER TABLE public.professional_profiles ADD COLUMN primary_expertise text[] NOT NULL DEFAULT '{}';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'professional_profiles' AND column_name = 'secondary_skills') THEN
+    ALTER TABLE public.professional_profiles ADD COLUMN secondary_skills text[] DEFAULT '{}';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'professional_profiles' AND column_name = 'top_sectors') THEN
+    ALTER TABLE public.professional_profiles ADD COLUMN top_sectors text[] DEFAULT '{}';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'professional_profiles' AND column_name = 'availability') THEN
+    ALTER TABLE public.professional_profiles ADD COLUMN availability text;
+  END IF;
+END $$;
+
+-- Unique professional profile per user
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'professional_profiles_user_id_key'
+  ) THEN
+    ALTER TABLE public.professional_profiles
+      ADD CONSTRAINT professional_profiles_user_id_key UNIQUE (user_id);
+  END IF;
+END $$;
+
+-- Check constraint for supported entity types
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'professional_entity_type_check'
+  ) THEN
+    ALTER TABLE public.professional_profiles
+      ADD CONSTRAINT professional_entity_type_check
+      CHECK (entity_type IN ('individual', 'firm', 'company'));
+  END IF;
+END $$;
+
+-- Timestamp trigger for updated_at
+CREATE OR REPLACE FUNCTION public.set_professional_profiles_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = timezone('utc', now());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_professional_profiles_updated_at ON public.professional_profiles;
+CREATE TRIGGER trg_professional_profiles_updated_at
+BEFORE UPDATE ON public.professional_profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.set_professional_profiles_updated_at();
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS professional_profiles_user_id_idx ON public.professional_profiles(user_id);
+CREATE INDEX IF NOT EXISTS professional_profiles_entity_type_idx ON public.professional_profiles(entity_type);
+
+-- Row level security
+ALTER TABLE public.professional_profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS professional_profiles_select ON public.professional_profiles;
+DROP POLICY IF EXISTS professional_profiles_modify ON public.professional_profiles;
+DROP POLICY IF EXISTS professional_profiles_service_role ON public.professional_profiles;
+
+CREATE POLICY professional_profiles_select
+  ON public.professional_profiles
+  FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.user_id = auth.uid()
+        AND ur.role_name IN ('admin', 'super_admin')
+    )
+  );
+
+CREATE POLICY professional_profiles_modify
+  ON public.professional_profiles
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY professional_profiles_service_role
+  ON public.professional_profiles
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- SME onboarding profile table
+CREATE TABLE IF NOT EXISTS public.sme_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  business_name text NOT NULL,
+  registration_number text,
+  registration_type text,
+  sector text,
+  subsector text,
+  years_in_operation int,
+  employee_count int,
+  turnover_bracket text,
+  products_overview text,
+  target_market text,
+  location_city text,
+  location_country text,
+  contact_name text,
+  contact_phone text,
+  business_email text,
+  website_url text,
+  social_links text[] DEFAULT '{}',
+  main_challenges text[] DEFAULT '{}',
+  support_needs text[] DEFAULT '{}',
+  logo_url text,
+  photos text[] DEFAULT '{}',
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'sme_profiles_user_id_key'
+  ) THEN
+    ALTER TABLE public.sme_profiles
+      ADD CONSTRAINT sme_profiles_user_id_key UNIQUE (user_id);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS sme_profiles_user_id_idx ON public.sme_profiles(user_id);
+ALTER TABLE public.sme_profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS sme_profiles_select ON public.sme_profiles;
+DROP POLICY IF EXISTS sme_profiles_modify ON public.sme_profiles;
+DROP POLICY IF EXISTS sme_profiles_service_role ON public.sme_profiles;
+
+CREATE POLICY sme_profiles_select
+  ON public.sme_profiles
+  FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.user_id = auth.uid()
+        AND ur.role_name IN ('admin', 'super_admin')
+    )
+  );
+
+CREATE POLICY sme_profiles_modify
+  ON public.sme_profiles
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY sme_profiles_service_role
+  ON public.sme_profiles
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+DROP TRIGGER IF EXISTS trg_sme_profiles_updated_at ON public.sme_profiles;
+CREATE TRIGGER trg_sme_profiles_updated_at
+BEFORE UPDATE ON public.sme_profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.set_professional_profiles_updated_at();
+
+-- Investor / Donor onboarding profile table
+CREATE TABLE IF NOT EXISTS public.investor_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  organisation_name text NOT NULL,
+  investor_type text,
+  ticket_size_min int,
+  ticket_size_max int,
+  preferred_sectors text[] DEFAULT '{}',
+  country_focus text[] DEFAULT '{}',
+  stage_preference text[] DEFAULT '{}',
+  instruments text[] DEFAULT '{}',
+  impact_focus text[] DEFAULT '{}',
+  contact_person text,
+  contact_role text,
+  website_url text,
+  linkedin_url text,
+  logo_url text,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'investor_profiles_user_id_key'
+  ) THEN
+    ALTER TABLE public.investor_profiles
+      ADD CONSTRAINT investor_profiles_user_id_key UNIQUE (user_id);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS investor_profiles_user_id_idx ON public.investor_profiles(user_id);
+ALTER TABLE public.investor_profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS investor_profiles_select ON public.investor_profiles;
+DROP POLICY IF EXISTS investor_profiles_modify ON public.investor_profiles;
+DROP POLICY IF EXISTS investor_profiles_service_role ON public.investor_profiles;
+
+CREATE POLICY investor_profiles_select
+  ON public.investor_profiles
+  FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.user_id = auth.uid()
+        AND ur.role_name IN ('admin', 'super_admin')
+    )
+  );
+
+CREATE POLICY investor_profiles_modify
+  ON public.investor_profiles
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY investor_profiles_service_role
+  ON public.investor_profiles
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+DROP TRIGGER IF EXISTS trg_investor_profiles_updated_at ON public.investor_profiles;
+CREATE TRIGGER trg_investor_profiles_updated_at
+BEFORE UPDATE ON public.investor_profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.set_professional_profiles_updated_at();
+
+-- Private storage bucket for profile media
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('profile-media', 'profile-media', false)
+ON CONFLICT (id) DO UPDATE SET public = false;
+
+-- Storage policies for owner and service role access
+DROP POLICY IF EXISTS "Profile media user access" ON storage.objects;
+DROP POLICY IF EXISTS "Profile media service role access" ON storage.objects;
+
+CREATE POLICY "Profile media user access"
+  ON storage.objects
+  FOR ALL
+  TO authenticated
+  USING (bucket_id = 'profile-media' AND auth.uid() = owner)
+  WITH CHECK (bucket_id = 'profile-media' AND auth.uid() = owner);
+
+CREATE POLICY "Profile media service role access"
+  ON storage.objects
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- create Supabase onboarding tables and storage policies for professional, SME, and investor profiles
- add client-side onboarding API helpers plus account-type routing guards
- build professional, SME, and investor onboarding pages with validation, uploads, and updated onboarding navigation/tests

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/GetStartedPage.test.tsx *(fails: missing environment variables and backend services such as CORS/SMTP in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925db142a8083288516f6e43b2a1447)