### PR TITLE
Relax configuration gating for missing Supabase

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -411,8 +411,22 @@ const InnerApp = () => {
     };
   }, [paymentConfigSnapshot]);
 
+  const isRuntimeProd =
+    import.meta.env.PROD || paymentConfigSnapshot.config.environment === "production";
+
   const shouldBlockRender =
-    !supabaseConfigStatus.hasValidConfig || paymentConfigSnapshot.fatalIssues.length > 0;
+    (isRuntimeProd && !supabaseConfigStatus.hasValidConfig) ||
+    paymentConfigSnapshot.fatalIssues.length > 0;
+
+  if (!shouldBlockRender && !supabaseConfigStatus.hasValidConfig) {
+    console.warn(
+      "[app] Supabase configuration missing. Using mock client so the UI can continue rendering.",
+      {
+        missingUrlKeys: supabaseConfigStatus.missingUrlKeys,
+        missingAnonKeys: supabaseConfigStatus.missingAnonKeys,
+      },
+    );
+  }
 
   if (shouldBlockRender) {
     return (


### PR DESCRIPTION
## Summary
- avoid blocking the UI when Supabase configuration is missing in non-production builds by checking runtime environment before rendering the configuration error
- surface a console warning when falling back to the mock Supabase client so missing keys are still visible during development

## Testing
- `npm test -- --runInBand` *(fails: requires email argument and Supabase env vars)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927f087195c83289652cf3932a4cef0)