### PR TITLE
Fix rendering stability across dashboards

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -649,7 +649,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     refreshPromiseRef.current = refreshTask;
 
     return refreshTask;
-  }, [resolveOfflineAuthState, user?.id]);
+  }, [user?.id]);
 
   const signIn = async (email: string, password: string): Promise<AuthState> => {
     logInfo('Initiating sign-in flow', { event: 'auth:signIn:start' });

--- a/src/features/compliance/ComplianceDashboard.tsx
+++ b/src/features/compliance/ComplianceDashboard.tsx
@@ -2,7 +2,7 @@
  * ComplianceDashboard - Main view for the Compliance Hub feature
  * Displays user's compliance tasks organized by status (Overdue, Upcoming, Completed)
  */
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 import { Button } from '@/components/ui/button';
@@ -39,13 +39,7 @@ export const ComplianceDashboard = () => {
   const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
   const [isAddStandardDrawerOpen, setIsAddStandardDrawerOpen] = useState(false);
 
-  useEffect(() => {
-    if (user) {
-      fetchTasks();
-    }
-  }, [user]);
-
-  const fetchTasks = async () => {
+  const fetchTasks = useCallback(async () => {
     try {
       setLoading(true);
       const { data, error } = await supabase
@@ -77,7 +71,13 @@ export const ComplianceDashboard = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (user) {
+      void fetchTasks();
+    }
+  }, [fetchTasks, user]);
 
   const markAsCompleted = async (taskId: string) => {
     try {

--- a/src/pages/DocumentGenerators.tsx
+++ b/src/pages/DocumentGenerators.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import AppLayout from '@/components/AppLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -70,7 +70,7 @@ const DocumentGenerators = () => {
     setStatusText('Awaiting payment confirmation');
   };
 
-  const loadHistory = async () => {
+  const loadHistory = useCallback(async () => {
     if (!user) return;
     try {
       const { requests } = await documentGeneratorService.listRequests(user.id);
@@ -78,11 +78,11 @@ const DocumentGenerators = () => {
     } catch (error) {
       console.error('[documents] history error', error);
     }
-  };
+  }, [user]);
 
   useEffect(() => {
-    loadHistory();
-  }, [user?.id]);
+    void loadHistory();
+  }, [loadHistory]);
 
   const triggerPayment = async () => {
     if (!user || !selectedType) {

--- a/src/pages/ProfileSetup.tsx
+++ b/src/pages/ProfileSetup.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { supabase } from '@/lib/supabase-enhanced';
 import { ProfileForm } from '@/components/ProfileForm';
@@ -36,7 +36,10 @@ export const ProfileSetup = () => {
   const { user, refreshUser } = useAppContext();
   const [lastAutoAppliedAccountType, setLastAutoAppliedAccountType] = useState<AccountTypeValue | null>(null);
 
-  const validAccountTypeValues = new Set<AccountTypeValue>(accountTypes.map(({ value }) => value));
+  const validAccountTypeValues = useMemo(
+    () => new Set<AccountTypeValue>(accountTypes.map(({ value }) => value)),
+    []
+  );
 
   const accountTypeFromParams = (() => {
     const paramValue = searchParams.get('accountType');


### PR DESCRIPTION
## Summary
- memoize profile setup account types to keep dependent effects stable
- wrap compliance dashboard and document history fetches in callbacks and align effect dependencies
- simplify auth refresh dependencies to avoid redundant re-renders

## Testing
- npm run lint
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926fcb953e883288ce002304d801fa5)