### PR TITLE
Improve forgot password flow and add coverage

### DIFF
--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { logSupabaseAuthError } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 import { Button } from '@/components/ui/button';
@@ -395,17 +395,26 @@ export const AuthForm = ({ mode, redirectTo, onSuccess, disabled = false, disabl
       )}
 
       {mode === 'signin' && (
-        <div className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            id="rememberPassword"
-            disabled={isFormDisabled}
-            className="h-4 w-4 rounded border-gray-300"
-            {...register('rememberPassword')}
-          />
-          <Label htmlFor="rememberPassword" className="cursor-pointer text-sm font-normal">
-            Remember my email on this device
-          </Label>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="rememberPassword"
+              disabled={isFormDisabled}
+              className="h-4 w-4 rounded border-gray-300"
+              {...register('rememberPassword')}
+            />
+            <Label htmlFor="rememberPassword" className="cursor-pointer text-sm font-normal">
+              Remember my email on this device
+            </Label>
+          </div>
+
+          <Link
+            to="/forgot-password"
+            className="text-sm font-semibold text-red-600 hover:text-red-700 focus-visible:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2"
+          >
+            Forgot password?
+          </Link>
         </div>
       )}
 

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -608,7 +608,7 @@ export class UserService extends BaseService<User> {
             pathKeys: PASSWORD_RESET_REDIRECT_PATH_KEYS,
           });
 
-          const { error } = await supabase.auth.resetPasswordForEmail(email, {
+          const { error } = await supabase.auth.resetPasswordForEmail(normalizedEmail, {
             ...(emailRedirectTo ? { redirectTo: emailRedirectTo } : {}),
           });
 

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -41,7 +41,8 @@ const ForgotPassword = () => {
     setErrorMessage(null);
 
     try {
-      const { error } = await userService.requestPasswordReset(email);
+      const normalizedEmail = email.trim().toLowerCase();
+      const { error } = await userService.requestPasswordReset(normalizedEmail);
 
       if (error) {
         const message =
@@ -58,7 +59,7 @@ const ForgotPassword = () => {
       setSuccess(true);
       toast({
         title: 'Check your email',
-        description: 'We sent you a link to reset your password.',
+        description: 'If an account exists for that email, we sent reset instructions.',
       });
     } finally {
       setLoading(false);
@@ -84,7 +85,8 @@ const ForgotPassword = () => {
                 <div className="space-y-2">
                   <h2 className="text-xl font-semibold text-gray-900">Reset link sent</h2>
                   <p className="text-gray-600">
-                    Please check your inbox for an email with the next steps. The link will expire shortly for security reasons.
+                    If an account exists for that email, we sent reset instructions. The link will expire shortly for security
+                    reasons.
                   </p>
                 </div>
                 <Button asChild className="w-full">

--- a/src/pages/__tests__/ForgotPassword.test.tsx
+++ b/src/pages/__tests__/ForgotPassword.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ForgotPassword from '../ForgotPassword';
+
+jest.mock('@/lib/services', () => {
+  const mockRequestPasswordReset = jest.fn();
+
+  return {
+    __esModule: true,
+    userService: {
+      requestPasswordReset: mockRequestPasswordReset,
+    },
+  };
+});
+
+jest.mock('@/hooks/use-toast', () => {
+  const mockToast = jest.fn();
+
+  return {
+    __esModule: true,
+    useToast: () => ({ toast: mockToast }),
+    mockToast,
+  };
+});
+
+const mockRequestPasswordReset =
+  (jest.requireMock('@/lib/services') as { userService: { requestPasswordReset: jest.Mock } }).userService
+    .requestPasswordReset;
+const mockToast = (jest.requireMock('@/hooks/use-toast') as { mockToast: jest.Mock }).mockToast;
+
+const renderComponent = () =>
+  render(
+    <MemoryRouter>
+      <ForgotPassword />
+    </MemoryRouter>,
+  );
+
+describe('ForgotPassword', () => {
+  beforeEach(() => {
+    mockRequestPasswordReset.mockReset();
+    mockToast.mockReset();
+  });
+
+  it('shows validation errors when submitting an empty form', async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Email is required')).toBeInTheDocument();
+    });
+  });
+
+  it('rejects an invalid email address', async () => {
+    renderComponent();
+
+    const emailInput = screen.getByLabelText(/email address/i);
+
+    fireEvent.change(emailInput, { target: { value: 'invalid' } });
+    fireEvent.blur(emailInput);
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a valid email address')).toBeInTheDocument();
+    });
+  });
+
+  it('requests a password reset with a normalised email and shows success state', async () => {
+    mockRequestPasswordReset.mockResolvedValue({ data: { success: true }, error: null });
+
+    renderComponent();
+
+    fireEvent.change(screen.getByLabelText(/email address/i), {
+      target: { value: ' TestUser@Example.COM ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/reset link sent/i)).toBeInTheDocument();
+    });
+
+    expect(mockRequestPasswordReset).toHaveBeenCalledWith('testuser@example.com');
+  });
+
+  it('surfaces service errors to the user', async () => {
+    mockRequestPasswordReset.mockResolvedValue({ data: null, error: new Error('Service unavailable') });
+
+    renderComponent();
+
+    fireEvent.change(screen.getByLabelText(/email address/i), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Service unavailable')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/__tests__/ResetPassword.test.tsx
+++ b/src/pages/__tests__/ResetPassword.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ResetPassword from '../ResetPassword';
+
+jest.mock('@/lib/services', () => {
+  const mockGetSessionFromUrl = jest.fn();
+  const mockGetUser = jest.fn();
+  const mockUpdatePassword = jest.fn();
+
+  return {
+    __esModule: true,
+    supabase: {
+      auth: {
+        getSessionFromUrl: mockGetSessionFromUrl,
+        getUser: mockGetUser,
+      },
+    },
+    userService: {
+      updatePassword: mockUpdatePassword,
+    },
+    mockGetSessionFromUrl,
+    mockGetUser,
+    mockUpdatePassword,
+  };
+});
+
+jest.mock('@/hooks/use-toast', () => {
+  const mockToast = jest.fn();
+
+  return {
+    __esModule: true,
+    useToast: () => ({ toast: mockToast }),
+    mockToast,
+  };
+});
+
+const serviceMocks = jest.requireMock('@/lib/services') as {
+  mockGetSessionFromUrl: jest.Mock;
+  mockGetUser: jest.Mock;
+  mockUpdatePassword: jest.Mock;
+};
+const mockGetSessionFromUrl = serviceMocks.mockGetSessionFromUrl;
+const mockGetUser = serviceMocks.mockGetUser;
+const mockUpdatePassword = serviceMocks.mockUpdatePassword;
+const mockToast = (jest.requireMock('@/hooks/use-toast') as { mockToast: jest.Mock }).mockToast;
+
+const renderComponent = () =>
+  render(
+    <MemoryRouter initialEntries={["/reset-password"]}>
+      <ResetPassword />
+    </MemoryRouter>,
+  );
+
+describe('ResetPassword', () => {
+  beforeEach(() => {
+    mockGetSessionFromUrl.mockReset().mockResolvedValue({ data: { session: {} }, error: null });
+    mockGetUser.mockReset().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockUpdatePassword.mockReset().mockResolvedValue({ data: { success: true }, error: null });
+    mockToast.mockReset();
+    window.history.pushState({}, '', '/reset-password#type=recovery');
+  });
+
+  it('validates matching passwords before submitting', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/new password/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/new password/i), { target: { value: 'Password123' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'Mismatch123' } });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+    });
+    expect(mockUpdatePassword).not.toHaveBeenCalled();
+  });
+
+  it('shows an error when the recovery link is invalid', async () => {
+    mockGetSessionFromUrl.mockResolvedValueOnce({ data: null, error: new Error('Invalid token') });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('This password reset link is invalid or has expired. Please request a new one.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('submits a valid password update and shows success', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/new password/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/new password/i), { target: { value: 'Password123' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'Password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+    await waitFor(() => {
+      expect(mockUpdatePassword).toHaveBeenCalledWith('Password123');
+      expect(screen.getByText(/password updated/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows a service error returned from the API', async () => {
+    mockUpdatePassword.mockResolvedValueOnce({ data: null, error: new Error('Reset failed') });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/new password/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/new password/i), { target: { value: 'Password123' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'Password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Reset failed')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an always-visible forgot password link to the sign-in experience
- normalize password reset requests and update messaging for secure handling
- add unit tests for forgot password and reset password flows

## Testing
- npm run test:jest -- src/pages/__tests__/SignIn.test.tsx src/pages/__tests__/ForgotPassword.test.tsx src/pages/__tests__/ResetPassword.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bdc79fac83288b2b1da9d3085138)