### PR TITLE
Add onboarding and payments agent orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,24 @@ This interactive script will:
 - Validate the configuration
 - Provide testing instructions
 
+## AI Onboarding & Payments Agent (Ciso)
+
+The Ciso agent orchestrates end-to-end signup, profile completion, and payments via dedicated API routes exposed by the Express backend:
+
+- **Signup:** `POST /api/agent/signup` – validates credentials, creates Supabase auth users, seeds profile rows, and logs correlation IDs to `agent_logs`.
+- **Signin:** `POST /api/agent/signin` – wraps Supabase password auth with consistent logging and error responses.
+- **Profile:** `GET/PUT /api/agent/profile` – fetch and update profile states with status transitions (`incomplete`, `pending_verification`, `active`).
+- **Checkout:** `POST /api/agent/payments/checkout` – records payments, calls the pluggable payment provider (Lenco placeholder), and returns checkout URLs.
+- **Webhook:** `POST /api/agent/payments/webhook` – idempotently updates payments/subscriptions and logs every event.
+
+Schema guardrails live in `supabase/migrations/20260101090000_onboarding_payments_agent.sql`, which ensures agent tables (`agent_logs`, `payments`, `subscriptions`) and profile status columns exist. Apply migrations with `npm run supabase:push` after deploying code changes.
+
+### Extending the agent
+
+- **Add a payment provider:** Implement `PaymentProvider` and wire it into `WathaciOnboardingAgent` (see `backend/services/payment-provider.js`).
+- **Introduce new plans:** Update plan codes or defaults in environment variables (`DEFAULT_PLAN_CODE`, `DEFAULT_PLAN_AMOUNT`) and reuse the checkout endpoint.
+- **Debug failures:** Check `agent_logs` for every signup, profile update, or payment webhook. Errors are never silent and return structured `{ code, error, details }` payloads to the frontend hooks under `src/hooks/useOnboardingAgent.ts`.
+
 For manual rotation or troubleshooting, see the [Lenco Keys Rotation Guide](docs/LENCO_KEYS_ROTATION_GUIDE.md).
 
 Key steps:

--- a/backend/index.js
+++ b/backend/index.js
@@ -84,6 +84,7 @@ const healthRoutes = require('./routes/health');
 const auditRoutes = require('./routes/audit');
 const diagnosticsRoutes = require('./routes/diagnostics');
 const creditPassportRoutes = require('./routes/credit-passports');
+const agentRoutes = require('./routes/agent');
 
 // Health check endpoint
 app.use(['/health', '/api/health'], healthRoutes);
@@ -120,6 +121,7 @@ app.use('/api/email', emailRoutes);
 app.use('/api/audit', auditRoutes);
 app.use('/api/diagnostics', diagnosticsRoutes);
 app.use('/api/credit-passports', creditPassportRoutes);
+app.use('/api/agent', agentRoutes);
 
 
 // Global error handler

--- a/backend/routes/agent.js
+++ b/backend/routes/agent.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const { WathaciOnboardingAgent, AgentError } = require('../services/wathaci-agent');
+
+const router = express.Router();
+const agent = new WathaciOnboardingAgent();
+
+const asyncHandler = (handler) => async (req, res) => {
+  try {
+    await handler(req, res);
+  } catch (error) {
+    console.error('[AgentRouteError]', error);
+    if (error instanceof AgentError) {
+      res.status(error.status || 400).json({ code: error.code, error: error.message, details: error.details });
+      return;
+    }
+    res.status(500).json({ code: 'INTERNAL_ERROR', error: 'Unexpected error occurred', details: error?.message });
+  }
+};
+
+router.post('/signup', asyncHandler(async (req, res) => {
+  const result = await agent.signup(req.body || {});
+  res.status(201).json(result);
+}));
+
+router.post('/signin', asyncHandler(async (req, res) => {
+  const result = await agent.signin(req.body || {});
+  res.status(200).json(result);
+}));
+
+router.get('/profile', asyncHandler(async (req, res) => {
+  const userId = req.query.userId || req.header('x-user-id');
+  const profile = await agent.getProfile(userId);
+  res.status(200).json(profile);
+}));
+
+router.put('/profile', asyncHandler(async (req, res) => {
+  const { userId, updates } = req.body || {};
+  const profile = await agent.updateProfile(userId, updates || {});
+  res.status(200).json(profile);
+}));
+
+router.post('/payments/checkout', asyncHandler(async (req, res) => {
+  const { userId, ...payload } = req.body || {};
+  const checkout = await agent.initiateCheckout(userId, payload);
+  res.status(200).json(checkout);
+}));
+
+router.post('/payments/webhook', asyncHandler(async (req, res) => {
+  await agent.handleWebhook(req.body || {});
+  res.status(200).json({ received: true });
+}));
+
+module.exports = router;

--- a/backend/services/payment-provider.js
+++ b/backend/services/payment-provider.js
@@ -1,0 +1,66 @@
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * Payment provider abstraction to keep gateways pluggable.
+ */
+class PaymentProvider {
+  constructor(name = 'unknown') {
+    this.name = name;
+  }
+
+  /**
+   * Initiate a checkout session.
+   * @param {{ amount: number; currency: string; reference: string; metadata?: Record<string, unknown> }} params
+   * @returns {Promise<{ checkoutUrl: string; providerPaymentId: string; rawResponse?: unknown }>}
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async createCheckout(params) {
+    throw new Error('createCheckout not implemented');
+  }
+
+  /**
+   * Verify a webhook payload and return normalized event data.
+   * @param {object} payload
+   * @returns {Promise<{ providerPaymentId: string; status: 'succeeded' | 'failed' | 'pending'; metadata?: Record<string, unknown> }>}
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async parseWebhook(payload) {
+    throw new Error('parseWebhook not implemented');
+  }
+}
+
+/**
+ * Lightweight placeholder implementation for Lenco until full gateway SDK is wired.
+ */
+class LencoPaymentProvider extends PaymentProvider {
+  constructor() {
+    super('lenco');
+  }
+
+  async createCheckout(params) {
+    const providerPaymentId = uuidv4();
+    const checkoutUrl = `${process.env.LENCO_CHECKOUT_BASE_URL || 'https://pay.lenco.example/checkout'}/${providerPaymentId}`;
+    return {
+      checkoutUrl,
+      providerPaymentId,
+      rawResponse: {
+        simulated: true,
+        params,
+      },
+    };
+  }
+
+  async parseWebhook(payload) {
+    const status = payload?.status === 'success' ? 'succeeded' : payload?.status === 'failed' ? 'failed' : 'pending';
+    return {
+      providerPaymentId: payload?.provider_payment_id || payload?.reference || payload?.id,
+      status,
+      metadata: payload || {},
+    };
+  }
+}
+
+module.exports = {
+  PaymentProvider,
+  LencoPaymentProvider,
+};

--- a/backend/services/wathaci-agent.js
+++ b/backend/services/wathaci-agent.js
@@ -1,0 +1,380 @@
+const { v4: uuidv4 } = require('uuid');
+const { getSupabaseClient, isSupabaseConfigured } = require('../lib/supabaseAdmin');
+const { LencoPaymentProvider } = require('./payment-provider');
+
+class AgentError extends Error {
+  constructor(message, code = 'AGENT_ERROR', status = 400, details) {
+    super(message);
+    this.code = code;
+    this.status = status;
+    this.details = details;
+  }
+}
+
+const normalizeAccountType = (value = '') => value?.toString()?.toUpperCase() || 'SME';
+
+const isGracePeriodActive = () => {
+  const graceDeadline = process.env.GRACE_PERIOD_END_DATE;
+  if (!graceDeadline) return true;
+  return new Date(graceDeadline).getTime() >= Date.now();
+};
+
+class WathaciOnboardingAgent {
+  constructor(options = {}) {
+    this.supabase = getSupabaseClient();
+    this.paymentProvider = options.paymentProvider || new LencoPaymentProvider();
+
+    if (!isSupabaseConfigured()) {
+      console.warn('[WathaciOnboardingAgent] Supabase is not configured. Agent operations will fail.');
+    }
+  }
+
+  async logEvent(entry) {
+    if (!isSupabaseConfigured()) {
+      console.error('[AgentLog]', entry);
+      return;
+    }
+
+    const payload = {
+      id: entry.id || uuidv4(),
+      user_id: entry.userId || entry.user_id || null,
+      event_type: entry.eventType,
+      payload: entry.payload || null,
+      status: entry.status || 'info',
+      message: entry.message,
+    };
+
+    const { error } = await this.supabase.from('agent_logs').insert(payload);
+    if (error) {
+      console.error('[AgentLog] Failed to persist log', error);
+    }
+  }
+
+  ensureConfigured() {
+    if (!isSupabaseConfigured()) {
+      throw new AgentError('Supabase is not configured', 'SUPABASE_NOT_CONFIGURED', 500);
+    }
+  }
+
+  async signup({ email, password, account_type, profile = {} }) {
+    this.ensureConfigured();
+
+    if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+      throw new AgentError('Invalid email format', 'INVALID_INPUT', 400, { field: 'email' });
+    }
+
+    if (!password || password.length < 6) {
+      throw new AgentError('Password must be at least 6 characters', 'INVALID_INPUT', 400, { field: 'password' });
+    }
+
+    const accountType = normalizeAccountType(account_type);
+    const correlationId = uuidv4();
+
+    try {
+      const { data, error } = await this.supabase.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+      });
+
+      if (error || !data?.user) {
+        throw new AgentError(error?.message || 'Failed to create auth user', 'AUTH_CREATE_FAILED', 500, error);
+      }
+
+      const userId = data.user.id;
+
+      const profilePayload = {
+        id: userId,
+        user_id: userId,
+        email,
+        account_type: accountType,
+        status: 'incomplete',
+        profile_completed: false,
+        ...profile,
+      };
+
+      const { error: profileError } = await this.supabase
+        .from('profiles')
+        .upsert(profilePayload, { onConflict: 'id' });
+
+      if (profileError) {
+        await this.supabase.auth.admin.deleteUser(userId);
+        throw new AgentError('Failed to create profile', 'PROFILE_CREATE_FAILED', 500, profileError);
+      }
+
+      let subscriptionRecord = null;
+      if (isGracePeriodActive()) {
+        const { data: subscriptionData, error: subscriptionError } = await this.supabase
+          .from('subscriptions')
+          .insert({
+            user_id: userId,
+            plan_code: process.env.DEFAULT_PLAN_CODE || 'FREE_TRIAL',
+            status: 'grace_period',
+            valid_from: new Date().toISOString(),
+            valid_to: null,
+            metadata: { correlationId },
+          })
+          .select()
+          .single();
+
+        if (subscriptionError) {
+          await this.logEvent({
+            userId,
+            eventType: 'subscription_create',
+            status: 'warning',
+            message: 'Failed to attach grace period subscription',
+            payload: { subscriptionError },
+          });
+        } else {
+          subscriptionRecord = subscriptionData;
+        }
+      }
+
+      await this.logEvent({
+        userId,
+        eventType: 'signup',
+        status: 'info',
+        message: 'User signed up via onboarding agent',
+        payload: { correlationId, accountType },
+      });
+
+      return {
+        userId,
+        profileId: userId,
+        subscription: subscriptionRecord,
+        nextStep: '/onboarding',
+      };
+    } catch (error) {
+      await this.logEvent({
+        eventType: 'signup',
+        status: 'error',
+        message: error.message,
+        payload: { code: error.code, details: error.details },
+      });
+      if (error instanceof AgentError) {
+        throw error;
+      }
+      throw new AgentError('Unable to complete signup', 'SIGNUP_FAILED', 500, error);
+    }
+  }
+
+  async signin({ email, password }) {
+    this.ensureConfigured();
+    if (!email || !password) {
+      throw new AgentError('Email and password are required', 'INVALID_INPUT', 400);
+    }
+
+    const { data, error } = await this.supabase.auth.signInWithPassword({ email, password });
+    if (error || !data?.session) {
+      await this.logEvent({ eventType: 'signin', status: 'error', message: error?.message || 'Invalid credentials' });
+      throw new AgentError('Invalid credentials', 'AUTH_FAILED', 401, error);
+    }
+
+    await this.logEvent({ userId: data.user?.id, eventType: 'signin', status: 'info', message: 'User signed in' });
+    return { session: data.session, user: data.user };
+  }
+
+  async getProfile(userId) {
+    this.ensureConfigured();
+    if (!userId) throw new AgentError('userId is required', 'INVALID_INPUT', 400);
+    const { data, error } = await this.supabase
+      .from('profiles')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+
+    if (error) {
+      throw new AgentError('Profile not found', 'PROFILE_NOT_FOUND', 404, error);
+    }
+
+    return data;
+  }
+
+  async updateProfile(userId, updates = {}) {
+    this.ensureConfigured();
+    if (!userId) throw new AgentError('userId is required', 'INVALID_INPUT', 400);
+
+    const requiredFields = ['full_name', 'phone'];
+    const missingRequired = requiredFields.filter((field) => updates[field] === undefined || updates[field] === null);
+
+    const status = missingRequired.length === 0 ? 'active' : 'pending_verification';
+    const profileUpdate = {
+      ...updates,
+      status,
+      profile_completed: missingRequired.length === 0,
+      updated_at: new Date().toISOString(),
+    };
+
+    const { data, error } = await this.supabase
+      .from('profiles')
+      .update(profileUpdate)
+      .eq('user_id', userId)
+      .select()
+      .single();
+
+    if (error) {
+      await this.logEvent({
+        userId,
+        eventType: 'profile_update',
+        status: 'error',
+        message: 'Profile update failed',
+        payload: { error },
+      });
+      throw new AgentError('Profile update failed', 'PROFILE_UPDATE_FAILED', 500, error);
+    }
+
+    await this.logEvent({ userId, eventType: 'profile_update', status: 'info', message: 'Profile updated' });
+    return data;
+  }
+
+  async initiateCheckout(userId, { plan_code, amount, currency = 'ZMW', type = 'subscription', metadata = {} }) {
+    this.ensureConfigured();
+    if (!userId) throw new AgentError('userId is required', 'INVALID_INPUT', 400);
+
+    const reference = uuidv4();
+    const normalizedAmount = amount ?? Number(process.env.DEFAULT_PLAN_AMOUNT || 0);
+    if (!normalizedAmount || Number.isNaN(normalizedAmount)) {
+      throw new AgentError('Amount is required for checkout', 'INVALID_INPUT', 400, { field: 'amount' });
+    }
+
+    const { data: paymentRecord, error: paymentError } = await this.supabase
+      .from('payments')
+      .insert({
+        user_id: userId,
+        amount: normalizedAmount,
+        currency,
+        payment_provider: this.paymentProvider.name,
+        status: 'initiated',
+        type,
+        reference,
+        metadata: { plan_code, ...metadata },
+      })
+      .select()
+      .single();
+
+    if (paymentError) {
+      throw new AgentError('Failed to record payment', 'PAYMENT_RECORD_FAILED', 500, paymentError);
+    }
+
+    const providerResponse = await this.paymentProvider.createCheckout({
+      amount: normalizedAmount,
+      currency,
+      reference,
+      metadata,
+    });
+
+    const { error: updateError } = await this.supabase
+      .from('payments')
+      .update({ provider_payment_id: providerResponse.providerPaymentId, metadata: { ...metadata, providerResponse } })
+      .eq('id', paymentRecord.id);
+
+    if (updateError) {
+      await this.logEvent({
+        userId,
+        eventType: 'payment',
+        status: 'warning',
+        message: 'Failed to attach provider reference to payment',
+        payload: { updateError },
+      });
+    }
+
+    await this.logEvent({
+      userId,
+      eventType: 'payment',
+      status: 'info',
+      message: 'Checkout initiated',
+      payload: { reference, plan_code },
+    });
+
+    return {
+      paymentId: paymentRecord.id,
+      providerPaymentId: providerResponse.providerPaymentId,
+      checkoutUrl: providerResponse.checkoutUrl,
+      reference,
+    };
+  }
+
+  async handleWebhook(payload = {}) {
+    this.ensureConfigured();
+    const normalized = await this.paymentProvider.parseWebhook(payload);
+    if (!normalized?.providerPaymentId) {
+      throw new AgentError('Missing provider payment id', 'INVALID_WEBHOOK', 400);
+    }
+
+    const { data: payment, error } = await this.supabase
+      .from('payments')
+      .select('*')
+      .eq('provider_payment_id', normalized.providerPaymentId)
+      .single();
+
+    if (error || !payment) {
+      await this.logEvent({
+        eventType: 'payment_webhook',
+        status: 'warning',
+        message: 'Payment not found for webhook',
+        payload: { normalized },
+      });
+      throw new AgentError('Payment not found', 'PAYMENT_NOT_FOUND', 404, error);
+    }
+
+    const { error: updateError } = await this.supabase
+      .from('payments')
+      .update({ status: normalized.status, metadata: { ...(payment.metadata || {}), webhook: normalized.metadata } })
+      .eq('id', payment.id);
+
+    if (updateError) {
+      throw new AgentError('Failed to update payment', 'PAYMENT_UPDATE_FAILED', 500, updateError);
+    }
+
+    if (normalized.status === 'succeeded') {
+      const validFrom = new Date();
+      const validTo = new Date(validFrom);
+      validTo.setMonth(validTo.getMonth() + 1);
+
+      const { error: subscriptionError } = await this.supabase
+        .from('subscriptions')
+        .upsert(
+          {
+            user_id: payment.user_id,
+            plan_code: payment.metadata?.plan_code || 'PRO_MONTHLY',
+            status: 'active',
+            valid_from: validFrom.toISOString(),
+            valid_to: validTo.toISOString(),
+            metadata: { paymentId: payment.id },
+          },
+          { onConflict: 'user_id' },
+        );
+
+      if (subscriptionError) {
+        await this.logEvent({
+          userId: payment.user_id,
+          eventType: 'subscription_update',
+          status: 'error',
+          message: 'Failed to activate subscription after payment',
+          payload: { subscriptionError },
+        });
+        throw new AgentError('Failed to update subscription', 'SUBSCRIPTION_UPDATE_FAILED', 500, subscriptionError);
+      }
+
+      await this.logEvent({
+        userId: payment.user_id,
+        eventType: 'subscription_update',
+        status: 'info',
+        message: 'Subscription activated',
+        payload: { paymentId: payment.id },
+      });
+    }
+
+    await this.logEvent({
+      userId: payment.user_id,
+      eventType: 'payment_webhook',
+      status: 'info',
+      message: 'Payment webhook processed',
+      payload: normalized,
+    });
+
+    return { ok: true };
+  }
+}
+
+module.exports = { WathaciOnboardingAgent, AgentError };

--- a/src/hooks/useOnboardingAgent.ts
+++ b/src/hooks/useOnboardingAgent.ts
@@ -1,0 +1,128 @@
+import { useCallback, useState } from 'react';
+import {
+  agentGetProfile,
+  agentInitiateCheckout,
+  agentSignin,
+  agentSignup,
+  agentUpdateProfile,
+} from '@/lib/agent/client';
+import type {
+  AgentCheckoutRequest,
+  AgentCheckoutResponse,
+  AgentProfileResponse,
+  AgentProfileUpdateRequest,
+  AgentSigninRequest,
+  AgentSigninResponse,
+  AgentSignupRequest,
+  AgentSignupResponse,
+} from '@/lib/agent/types';
+
+const buildFriendlyError = (error: unknown): string => {
+  if (error && typeof error === 'object' && 'message' in error) {
+    return (error as { message?: string }).message || 'Request failed';
+  }
+  return 'Request failed';
+};
+
+export function useAgentSignup() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const signup = useCallback(async (payload: AgentSignupRequest): Promise<AgentSignupResponse> => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await agentSignup(payload);
+    } catch (err) {
+      const message = buildFriendlyError(err);
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { signup, loading, error };
+}
+
+export function useAgentSignin() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const signin = useCallback(async (payload: AgentSigninRequest): Promise<AgentSigninResponse> => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await agentSignin(payload);
+    } catch (err) {
+      const message = buildFriendlyError(err);
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { signin, loading, error };
+}
+
+export function useAgentProfile() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [profile, setProfile] = useState<AgentProfileResponse | null>(null);
+
+  const fetchProfile = useCallback(async (userId: string): Promise<AgentProfileResponse> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await agentGetProfile(userId);
+      setProfile(result);
+      return result;
+    } catch (err) {
+      const message = buildFriendlyError(err);
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const updateProfile = useCallback(async (payload: AgentProfileUpdateRequest): Promise<AgentProfileResponse> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await agentUpdateProfile(payload);
+      setProfile(result);
+      return result;
+    } catch (err) {
+      const message = buildFriendlyError(err);
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { profile, loading, error, fetchProfile, updateProfile };
+}
+
+export function useAgentCheckout() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const initiateCheckout = useCallback(async (payload: AgentCheckoutRequest): Promise<AgentCheckoutResponse> => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await agentInitiateCheckout(payload);
+    } catch (err) {
+      const message = buildFriendlyError(err);
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { initiateCheckout, loading, error };
+}

--- a/src/lib/agent/client.ts
+++ b/src/lib/agent/client.ts
@@ -1,0 +1,36 @@
+import { apiFetch, apiGet, apiPost } from '@/lib/api/client';
+import {
+  AgentCheckoutRequest,
+  AgentCheckoutResponse,
+  AgentProfileResponse,
+  AgentProfileUpdateRequest,
+  AgentSigninRequest,
+  AgentSigninResponse,
+  AgentSignupRequest,
+  AgentSignupResponse,
+} from './types';
+
+const basePath = '/api/agent';
+
+export async function agentSignup(payload: AgentSignupRequest): Promise<AgentSignupResponse> {
+  return apiPost(`${basePath}/signup`, payload);
+}
+
+export async function agentSignin(payload: AgentSigninRequest): Promise<AgentSigninResponse> {
+  return apiPost(`${basePath}/signin`, payload);
+}
+
+export async function agentGetProfile(userId: string): Promise<AgentProfileResponse> {
+  return apiGet(`${basePath}/profile?userId=${encodeURIComponent(userId)}`);
+}
+
+export async function agentUpdateProfile(payload: AgentProfileUpdateRequest): Promise<AgentProfileResponse> {
+  return apiFetch(`${basePath}/profile`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function agentInitiateCheckout(payload: AgentCheckoutRequest): Promise<AgentCheckoutResponse> {
+  return apiPost(`${basePath}/payments/checkout`, payload);
+}

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -1,0 +1,53 @@
+export type ProfileStatus = 'incomplete' | 'pending_verification' | 'active';
+
+export interface AgentSignupRequest {
+  email: string;
+  password: string;
+  account_type: string;
+  profile?: Record<string, unknown>;
+}
+
+export interface AgentSigninRequest {
+  email: string;
+  password: string;
+}
+
+export interface AgentProfileUpdateRequest {
+  userId: string;
+  updates: Record<string, unknown>;
+}
+
+export interface AgentCheckoutRequest {
+  userId: string;
+  plan_code?: string;
+  amount: number;
+  currency?: string;
+  type?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AgentSignupResponse {
+  userId: string;
+  profileId: string;
+  subscription?: unknown;
+  nextStep: string;
+}
+
+export interface AgentSigninResponse {
+  session: unknown;
+  user: unknown;
+}
+
+export interface AgentProfileResponse {
+  id?: string;
+  user_id?: string;
+  status?: ProfileStatus;
+  [key: string]: unknown;
+}
+
+export interface AgentCheckoutResponse {
+  paymentId: string;
+  providerPaymentId: string;
+  checkoutUrl: string;
+  reference: string;
+}

--- a/supabase/migrations/20260101090000_onboarding_payments_agent.sql
+++ b/supabase/migrations/20260101090000_onboarding_payments_agent.sql
@@ -1,0 +1,128 @@
+BEGIN;
+
+-- Enums
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'profile_status_enum') THEN
+    CREATE TYPE public.profile_status_enum AS ENUM ('incomplete', 'pending_verification', 'active');
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'subscription_status_enum') THEN
+    CREATE TYPE public.subscription_status_enum AS ENUM ('active', 'expired', 'canceled', 'grace_period');
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'payment_status_enum') THEN
+    CREATE TYPE public.payment_status_enum AS ENUM ('initiated', 'pending', 'succeeded', 'failed', 'refunded');
+  END IF;
+END
+$$;
+
+-- Profiles guardrails
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS user_id uuid REFERENCES auth.users (id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS status profile_status_enum NOT NULL DEFAULT 'incomplete',
+  ADD COLUMN IF NOT EXISTS bio text,
+  ADD COLUMN IF NOT EXISTS location text,
+  ADD COLUMN IF NOT EXISTS payment_phone text,
+  ADD COLUMN IF NOT EXISTS use_same_phone boolean,
+  ADD COLUMN IF NOT EXISTS profile_completed boolean DEFAULT false;
+
+UPDATE public.profiles
+SET user_id = id
+WHERE user_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS profiles_user_id_idx ON public.profiles(user_id);
+CREATE INDEX IF NOT EXISTS profiles_status_idx ON public.profiles(status);
+
+-- Payments table
+CREATE TABLE IF NOT EXISTS public.payments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  amount numeric NOT NULL,
+  currency text NOT NULL DEFAULT 'ZMW',
+  payment_provider text NOT NULL,
+  provider_payment_id text,
+  status payment_status_enum NOT NULL DEFAULT 'initiated',
+  type text NOT NULL DEFAULT 'subscription',
+  metadata jsonb,
+  reference text UNIQUE,
+  created_at timestamptz DEFAULT timezone('utc', now()),
+  updated_at timestamptz DEFAULT timezone('utc', now())
+);
+
+ALTER TABLE public.payments
+  ADD COLUMN IF NOT EXISTS provider_reference text,
+  ADD COLUMN IF NOT EXISTS lenco_transaction_id text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS payments_provider_reference_unique_idx
+  ON public.payments(provider_payment_id)
+  WHERE provider_payment_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS payments_user_status_idx
+  ON public.payments(user_id, status);
+
+-- Subscriptions table
+CREATE TABLE IF NOT EXISTS public.subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  plan_code text NOT NULL,
+  status subscription_status_enum NOT NULL DEFAULT 'grace_period',
+  valid_from timestamptz DEFAULT timezone('utc', now()),
+  valid_to timestamptz,
+  metadata jsonb,
+  created_at timestamptz DEFAULT timezone('utc', now()),
+  updated_at timestamptz DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS subscriptions_user_status_idx
+  ON public.subscriptions(user_id, status);
+
+CREATE INDEX IF NOT EXISTS subscriptions_plan_idx
+  ON public.subscriptions(plan_code);
+
+-- Agent logs
+CREATE TABLE IF NOT EXISTS public.agent_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  event_type text NOT NULL,
+  payload jsonb,
+  status text NOT NULL DEFAULT 'info',
+  message text,
+  created_at timestamptz DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS agent_logs_user_event_idx
+  ON public.agent_logs(user_id, event_type);
+
+-- Bookkeeping triggers
+CREATE OR REPLACE FUNCTION public.set_current_timestamp_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = timezone('utc', now());
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_payments_updated_at ON public.payments;
+CREATE TRIGGER set_payments_updated_at
+BEFORE UPDATE ON public.payments
+FOR EACH ROW
+EXECUTE FUNCTION public.set_current_timestamp_updated_at();
+
+DROP TRIGGER IF EXISTS set_subscriptions_updated_at ON public.subscriptions;
+CREATE TRIGGER set_subscriptions_updated_at
+BEFORE UPDATE ON public.subscriptions
+FOR EACH ROW
+EXECUTE FUNCTION public.set_current_timestamp_updated_at();
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add Wathaci onboarding/payments agent service with signup, signin, profile, checkout, and webhook endpoints plus structured logging
- introduce pluggable payment provider abstraction and Supabase-backed persistence for payments, subscriptions, and agent events
- create frontend agent client/hooks and document Ciso responsibilities alongside a migration that enforces required tables/columns

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea9cc9edc83288314f23bd9e7a8df)