### PR TITLE
Apply global header layout across all routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useEffect, useMemo } from "react";
+import { ReactNode, Suspense, lazy, useEffect, useMemo } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -13,6 +13,7 @@ import { ConfigurationError } from "@/components/ConfigurationError";
 import { RouteChangeDebugger } from "@/components/RouteChangeDebugger";
 import { supabaseConfigStatus } from "@/config/appConfig";
 import { getPaymentConfig } from "@/lib/payment-config";
+import AppLayout from "./components/AppLayout";
 import "./i18n";
 
 const queryClient = new QueryClient();
@@ -147,6 +148,10 @@ const ComplianceDashboard = lazy(() =>
   }))
 );
 
+const withAppLayout = (element: ReactNode, options: { showFooter?: boolean } = {}) => (
+  <AppLayout showFooter={options.showFooter ?? true}>{element}</AppLayout>
+);
+
 
 export const AppRoutes = () => (
   <Suspense fallback={<LoadingScreen />}>
@@ -155,15 +160,15 @@ export const AppRoutes = () => (
       <Route path="/marketplace" element={<Marketplace />} />
       <Route path="/freelancer-hub" element={<FreelancerHub />} />
       <Route path="/resources" element={<Resources />} />
-      <Route path="/signin" element={<SignIn />} />
-      <Route path="/signup" element={<SignUp />} />
-      <Route path="/signup-zaqa" element={<ZaqaSignup />} />
-      <Route path="/forgot-password" element={<ForgotPassword />} />
-      <Route path="/reset-password" element={<ResetPassword />} />
-      <Route path="/get-started" element={<GetStartedPage />} />
-      <Route path="/profile-setup" element={<ProfileSetup />} />
-      <Route path="/profile-review" element={<ProfileReview />} />
-      <Route path="/subscription-plans" element={<SubscriptionPlans />} />
+      <Route path="/signin" element={withAppLayout(<SignIn />, { showFooter: false })} />
+      <Route path="/signup" element={withAppLayout(<SignUp />, { showFooter: false })} />
+      <Route path="/signup-zaqa" element={withAppLayout(<ZaqaSignup />, { showFooter: false })} />
+      <Route path="/forgot-password" element={withAppLayout(<ForgotPassword />, { showFooter: false })} />
+      <Route path="/reset-password" element={withAppLayout(<ResetPassword />, { showFooter: false })} />
+      <Route path="/get-started" element={withAppLayout(<GetStartedPage />)} />
+      <Route path="/profile-setup" element={withAppLayout(<ProfileSetup />, { showFooter: false })} />
+      <Route path="/profile-review" element={withAppLayout(<ProfileReview />, { showFooter: false })} />
+      <Route path="/subscription-plans" element={withAppLayout(<SubscriptionPlans />)} />
       <Route path="/partnership-hub" element={<PartnershipHub />} />
       <Route
         path="/funding-hub"
@@ -173,10 +178,10 @@ export const AppRoutes = () => (
           </PrivateRoute>
         }
       />
-      <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-      <Route path="/terms-of-service" element={<TermsOfService />} />
+      <Route path="/privacy-policy" element={withAppLayout(<PrivacyPolicy />)} />
+      <Route path="/terms-of-service" element={withAppLayout(<TermsOfService />)} />
       <Route path="/about-us" element={<AboutUs />} />
-      <Route path="/test-error" element={<TestError />} />
+      <Route path="/test-error" element={withAppLayout(<TestError />, { showFooter: false })} />
       <Route
         path="/messages"
         element={
@@ -188,41 +193,56 @@ export const AppRoutes = () => (
       <Route
         path="/sme-assessment"
         element={
-          <PrivateRoute>
-            <SMEAssessment />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <SMEAssessment />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/investor-assessment"
         element={
-          <PrivateRoute>
-            <InvestorAssessment />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <InvestorAssessment />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/donor-assessment"
         element={
-          <PrivateRoute>
-            <DonorAssessment />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <DonorAssessment />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/professional-assessment"
         element={
-          <PrivateRoute>
-            <ProfessionalAssessment />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <ProfessionalAssessment />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/government-assessment"
         element={
-          <PrivateRoute>
-            <GovernmentAssessment />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <GovernmentAssessment />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       
@@ -230,71 +250,95 @@ export const AppRoutes = () => (
       <Route
         path="/onboarding/sme/needs-assessment"
         element={
-          <PrivateRoute>
-            <SmeNeedsAssessmentPage />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <SmeNeedsAssessmentPage />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/onboarding/sme"
         element={
-          <PrivateRoute>
-            <AccountTypeRoute allowed={["sme"]}>
-              <SmeOnboardingPage />
-            </AccountTypeRoute>
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <AccountTypeRoute allowed={["sme"]}>
+                <SmeOnboardingPage />
+              </AccountTypeRoute>
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/onboarding/professional/needs-assessment"
         element={
-          <PrivateRoute>
-            <ProfessionalNeedsAssessmentPage />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <ProfessionalNeedsAssessmentPage />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/onboarding/professional"
         element={
-          <PrivateRoute>
-            <AccountTypeRoute allowed={["professional"]}>
-              <ProfessionalOnboardingPage />
-            </AccountTypeRoute>
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <AccountTypeRoute allowed={["professional"]}>
+                <ProfessionalOnboardingPage />
+              </AccountTypeRoute>
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/onboarding/donor/needs-assessment"
         element={
-          <PrivateRoute>
-            <DonorNeedsAssessmentPage />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <DonorNeedsAssessmentPage />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/onboarding/investor/needs-assessment"
         element={
-          <PrivateRoute>
-            <InvestorNeedsAssessmentPage />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <InvestorNeedsAssessmentPage />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/onboarding/investor"
         element={
-          <PrivateRoute>
-            <AccountTypeRoute allowed={["investor", "donor"]}>
-              <InvestorOnboardingPage />
-            </AccountTypeRoute>
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <AccountTypeRoute allowed={["investor", "donor"]}>
+                <InvestorOnboardingPage />
+              </AccountTypeRoute>
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       <Route
         path="/onboarding/government/needs-assessment"
         element={
-          <PrivateRoute>
-            <GovernmentNeedsAssessmentPage />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <GovernmentNeedsAssessmentPage />
+            </PrivateRoute>,
+            { showFooter: false }
+          )
         }
       />
       
@@ -320,9 +364,11 @@ export const AppRoutes = () => (
       <Route
         path="/compliance"
         element={
-          <PrivateRoute>
-            <ComplianceDashboard />
-          </PrivateRoute>
+          withAppLayout(
+            <PrivateRoute>
+              <ComplianceDashboard />
+            </PrivateRoute>
+          )
         }
       />
 
@@ -342,8 +388,8 @@ export const AppRoutes = () => (
           </PrivateRoute>
         }
       />
-      
-      <Route path="*" element={<NotFound />} />
+
+      <Route path="*" element={withAppLayout(<NotFound />, { showFooter: false })} />
     </Routes>
   </Suspense>
 );

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -5,9 +5,10 @@ import Footer from './Footer';
 interface AppLayoutProps {
   children?: ReactNode;
   showHomeContent?: boolean;
+  showFooter?: boolean;
 }
 
-export const AppLayout = ({ children, showHomeContent = false }: AppLayoutProps) => {
+export const AppLayout = ({ children, showHomeContent = false, showFooter = true }: AppLayoutProps) => {
   return (
     <div className="min-h-screen bg-white">
       <Header />
@@ -21,7 +22,7 @@ export const AppLayout = ({ children, showHomeContent = false }: AppLayoutProps)
           children
         )}
       </main>
-      <Footer />
+      {showFooter && <Footer />}
     </div>
   );
 };

--- a/src/pages/PartnershipHub.tsx
+++ b/src/pages/PartnershipHub.tsx
@@ -7,11 +7,10 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Header } from '@/components/Header';
-import { Footer } from '@/components/Footer';
 import { supabase } from '@/lib/supabase-enhanced';
 import IndustryMatcher from '@/components/industry/IndustryMatcher';
 import { Handshake, Users, TrendingUp, Award, Building, Globe, CheckCircle, Star, Target } from 'lucide-react';
+import AppLayout from '@/components/AppLayout';
 
 const partnerTypes = [
   {
@@ -92,9 +91,9 @@ export const PartnershipHub = () => {
     }
   };
 
-    return (
+  return (
+    <AppLayout>
       <div className="min-h-screen bg-white relative">
-        <Header />
 
         <div
           aria-hidden="true"
@@ -331,7 +330,7 @@ export const PartnershipHub = () => {
         </Tabs>
       </div>
       
-      <Footer />
-    </div>
+      </div>
+    </AppLayout>
   );
 };


### PR DESCRIPTION
## Summary
- extend the shared layout so the global header can be shown without the footer when needed
- wrap authentication, assessment, onboarding, and utility routes with the reusable header layout to ensure consistency
- refactor Partnership Hub to consume the shared layout instead of rendering its own header/footer

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692810d559808328838f0c220b9e696a)