### PR TITLE
Enhance homepage hero styling

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 const HeroSection = () => {
   return (
-    <section className="relative overflow-hidden py-20">
+    <section className="hero-section relative overflow-hidden py-28 lg:py-32">
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 -z-10 overflow-hidden"
@@ -30,48 +30,55 @@ const HeroSection = () => {
         <div className="absolute inset-0 bg-gradient-to-br from-white/55 via-white/35 to-white/20 backdrop-blur-[1px]" />
       </div>
 
-      <div className="relative z-10 max-w-6xl mx-auto px-6">
-        <div className="text-center mb-16">
-          <div className="mb-8">
+      <div className="relative z-10 max-w-[74rem] mx-auto px-6 lg:px-10">
+        <div className="hero-content-panel text-center mb-16 lg:mb-20 max-w-4xl mx-auto">
+          <div className="mb-10 flex justify-center">
             <img
               src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
               alt="WATHACI CONNECT"
               loading="lazy"
               decoding="async"
-              className="h-32 w-auto mx-auto drop-shadow-2xl"
+              className="h-32 w-auto drop-shadow-2xl"
             />
           </div>
-          <h1 className="text-5xl font-bold text-gray-900 mb-6 leading-tight">
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-semibold lg:font-bold text-white mb-6 leading-tight tracking-tight drop-shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
             Empowering Zambian
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-600 to-green-600"> Business Excellence</span>
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 via-yellow-400 to-green-500"> Business Excellence</span>
           </h1>
-          <p className="text-xl text-gray-600 mb-8 max-w-3xl mx-auto leading-relaxed">
-            Connect with professional services, find skilled freelancers, and access resources 
+          <p className="text-lg sm:text-xl text-white/90 mb-10 max-w-3xl mx-auto leading-relaxed">
+            Connect with professional services, find skilled freelancers, and access resources
             designed specifically for Zambian businesses. Your gateway to growth and success.
           </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <div className="flex flex-col sm:flex-row gap-4 sm:gap-5 justify-center">
             <Link to="/get-started">
-              <Button size="lg" className="bg-gradient-to-r from-orange-600 to-orange-700 hover:from-orange-700 hover:to-orange-800 text-white px-8 py-3 text-lg">
+              <Button
+                size="lg"
+                className="rounded-xl bg-gradient-to-r from-orange-600 to-orange-700 hover:from-orange-700 hover:to-orange-800 text-white px-8 py-3 text-lg font-semibold shadow-[0_10px_30px_rgba(0,0,0,0.15)] transition-all duration-300 ease-out hover:-translate-y-0.5"
+              >
                 Get Started Today
                 <ArrowRight className="ml-2 w-5 h-5" />
               </Button>
             </Link>
             <Link to="/marketplace">
-              <Button variant="outline" size="lg" className="border-2 border-green-600 text-green-700 hover:bg-green-50 px-8 py-3 text-lg">
+              <Button
+                variant="outline"
+                size="lg"
+                className="rounded-xl border-2 border-white/60 bg-white/10 text-white hover:bg-white/20 px-8 py-3 text-lg font-semibold backdrop-blur-[2px] transition-all duration-300 ease-out hover:-translate-y-0.5"
+              >
                 Explore Marketplace
               </Button>
             </Link>
           </div>
         </div>
 
-        <div className="grid md:grid-cols-3 gap-8 mt-16">
+        <div className="grid md:grid-cols-3 gap-8 mt-20 lg:mt-24">
           <div
             role="button"
             tabIndex={0}
             data-analytics-id="professional-network"
             aria-label="Join the professional network"
             title="Expand your professional contacts"
-            className="text-center p-6 bg-white rounded-xl shadow-lg border border-blue-100 hover:shadow-xl focus:shadow-xl transition-shadow focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            className="text-center p-6 bg-white rounded-2xl shadow-[0_10px_30px_rgba(0,0,0,0.15)] border border-blue-100/80 hover:shadow-xl focus:shadow-xl transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
           >
             <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center mx-auto mb-4">
               <Users aria-hidden="true" className="w-8 h-8 text-white" />
@@ -88,7 +95,7 @@ const HeroSection = () => {
             data-analytics-id="business-growth"
             aria-label="Grow your business"
             title="Access tools to accelerate your business"
-            className="text-center p-6 bg-white rounded-xl shadow-lg border border-green-100 hover:shadow-xl focus:shadow-xl transition-shadow focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+            className="text-center p-6 bg-white rounded-2xl shadow-[0_10px_30px_rgba(0,0,0,0.15)] border border-green-100/80 hover:shadow-xl focus:shadow-xl transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
           >
             <div className="w-16 h-16 bg-gradient-to-br from-green-500 to-green-600 rounded-full flex items-center justify-center mx-auto mb-4">
               <TrendingUp aria-hidden="true" className="w-8 h-8 text-white" />
@@ -105,7 +112,7 @@ const HeroSection = () => {
             data-analytics-id="quality-assurance"
             aria-label="Ensure quality"
             title="Work with vetted, reliable professionals"
-            className="text-center p-6 bg-white rounded-xl shadow-lg border border-amber-100 hover:shadow-xl focus:shadow-xl transition-shadow focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
+            className="text-center p-6 bg-white rounded-2xl shadow-[0_10px_30px_rgba(0,0,0,0.15)] border border-amber-100/80 hover:shadow-xl focus:shadow-xl transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
           >
             <div className="w-16 h-16 bg-gradient-to-br from-amber-500 to-amber-600 rounded-full flex items-center justify-center mx-auto mb-4">
               <ShieldCheck aria-hidden="true" className="w-8 h-8 text-white" />

--- a/src/index.css
+++ b/src/index.css
@@ -84,6 +84,50 @@
   @apply bg-gradient-to-r from-blue-600 to-emerald-600 bg-clip-text text-transparent;
 }
 
+.hero-section {
+  position: relative;
+  isolation: isolate;
+}
+
+.hero-section::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0%, rgba(0, 0, 0, 0.45) 45%, rgba(0, 0, 0, 0.55) 100%);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.hero-section::after {
+  content: "";
+  position: absolute;
+  inset: -30px;
+  background: radial-gradient(120% 120% at 50% 35%, rgba(0, 0, 0, 0) 55%, rgba(0, 0, 0, 0.32) 100%);
+  z-index: 0;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+}
+
+.hero-content-panel {
+  position: relative;
+  z-index: 1;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+  border-radius: 24px;
+  padding: 2.75rem 2rem;
+  backdrop-filter: blur(6px);
+}
+
+.hero-content-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(100% 120% at 50% 0%, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 65%);
+  border-radius: 24px;
+  pointer-events: none;
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 8px;


### PR DESCRIPTION
## Summary
- Added hero overlay, vignette, and premium panel styling to mirror Freelancer Hub aesthetics without replacing the existing background image
- Updated hero typography, spacing, container widths, and CTA treatments for better readability and alignment with Wathaci identity
- Refined feature card shadows and vertical rhythm to create a cleaner, grid-aligned presentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69269e6c3ca88328a7a7f114ef70f0ea)