### PR TITLE
Align API env usage and tighten CORS

### DIFF
--- a/backend/middleware/cors.js
+++ b/backend/middleware/cors.js
@@ -3,37 +3,39 @@ const createCorsMiddleware = ({
   allowCredentials = false,
   allowNoOrigin = false,
   allowedMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-  allowedHeaders = ['Content-Type', 'Authorization'],
+  allowedHeaders = ['Origin', 'X-Requested-With', 'Content-Type', 'Accept', 'Authorization'],
 } = {}) => {
-  const normalizedOrigins = Array.from(new Set(allowedOrigins)).filter(Boolean);
-  const allowAll = normalizedOrigins.length === 0 || normalizedOrigins.includes('*');
+  const normalizedOrigins = Array.from(new Set(allowedOrigins))
+    .filter(origin => Boolean(origin) && origin !== '*');
 
   return (req, res, next) => {
     const origin = req.headers.origin;
-    const isAllowed = (allowNoOrigin && !origin) || allowAll || normalizedOrigins.includes(origin);
+    const isAllowed = (allowNoOrigin && !origin) || normalizedOrigins.includes(origin);
 
-    if (!isAllowed) {
-      const error = new Error('Not allowed by CORS');
-      error.status = 403;
-      return next(error);
-    }
-
-    if (origin) {
-      // When credentials are allowed, we cannot use wildcard '*'
-      // We must echo back the specific origin
-      res.header('Access-Control-Allow-Origin', (allowAll && !allowCredentials) ? '*' : origin);
+    if (origin && normalizedOrigins.includes(origin)) {
+      res.header('Access-Control-Allow-Origin', origin);
       res.header('Vary', 'Origin');
     }
 
-    res.header('Access-Control-Allow-Methods', allowedMethods.join(','));
-    res.header('Access-Control-Allow-Headers', allowedHeaders.join(','));
+    res.header('Access-Control-Allow-Methods', allowedMethods.join(', '));
+    res.header('Access-Control-Allow-Headers', allowedHeaders.join(', '));
 
     if (allowCredentials) {
       res.header('Access-Control-Allow-Credentials', 'true');
     }
 
     if (req.method === 'OPTIONS') {
+      if (!isAllowed && origin) {
+        return res.status(403).json({ error: 'Not allowed by CORS' });
+      }
+
       return res.sendStatus(204);
+    }
+
+    if (!isAllowed) {
+      const error = new Error('Not allowed by CORS');
+      error.status = 403;
+      return next(error);
     }
 
     return next();

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -14,19 +14,19 @@
  * @returns The API base URL without trailing slash
  */
 const getApiBaseUrl = (): string => {
-  const envUrl = import.meta.env.VITE_API_BASE_URL ?? import.meta.env.REACT_APP_API_BASE_URL;
-  
-  // In production, API base URL must be set
+  const envUrl = import.meta.env.VITE_API_BASE_URL?.trim();
+
+  // In production, API base URL must be explicitly configured
   if (import.meta.env.MODE === 'production' && !envUrl) {
     throw new Error(
       'API base URL is required in production mode. ' +
-      'Please set VITE_API_BASE_URL or REACT_APP_API_BASE_URL to your live backend API URL (e.g., https://api.wathaci.com)'
+      'Please set VITE_API_BASE_URL to your live backend API URL (e.g., https://wathaci-connect-platform2.vercel.app)'
     );
   }
-  
-  // Default to localhost in development
+
+  // Default to localhost in development when unset
   const baseUrl = envUrl ?? 'http://localhost:3000';
-  
+
   // Remove trailing slash for consistency
   return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
 };

--- a/src/config/getAppConfig.ts
+++ b/src/config/getAppConfig.ts
@@ -91,11 +91,11 @@ export function getAppEnvStatus(): AppEnvStatus {
   // API CONFIGURATION
   // ============================================================
 
-  const apiBaseUrl = env.VITE_API_BASE_URL ?? env.REACT_APP_API_BASE_URL;
+  const apiBaseUrl = env.VITE_API_BASE_URL?.trim();
   
   if (!apiBaseUrl) {
     blockingErrors.push(
-      'Missing API base URL. Set VITE_API_BASE_URL or REACT_APP_API_BASE_URL to your backend API base URL (e.g., https://api.wathaci.com).'
+      'Missing API base URL. Set VITE_API_BASE_URL to your backend API base URL (e.g., https://wathaci-connect-platform2.vercel.app).'
     );
   } else {
     // Check for common development values in production

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,7 +2,6 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
-  readonly REACT_APP_API_BASE_URL?: string;
   readonly VITE_MAINTENANCE_MODE?: string;
   readonly VITE_MAINTENANCE_ALLOW_SIGNIN?: string;
   readonly VITE_MAINTENANCE_ALLOW_SIGNUP?: string;

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -6,7 +6,7 @@ const normalizePath = (path: string) => (path.startsWith('/') ? path : `/${path}
 
 const ensureApiBaseUrl = () => {
   if (!API_BASE_URL) {
-    throw new Error('API base URL is not configured. Please set VITE_API_BASE_URL or REACT_APP_API_BASE_URL.');
+    throw new Error('API base URL is not configured. Please set VITE_API_BASE_URL.');
   }
 };
 


### PR DESCRIPTION
## Summary
- enforce explicit allowlist-based CORS middleware using ALLOWED_ORIGINS defaults and updated headers
- require API base URL configuration via `VITE_API_BASE_URL` across client code and validation helpers
- clean up environment typings and API client messaging to match the single-source base URL

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692699869af0832883b6a1b4fedfa5ac)