### PR TITLE
Temporarily bypass subscription gating for hub pages

### DIFF
--- a/src/features/compliance/ComplianceDashboard.tsx
+++ b/src/features/compliance/ComplianceDashboard.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 import { AddComplianceTaskModal } from './AddComplianceTaskModal';
 import { AddStandardTasksDrawer } from './AddStandardTasksDrawer';
 import { withSupportContact } from '@/lib/supportEmail';
+import { useSubscriptionAccess } from '@/hooks/useSubscriptionAccess';
 
 interface ComplianceTask {
   id: string;
@@ -38,7 +39,11 @@ export const ComplianceDashboard = () => {
   const [loading, setLoading] = useState(true);
   const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
   const [isAddStandardDrawerOpen, setIsAddStandardDrawerOpen] = useState(false);
-  const viewOnly = false;
+  const { isSubscribed } = useSubscriptionAccess('compliance hub');
+
+  // TEMPORARY: subscription gating bypass for Compliance Hub analysis (see subscriptionDebug.ts)
+  // TODO: Reinstate subscription-based viewOnly when analysis is complete.
+  const viewOnly = !isSubscribed;
 
   const ensureInteractive = () => {
     return true;

--- a/src/features/credit-passport/CreditPassportPage.tsx
+++ b/src/features/credit-passport/CreditPassportPage.tsx
@@ -18,6 +18,7 @@ import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { useSubscriptionAccess } from '@/hooks/useSubscriptionAccess';
 import { defaultPassportInputs } from './mockData';
 import { generateCreditPassport, PRICE_POINTS } from './scoring';
 import {
@@ -205,7 +206,11 @@ export const CreditPassportPage = () => {
   const [result, setResult] = useState<CreditPassportResult | null>(null);
   const [history, setHistory] = useState<CreditPassportResult[]>([]);
   const [notes, setNotes] = useState('');
-  const viewOnly = false;
+  const { isSubscribed } = useSubscriptionAccess('credit passport');
+
+  // TEMPORARY: subscription gating bypass for Credit Passport analysis (see subscriptionDebug.ts)
+  // TODO: Restore subscription-gated viewOnly behavior when analysis is complete.
+  const viewOnly = !isSubscribed;
 
   const ensureInteractive = () => {
     return true;

--- a/src/pages/FundingHub.tsx
+++ b/src/pages/FundingHub.tsx
@@ -5,9 +5,14 @@ import { FundingMatcher } from '@/components/funding/FundingMatcher';
 import LiveFundingMatcher from '@/components/funding/LiveFundingMatcher';
 import { AutomatedMatchingEngine } from '@/components/funding/AutomatedMatchingEngine';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useSubscriptionAccess } from '@/hooks/useSubscriptionAccess';
 
 const FundingHub = () => {
-  const sharedProps = { viewOnly: false } as const;
+  const { isSubscribed } = useSubscriptionAccess('funding hub');
+
+  // TEMPORARY: subscription gating bypass for Funding Hub analysis (see subscriptionDebug.ts)
+  // TODO: Restore subscription-gated viewOnly handling when analysis is complete.
+  const sharedProps = { viewOnly: !isSubscribed } as const;
 
   return (
     <AppLayout>


### PR DESCRIPTION
## Summary
- hook Funding Hub, Compliance Hub, and Credit Passport into the subscription debug bypass so they render unlocked during analysis
- document temporary subscription gating overrides with clear TODO comments for re-enabling viewOnly behavior later

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c4eb0dd883289241e6091642f765)