### PR TITLE
Temporarily disable subscription requirements for onboarding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,9 @@ const GovernmentAssessment = lazy(() =>
 );
 const DocumentGenerators = lazy(() => import("./pages/DocumentGenerators"));
 const CreditPassport = lazy(() => import("./pages/CreditPassport"));
+const OnboardingLanding = lazy(() =>
+  import("./pages/OnboardingLanding").then((module) => ({ default: module.OnboardingLanding }))
+);
 
 // Onboarding pages
 const SmeNeedsAssessmentPage = lazy(() =>
@@ -166,6 +169,7 @@ export const AppRoutes = () => (
       <Route path="/forgot-password" element={withAppLayout(<ForgotPassword />, { showFooter: false })} />
       <Route path="/reset-password" element={withAppLayout(<ResetPassword />, { showFooter: false })} />
       <Route path="/get-started" element={withAppLayout(<GetStartedPage />)} />
+      <Route path="/onboarding" element={withAppLayout(<OnboardingLanding />, { showFooter: false })} />
       <Route path="/profile-setup" element={withAppLayout(<ProfileSetup />, { showFooter: false })} />
       <Route path="/profile-review" element={withAppLayout(<ProfileReview />, { showFooter: false })} />
       <Route path="/subscription-plans" element={withAppLayout(<SubscriptionPlans />)} />

--- a/src/components/AccessGate.tsx
+++ b/src/components/AccessGate.tsx
@@ -9,6 +9,7 @@ import {
   SUBSCRIPTION_DEBUG_BYPASS_ENABLED,
 } from '@/config/subscriptionDebug';
 import { useNavigate } from 'react-router-dom';
+import { isSubscriptionTemporarilyDisabled } from '@/lib/subscriptionWindow';
 
 interface AccessGateProps {
   children: React.ReactNode;
@@ -24,6 +25,12 @@ export const AccessGate = ({ children, feature }: AccessGateProps) => {
   useEffect(() => {
     const checkAccess = async () => {
       const normalizedFeature = feature.toLowerCase();
+
+      if (isSubscriptionTemporarilyDisabled()) {
+        setHasAccess(true);
+        setLoading(false);
+        return;
+      }
 
       if (
         SUBSCRIPTION_DEBUG_BYPASS_ENABLED &&

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -28,10 +28,16 @@ const HeroSection = () => {
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-600 to-green-600"> Business Excellence</span>
           </h1>
           <p className="text-xl text-gray-600 mb-8 max-w-3xl mx-auto leading-relaxed">
-            Connect with professional services, find skilled freelancers, and access resources 
+            Connect with professional services, find skilled freelancers, and access resources
             designed specifically for Zambian businesses. Your gateway to growth and success.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link to="/onboarding">
+              <Button size="lg" className="bg-gradient-to-r from-emerald-600 to-emerald-700 hover:from-emerald-700 hover:to-emerald-800 text-white px-8 py-3 text-lg">
+                Join the Founding Cohort – Create Your Profile
+                <ArrowRight className="ml-2 w-5 h-5" />
+              </Button>
+            </Link>
             <Link to="/get-started">
               <Button size="lg" className="bg-gradient-to-r from-orange-600 to-orange-700 hover:from-orange-700 hover:to-orange-800 text-white px-8 py-3 text-lg">
                 Get Started Today

--- a/src/components/OnboardingGraceBanner.tsx
+++ b/src/components/OnboardingGraceBanner.tsx
@@ -1,0 +1,31 @@
+import { Megaphone } from 'lucide-react';
+import {
+  getSubscriptionGraceBannerText,
+  getSubscriptionGraceFollowUpText,
+} from '@/lib/subscriptionWindow';
+import { cn } from '@/lib/utils';
+
+interface OnboardingGraceBannerProps {
+  className?: string;
+}
+
+export const OnboardingGraceBanner = ({ className }: OnboardingGraceBannerProps) => {
+  return (
+    <div
+      className={cn(
+        'mb-6 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900 shadow-sm',
+        className
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <Megaphone className="mt-0.5 h-4 w-4 text-emerald-600" aria-hidden="true" />
+        <div className="space-y-1">
+          <p className="font-semibold">{getSubscriptionGraceBannerText()}</p>
+          <p className="text-emerald-800/90">{getSubscriptionGraceFollowUpText()}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OnboardingGraceBanner;

--- a/src/hooks/useSubscriptionAccess.ts
+++ b/src/hooks/useSubscriptionAccess.ts
@@ -5,6 +5,7 @@ import {
   SUBSCRIPTION_BYPASS_FEATURES,
   SUBSCRIPTION_DEBUG_BYPASS_ENABLED,
 } from '@/config/subscriptionDebug';
+import { isSubscriptionTemporarilyDisabled } from '@/lib/subscriptionWindow';
 
 interface SubscriptionAccessState {
   isSubscribed: boolean;
@@ -29,6 +30,15 @@ export const useSubscriptionAccess = (featureKey?: string): SubscriptionAccessSt
     let isMounted = true;
 
     const checkSubscription = async () => {
+      if (isSubscriptionTemporarilyDisabled()) {
+        setState({
+          isSubscribed: true,
+          isAuthenticated: Boolean(user),
+          loading: false,
+        });
+        return;
+      }
+
       if (bypassActive) {
         // TEMPORARY: Treat target features as subscribed for analysis
         setState({

--- a/src/lib/services/subscription-service.ts
+++ b/src/lib/services/subscription-service.ts
@@ -6,6 +6,7 @@ import { BaseService } from './base-service';
 import { supabase, withErrorHandling } from '@/lib/supabase-enhanced';
 import { lencoPaymentService } from './lenco-payment-service';
 import { logger } from '../logger';
+import { isSubscriptionTemporarilyDisabled } from '@/lib/subscriptionWindow';
 import type { 
   SubscriptionPlan, 
   UserSubscription, 
@@ -664,6 +665,10 @@ export class SubscriptionService extends BaseService<UserSubscription> {
   }
 
   async hasActiveSubscription(userId: string): Promise<DatabaseResponse<boolean>> {
+    if (isSubscriptionTemporarilyDisabled()) {
+      return { data: true, error: null };
+    }
+
     return withErrorHandling(
       async () => {
         const { data, error } = await supabase
@@ -708,6 +713,10 @@ export class SubscriptionService extends BaseService<UserSubscription> {
   }
 
   async hasFeatureAccess(userId: string, feature: string): Promise<DatabaseResponse<boolean>> {
+    if (isSubscriptionTemporarilyDisabled()) {
+      return { data: true, error: null };
+    }
+
     return withErrorHandling(
       async () => {
         const { data: features, error } = await this.getUserSubscriptionFeatures(userId);

--- a/src/lib/subscriptionWindow.ts
+++ b/src/lib/subscriptionWindow.ts
@@ -1,0 +1,21 @@
+const GRACE_CUTOFF_ISO = '2026-01-04T23:59:59+02:00';
+const GRACE_LABEL = '4 January 2026 (Africa/Lusaka)';
+
+export const SUBSCRIPTION_GRACE_CUTOFF = GRACE_CUTOFF_ISO;
+export const SUBSCRIPTION_GRACE_LABEL = GRACE_LABEL;
+
+export function getSubscriptionGraceCutoffDate(): Date {
+  return new Date(SUBSCRIPTION_GRACE_CUTOFF);
+}
+
+export function isSubscriptionTemporarilyDisabled(currentDate: Date = new Date()): boolean {
+  return currentDate <= getSubscriptionGraceCutoffDate();
+}
+
+export function getSubscriptionGraceBannerText(): string {
+  return `Free access: Subscription requirements are temporarily disabled until ${SUBSCRIPTION_GRACE_LABEL}. Create your WATHACI Connect profile now.`;
+}
+
+export function getSubscriptionGraceFollowUpText(): string {
+  return `Offer valid until ${SUBSCRIPTION_GRACE_LABEL}.`;
+}

--- a/src/pages/OnboardingLanding.tsx
+++ b/src/pages/OnboardingLanding.tsx
@@ -1,0 +1,117 @@
+import { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import AppLayout from '@/components/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useSupabaseAuth } from '@/hooks/useSupabaseAuth';
+import { useAppContext } from '@/contexts/AppContext';
+import { Loader2, Sparkles } from 'lucide-react';
+import OnboardingGraceBanner from '@/components/OnboardingGraceBanner';
+import { SUBSCRIPTION_GRACE_LABEL } from '@/lib/subscriptionWindow';
+
+const accountTypeRoutes: Record<string, string> = {
+  sme: '/onboarding/sme',
+  professional: '/onboarding/professional',
+  investor: '/onboarding/investor',
+  donor: '/onboarding/investor',
+  government: '/onboarding/government/needs-assessment',
+};
+
+export const OnboardingLanding = () => {
+  const navigate = useNavigate();
+  const { user: supabaseUser, loading } = useSupabaseAuth();
+  const { profile } = useAppContext();
+
+  const accountType = profile?.account_type || (supabaseUser?.user_metadata as any)?.account_type;
+
+  useEffect(() => {
+    if (loading) return;
+    if (!supabaseUser) return;
+
+    if (accountType && accountTypeRoutes[accountType]) {
+      navigate(accountTypeRoutes[accountType], { replace: true });
+      return;
+    }
+
+    navigate('/get-started', { replace: true });
+  }, [accountType, loading, navigate, supabaseUser]);
+
+  if (loading) {
+    return (
+      <AppLayout showFooter={false}>
+        <div className="flex min-h-[60vh] items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-primary" />
+        </div>
+      </AppLayout>
+    );
+  }
+
+  if (supabaseUser) {
+    return null;
+  }
+
+  return (
+    <AppLayout showFooter={false}>
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-orange-50 via-white to-emerald-50" aria-hidden="true" />
+        <div className="relative z-10 mx-auto max-w-5xl px-6 py-16">
+          <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
+            <div className="max-w-2xl">
+              <div className="inline-flex items-center gap-2 rounded-full bg-orange-100 px-3 py-1 text-sm font-semibold text-orange-800">
+                <Sparkles className="h-4 w-4" aria-hidden="true" />
+                Founding cohort free access
+              </div>
+              <h1 className="mt-6 text-4xl font-bold text-gray-900 md:text-5xl">
+                Start your WATHACI Connect onboarding
+              </h1>
+              <p className="mt-4 text-lg text-gray-700">
+                Create your account and profile without a subscription until {SUBSCRIPTION_GRACE_LABEL}.
+                Use this link to invite peers from LinkedIn, email, or anywhere else and bring them
+                straight into onboarding.
+              </p>
+              <div className="mt-6">
+                <OnboardingGraceBanner className="mb-0" />
+              </div>
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+                <Button asChild size="lg" className="bg-gradient-to-r from-emerald-600 to-emerald-700 text-white shadow-lg">
+                  <Link to="/signup">Create your free account</Link>
+                </Button>
+                <Button asChild variant="outline" size="lg" className="border-2">
+                  <Link to="/signin">Already have an account? Sign in</Link>
+                </Button>
+              </div>
+              <p className="mt-3 text-sm text-gray-600">
+                Sharing this page will guide new users to sign up and go directly into the onboarding flow.
+              </p>
+            </div>
+
+            <Card className="w-full max-w-md border-emerald-100 shadow-lg shadow-emerald-100">
+              <CardHeader>
+                <CardTitle>What to expect</CardTitle>
+                <CardDescription>
+                  Complete your profile now while subscription requirements are paused.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-gray-700">
+                <div>
+                  <p className="font-semibold text-gray-900">1. Create your account</p>
+                  <p className="text-sm">Sign up with your work email to save your progress.</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-gray-900">2. Tell us about yourself</p>
+                  <p className="text-sm">Share your role, expertise, or organisation details.</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-gray-900">3. Launch your profile</p>
+                  <p className="text-sm">Get matched to opportunities without any paywall until {SUBSCRIPTION_GRACE_LABEL}.</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default OnboardingLanding;

--- a/src/pages/onboarding/DonorNeedsAssessmentPage.tsx
+++ b/src/pages/onboarding/DonorNeedsAssessmentPage.tsx
@@ -14,6 +14,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { upsertProfile, saveDonorNeedsAssessment } from '@/lib/onboarding';
 import { ArrowLeft, ArrowRight, CheckCircle } from 'lucide-react';
+import OnboardingGraceBanner from '@/components/OnboardingGraceBanner';
 
 const donorAssessmentSchema = z.object({
   organization_name: z.string().min(2, 'Organization name is required'),
@@ -180,6 +181,8 @@ export const DonorNeedsAssessmentPage = () => {
             <h1 className="text-3xl font-bold text-gray-900 mb-2">Donor Profile</h1>
             <p className="text-gray-600">Tell us about your funding priorities</p>
           </div>
+
+          <OnboardingGraceBanner />
 
           <Progress value={progress} className="mb-4" />
           <p className="text-sm text-gray-600 text-center">Step {currentStep} of {totalSteps}</p>

--- a/src/pages/onboarding/InvestorNeedsAssessmentPage.tsx
+++ b/src/pages/onboarding/InvestorNeedsAssessmentPage.tsx
@@ -14,6 +14,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { upsertProfile, saveInvestorNeedsAssessment } from '@/lib/onboarding';
 import { ArrowLeft, ArrowRight, CheckCircle } from 'lucide-react';
+import OnboardingGraceBanner from '@/components/OnboardingGraceBanner';
 
 const investorAssessmentSchema = z.object({
   organization_name: z.string().min(2, 'Name/Organization is required'),
@@ -201,6 +202,8 @@ export const InvestorNeedsAssessmentPage = () => {
             <h1 className="text-3xl font-bold text-gray-900 mb-2">Investor Profile</h1>
             <p className="text-gray-600">Tell us about your investment preferences</p>
           </div>
+
+          <OnboardingGraceBanner />
 
           <Progress value={progress} className="mb-4" />
           <p className="text-sm text-gray-600 text-center">Step {currentStep} of {totalSteps}</p>

--- a/src/pages/onboarding/InvestorOnboardingPage.tsx
+++ b/src/pages/onboarding/InvestorOnboardingPage.tsx
@@ -13,6 +13,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import { getInvestorProfile, upsertInvestorProfile, uploadProfileMedia } from '@/lib/api/profile-onboarding';
 import { ArrowLeft, Loader2, Upload, Check } from 'lucide-react';
 import { supabaseClient } from '@/lib/supabaseClient';
+import OnboardingGraceBanner from '@/components/OnboardingGraceBanner';
 
 const investorTypes = ['Angel', 'VC', 'Bank', 'Donor', 'Foundation', 'Development Finance'];
 const sectors = ['Agriculture', 'Retail', 'Manufacturing', 'Tech & Digital', 'Healthcare', 'Education', 'Logistics'];
@@ -177,6 +178,8 @@ export const InvestorOnboardingPage = () => {
           <h1 className="text-3xl font-bold text-gray-900 mb-2">Complete your Investor/Donor Profile</h1>
           <p className="text-gray-700">Tell us about your mandate so we can match you with the right opportunities.</p>
         </div>
+
+        <OnboardingGraceBanner />
 
         <form onSubmit={handleSubmit((values) => onSubmit(values, false))} className="space-y-6">
           <Card>

--- a/src/pages/onboarding/ProfessionalNeedsAssessmentPage.tsx
+++ b/src/pages/onboarding/ProfessionalNeedsAssessmentPage.tsx
@@ -15,6 +15,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import { upsertProfile, saveProfessionalNeedsAssessment } from '@/lib/onboarding';
 import { getProfessionalProfile } from '@/lib/api/profile-onboarding';
 import { ArrowLeft, ArrowRight, CheckCircle } from 'lucide-react';
+import OnboardingGraceBanner from '@/components/OnboardingGraceBanner';
 
 const professionalAssessmentSchema = z.object({
   full_name: z.string().min(2, 'Full name is required'),
@@ -182,6 +183,8 @@ export const ProfessionalNeedsAssessmentPage = () => {
             <h1 className="text-3xl font-bold text-gray-900 mb-2">Professional Profile</h1>
             <p className="text-gray-600">Tell us about your expertise</p>
           </div>
+
+          <OnboardingGraceBanner />
 
           <Progress value={progress} className="mb-4" />
           <p className="text-sm text-gray-600 text-center">Step {currentStep} of {totalSteps}</p>

--- a/src/pages/onboarding/ProfessionalOnboardingPage.tsx
+++ b/src/pages/onboarding/ProfessionalOnboardingPage.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/lib/api/profile-onboarding';
 import { supabaseClient } from '@/lib/supabaseClient';
 import { ArrowLeft, ArrowRight, Check, Loader2, Upload } from 'lucide-react';
+import OnboardingGraceBanner from '@/components/OnboardingGraceBanner';
 
 const primaryExpertiseOptions = [
   'Financial Modelling',
@@ -384,6 +385,8 @@ export const ProfessionalOnboardingPage = () => {
             This helps SMEs and partners understand your expertise and how to work with you.
           </p>
         </div>
+
+        <OnboardingGraceBanner />
 
         <div className="mb-6 space-y-2">
           <Progress value={progress} />

--- a/src/pages/onboarding/SmeNeedsAssessmentPage.tsx
+++ b/src/pages/onboarding/SmeNeedsAssessmentPage.tsx
@@ -14,6 +14,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { upsertProfile, saveSmeNeedsAssessment } from '@/lib/onboarding';
 import { ArrowLeft, ArrowRight, CheckCircle } from 'lucide-react';
+import OnboardingGraceBanner from '@/components/OnboardingGraceBanner';
 
 // Validation schema
 const smeAssessmentSchema = z.object({
@@ -223,6 +224,8 @@ export const SmeNeedsAssessmentPage = () => {
             <h1 className="text-3xl font-bold text-gray-900 mb-2">SME Needs Assessment</h1>
             <p className="text-gray-600">Help us understand your business needs</p>
           </div>
+
+          <OnboardingGraceBanner />
 
           <Progress value={progress} className="mb-4" />
           <p className="text-sm text-gray-600 text-center">Step {currentStep} of {totalSteps}</p>

--- a/src/pages/onboarding/SmeOnboardingPage.tsx
+++ b/src/pages/onboarding/SmeOnboardingPage.tsx
@@ -14,6 +14,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import { getSmeProfile, upsertSmeProfile, uploadProfileMedia } from '@/lib/api/profile-onboarding';
 import { ArrowLeft, Loader2, Upload, Check } from 'lucide-react';
 import { supabaseClient } from '@/lib/supabaseClient';
+import OnboardingGraceBanner from '@/components/OnboardingGraceBanner';
 
 const challenges = [
   'Access to finance',
@@ -208,6 +209,8 @@ export const SmeOnboardingPage = () => {
           <h1 className="text-3xl font-bold text-gray-900 mb-2">Complete your SME Profile</h1>
           <p className="text-gray-700">Share your business details to unlock tailored support and services.</p>
         </div>
+
+        <OnboardingGraceBanner />
 
         <form onSubmit={handleSubmit((values) => onSubmit(values, false))} className="space-y-6">
           <Card>


### PR DESCRIPTION
## Summary
- add a shared subscription grace-period helper to bypass subscription enforcement during the temporary window
- update subscription checks and onboarding UI to honor the grace period and highlight free access messaging
- add a shareable onboarding entry route and homepage CTA that sends users directly into profile creation

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea2b3881c8328a3a84f3599797b29)