### PR TITLE
Align auth dashboard routing with shared Supabase client

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from "react";
-import { supabaseClient, accountTypePaths, type AccountType } from "@/lib/wathaciSupabaseClient";
+import {
+  supabaseClient,
+  getDashboardPathForAccountType,
+  type AccountType,
+} from "@/lib/wathaciSupabaseClient";
 import { withSupportContact } from "@/lib/supportEmail";
 
 export interface LoginFormProps {
-  onLogin?: (accountType: AccountType) => void;
+  onLogin?: (accountType: AccountType | null | undefined) => void;
 }
 
 export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
@@ -46,9 +50,12 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
         return;
       }
 
-      const accountType = profile?.account_type as AccountType;
-      const destination = accountType ? accountTypePaths[accountType] : "/";
-      onLogin?.(accountType);
+      const normalizedType = (typeof profile?.account_type === "string"
+        ? (profile.account_type.toLowerCase() as AccountType)
+        : null);
+
+      const destination = getDashboardPathForAccountType(normalizedType);
+      onLogin?.(normalizedType || undefined);
       window.location.href = destination;
     } catch (unknownError) {
       console.error(unknownError);

--- a/src/lib/wathaciSupabaseClient.ts
+++ b/src/lib/wathaciSupabaseClient.ts
@@ -1,36 +1,26 @@
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { supabaseClient } from "./supabaseClient";
+import type { AccountTypeValue } from "@/data/accountTypes";
 
-// Minimal Supabase client dedicated to the Wathaci auth/onboarding flow.
-// Ensure VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY are set in your
-// Vite environment (e.g., .env.local). We intentionally keep this lean so
-// it can be copied into standalone onboarding pages without the broader
-// application config dependencies.
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// Use the shared, fully-configured Supabase client so auth state is consistent
+// across the app (sessions, headers, interceptors, etc.). This prevents the
+// standalone onboarding utilities from crashing when environment variables are
+// missing and keeps login/signup flows aligned with the main application.
+export { supabaseClient };
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  // Early surface of misconfiguration for developers.
-  throw new Error(
-    "Missing Supabase configuration. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your environment."
-  );
-}
-
-export const supabaseClient: SupabaseClient = createClient(
-  supabaseUrl,
-  supabaseAnonKey
-);
-
-export type AccountType =
-  | "SME"
-  | "INVESTOR"
-  | "SERVICE_PROVIDER"
-  | "PARTNER"
-  | "ADMIN";
+export type AccountType = AccountTypeValue;
 
 export const accountTypePaths: Record<AccountType, string> = {
-  SME: "/dashboard/sme",
-  INVESTOR: "/dashboard/investor",
-  SERVICE_PROVIDER: "/dashboard/service-provider",
-  PARTNER: "/dashboard/partner",
-  ADMIN: "/dashboard/admin",
+  sme: "/sme-assessment",
+  sole_proprietor: "/sme-assessment",
+  investor: "/investor-assessment",
+  professional: "/professional-assessment",
+  donor: "/donor-assessment",
+  government: "/government-assessment",
+};
+
+export const getDashboardPathForAccountType = (accountType?: string | null): string => {
+  if (!accountType) return "/profile-review";
+
+  const normalized = accountType.trim().toLowerCase() as AccountTypeValue;
+  return accountTypePaths[normalized] ?? "/profile-review";
 };


### PR DESCRIPTION
## Summary
- reuse the shared Supabase client in the Wathaci auth helpers to avoid configuration crashes and keep sessions aligned
- normalize account type handling and map each role to existing onboarding/assessment routes
- update the legacy login form to derive dashboard destinations from normalized account types and call the shared client

## Testing
- npm test -- --testPathPattern=AuthForm.redirect.test.tsx --runInBand *(fails: missing Supabase/SMTP/test email configuration in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281e51d4e48328b3e66056baec66f3)