### PR TITLE
Add debugging instrumentation for subscription bypass on key hubs

### DIFF
--- a/src/components/AccessGate.tsx
+++ b/src/components/AccessGate.tsx
@@ -32,6 +32,10 @@ export const AccessGate = ({ children, feature }: AccessGateProps) => {
       SUBSCRIPTION_BYPASS_FEATURES.has(normalizedFeature)
     ) {
       // TEMPORARY: Subscription gating disabled for this feature to allow debugging
+      console.log('[subscription-debug] AccessGate bypass enabled', {
+        feature,
+        pathname: typeof window !== 'undefined' ? window.location.pathname : 'unknown',
+      });
       setHasAccess(true);
       setLoading(false);
       return;
@@ -39,6 +43,11 @@ export const AccessGate = ({ children, feature }: AccessGateProps) => {
 
     try {
       const { data: { user } } = await supabase.auth.getUser();
+      console.log('[subscription-debug] AccessGate subscription check', {
+        feature,
+        pathname: typeof window !== 'undefined' ? window.location.pathname : 'unknown',
+        hasUser: Boolean(user),
+      });
       if (!user) {
         setLoading(false);
         return;

--- a/src/features/compliance/ComplianceDashboard.tsx
+++ b/src/features/compliance/ComplianceDashboard.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 import { AddComplianceTaskModal } from './AddComplianceTaskModal';
 import { AddStandardTasksDrawer } from './AddStandardTasksDrawer';
 import { withSupportContact } from '@/lib/supportEmail';
+import { useSubscriptionAccess } from '@/hooks/useSubscriptionAccess';
 
 interface ComplianceTask {
   id: string;
@@ -39,6 +40,13 @@ export const ComplianceDashboard = () => {
   const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
   const [isAddStandardDrawerOpen, setIsAddStandardDrawerOpen] = useState(false);
   const viewOnly = false;
+
+  // TEMPORARY: Trace subscription gating status for Compliance Hub
+  const subscriptionState = useSubscriptionAccess('compliance-hub');
+
+  useEffect(() => {
+    console.log('[subscription-debug] Compliance Hub access', subscriptionState);
+  }, [subscriptionState]);
 
   const ensureInteractive = () => {
     return true;

--- a/src/features/credit-passport/CreditPassportPage.tsx
+++ b/src/features/credit-passport/CreditPassportPage.tsx
@@ -26,6 +26,7 @@ import {
   MonetizationState,
   PaymentAction,
 } from './types';
+import { useSubscriptionAccess } from '@/hooks/useSubscriptionAccess';
 
 const PaymentGrid = ({
   actions,
@@ -206,6 +207,13 @@ export const CreditPassportPage = () => {
   const [history, setHistory] = useState<CreditPassportResult[]>([]);
   const [notes, setNotes] = useState('');
   const viewOnly = false;
+  
+  // TEMPORARY: Trace subscription gating status for Credit Passport
+  const subscriptionState = useSubscriptionAccess('credit-passport');
+
+  useEffect(() => {
+    console.log('[subscription-debug] Credit Passport access', subscriptionState);
+  }, [subscriptionState]);
 
   const ensureInteractive = () => {
     return true;

--- a/src/hooks/useSubscriptionAccess.ts
+++ b/src/hooks/useSubscriptionAccess.ts
@@ -31,6 +31,10 @@ export const useSubscriptionAccess = (featureKey?: string): SubscriptionAccessSt
     const checkSubscription = async () => {
       if (bypassActive) {
         // TEMPORARY: Treat target features as subscribed for analysis
+        console.log('[subscription-debug] Bypass active for feature', {
+          featureKey,
+          pathname: typeof window !== 'undefined' ? window.location.pathname : 'unknown',
+        });
         setState({
           isSubscribed: true,
           isAuthenticated: Boolean(user),
@@ -40,6 +44,10 @@ export const useSubscriptionAccess = (featureKey?: string): SubscriptionAccessSt
       }
 
       if (!user) {
+        console.log('[subscription-debug] No user while checking subscription', {
+          featureKey,
+          pathname: typeof window !== 'undefined' ? window.location.pathname : 'unknown',
+        });
         if (isMounted) {
           setState({ isSubscribed: false, isAuthenticated: false, loading: false });
         }
@@ -48,6 +56,13 @@ export const useSubscriptionAccess = (featureKey?: string): SubscriptionAccessSt
 
       const { data, error } = await subscriptionService.hasActiveSubscription(user.id);
       if (!isMounted) return;
+
+      console.log('[subscription-debug] Subscription lookup complete', {
+        featureKey,
+        hasActiveSubscription: !!data && !error,
+        error,
+        pathname: typeof window !== 'undefined' ? window.location.pathname : 'unknown',
+      });
 
       setState({
         isSubscribed: !!data && !error,

--- a/src/pages/FundingHub.tsx
+++ b/src/pages/FundingHub.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AppLayout } from '@/components/AppLayout';
 import { FundingHub as FundingHubComponent } from '@/components/funding/FundingHub';
 import { FundingMatcher } from '@/components/funding/FundingMatcher';
 import LiveFundingMatcher from '@/components/funding/LiveFundingMatcher';
 import { AutomatedMatchingEngine } from '@/components/funding/AutomatedMatchingEngine';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useSubscriptionAccess } from '@/hooks/useSubscriptionAccess';
 
 const FundingHub = () => {
+  // TEMPORARY: Trace subscription gating status for Funding Hub
+  const subscriptionState = useSubscriptionAccess('funding-hub');
+
+  useEffect(() => {
+    console.log('[subscription-debug] Funding Hub access', subscriptionState);
+  }, [subscriptionState]);
+
   const sharedProps = { viewOnly: false } as const;
 
   return (


### PR DESCRIPTION
## Summary
- add runtime logging in subscription access hook and AccessGate to confirm bypass behavior
- instrument Funding Hub, Compliance Hub, and Credit Passport pages to trace subscription state during bypass verification

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c6430b248328a5852e7883f57cdc)