### PR TITLE
Add Ciso support widget and Supabase agent client

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { ConfigurationError } from "@/components/ConfigurationError";
 import { RouteChangeDebugger } from "@/components/RouteChangeDebugger";
 import { supabaseConfigStatus } from "@/config/appConfig";
 import { getPaymentConfig } from "@/lib/payment-config";
+import CisoWidget from "@/components/CisoWidget";
 import AppLayout from "./components/AppLayout";
 import "./i18n";
 
@@ -497,6 +498,7 @@ const InnerApp = () => {
             {import.meta.env.DEV ? <RouteChangeDebugger /> : null}
             <AppRoutes />
           </BrowserRouter>
+          <CisoWidget />
         </AppProvider>
       </TooltipProvider>
     </QueryClientProvider>

--- a/src/components/CisoWidget.tsx
+++ b/src/components/CisoWidget.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from "react";
+import { callCisoAgent, CisoMessage } from "../lib/cisoClient";
+
+const CisoWidget: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [messages, setMessages] = useState<CisoMessage[]>([]);
+
+  const toggleOpen = () => setIsOpen((prev) => !prev);
+
+  const handleSend = async () => {
+    if (!input.trim()) return;
+
+    const userMessage: CisoMessage = {
+      role: "user",
+      content: input.trim(),
+    };
+
+    const newMessages = [...messages, userMessage];
+    setMessages(newMessages);
+    setInput("");
+    setIsLoading(true);
+
+    try {
+      const reply = await callCisoAgent(newMessages, "user");
+      const assistantMessage: CisoMessage = {
+        role: "assistant",
+        content: reply,
+      };
+      setMessages((prev) => [...prev, assistantMessage]);
+    } catch (err) {
+      console.error(err);
+      const errorMessage: CisoMessage = {
+        role: "assistant",
+        content:
+          "I ran into a problem trying to respond. Please try again or email support@wathaci.com.",
+      };
+      setMessages((prev) => [...prev, errorMessage]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (
+    e,
+  ) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={toggleOpen}
+        className="
+          fixed
+          bottom-4
+          right-4
+          z-50
+          flex
+          items-center
+          justify-center
+          h-14
+          w-14
+          rounded-full
+          bg-emerald-600
+          text-white
+          shadow-lg
+          hover:bg-emerald-700
+          focus:outline-none
+        "
+        aria-label="Ask Ciso for help"
+      >
+        <span className="text-lg font-bold">C</span>
+      </button>
+
+      {isOpen && (
+        <div
+          className="
+            fixed
+            bottom-20
+            right-4
+            z-50
+            w-80
+            max-w-full
+            bg-white
+            shadow-2xl
+            rounded-xl
+            border
+            border-gray-200
+            flex
+            flex-col
+            overflow-hidden
+          "
+        >
+          <div className="flex items-center justify-between px-3 py-2 bg-emerald-600 text-white">
+            <div className="flex items-center gap-2">
+              <div className="h-7 w-7 rounded-full bg-white/20 flex items-center justify-center text-sm font-bold">
+                C
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm font-semibold">@Ask Ciso for help</span>
+                <span className="text-[11px] text-emerald-100">
+                  Onboarding • Payments • Profiles
+                </span>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={toggleOpen}
+              className="text-xs hover:text-gray-200"
+            >
+              ✕
+            </button>
+          </div>
+
+          <div className="flex-1 px-3 py-2 space-y-2 overflow-y-auto text-sm bg-gray-50">
+            {messages.length === 0 && (
+              <p className="text-xs text-gray-500">
+                Hi, I&apos;m Ciso. Ask me about sign-ups, profiles, payments, or how
+                WATHACI Connect works.
+              </p>
+            )}
+
+            {messages.map((msg, idx) => (
+              <div
+                key={idx}
+                className={`flex ${
+                  msg.role === "user" ? "justify-end" : "justify-start"
+                }`}
+              >
+                <div
+                  className={`
+                    max-w-[80%] rounded-lg px-2.5 py-1.5 text-xs
+                    ${
+                      msg.role === "user"
+                        ? "bg-emerald-600 text-white"
+                        : "bg-white text-gray-800 border border-gray-200"
+                    }
+                  `}
+                >
+                  {msg.content}
+                </div>
+              </div>
+            ))}
+
+            {isLoading && (
+              <p className="text-xs text-gray-400 italic">Ciso is typing…</p>
+            )}
+          </div>
+
+          <div className="border-t border-gray-200 bg-white px-3 py-2">
+            <textarea
+              rows={2}
+              className="
+                w-full
+                resize-none
+                text-xs
+                border
+                border-gray-300
+                rounded-md
+                px-2
+                py-1
+                focus:outline-none
+                focus:ring-1
+                focus:ring-emerald-500
+                focus:border-emerald-500
+              "
+              placeholder="Type your question here…"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            <div className="flex justify-end mt-1">
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={isLoading || !input.trim()}
+                className="
+                  text-xs
+                  px-3
+                  py-1
+                  rounded
+                  bg-emerald-600
+                  text-white
+                  hover:bg-emerald-700
+                  disabled:bg-gray-300
+                  disabled:cursor-not-allowed
+                "
+              >
+                Send
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default CisoWidget;

--- a/src/lib/cisoClient.ts
+++ b/src/lib/cisoClient.ts
@@ -1,0 +1,110 @@
+export type CisoMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+
+const CISO_USER_SYSTEM_PROMPT = `
+You are "Ciso", the AI operations and onboarding assistant for the WATHACI Connect platform.
+
+Your responsibilities:
+- Help users sign up, sign in, and complete their profiles (SMEs, investors, donors, government institutions, professionals, freelancers).
+- Guide users through payments, subscriptions, services, products, and platform fees in a clear, step-by-step way.
+- Help match SMEs with investors, donors, government agencies, and professionals based on needs, objectives, and goals.
+- Explain WATHACI workflows (onboarding, matching, payments, negotiations, platform fees) in simple, actionable language.
+- When you don't have direct access to data (e.g., specific transactions or internal logs), clearly say what you can and can't see, and suggest the next practical step.
+
+Tone and style:
+- Professional but friendly and encouraging.
+- Short, clear, and structured: use bullet points and numbered steps where it helps.
+- Assume the user may not be technical. Avoid jargon or explain it.
+- Always think in terms of: "What is the next useful, low-friction action for this user?"
+
+Guardrails:
+- Never claim you have real-time access to production databases, payments, or private emails.
+- Instead, say things like: "I don't see your exact payment status, but here is how you can check or escalate it."
+- Do not expose internal keys, tokens, or configuration details.
+- When a problem sounds serious (sign-in failures, suspected fraud, or repeated payment errors), advise the user to contact support@wathaci.com and clearly outline what information they should include.
+`;
+
+const CISO_ADMIN_SYSTEM_PROMPT = `
+You are "Ciso", the AI admin and operations assistant for the WATHACI Connect platform.
+
+You are assisting internal platform administrators, not end-users.
+
+Your responsibilities:
+- Help admins reason about payments, subscriptions, platform fees, and Lenco gateway health.
+- Help admins troubleshoot sign-up/sign-in flows, profile completion, and onboarding issues.
+- Help admins think through SME–investor–donor–government–professional matching strategies and data structures.
+- Suggest safe, robust workflows and monitoring strategies for payments, notifications, and compliance.
+- Propose clear, testable steps for debugging backend issues, Supabase functions, Lenco webhooks, and SMTP/WhatsApp/SMS integrations.
+
+Tone and style:
+- Precise, technical, and structured (steps, checklists, and bullet points).
+- Always consider data integrity, auditability, and user experience.
+- Call out risks and edge cases explicitly (e.g., double charges, failed webhooks, partial sign-ups).
+
+Guardrails:
+- You do NOT execute code or directly access the production environment.
+- You generate plans, commands, and code samples that a human admin or engineer can apply.
+- Never print or guess secret keys or passwords.
+`;
+
+const AGENT_URL = import.meta.env.VITE_WATHACI_CISO_AGENT_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!AGENT_URL) {
+  console.warn(
+    "[Ciso] VITE_WATHACI_CISO_AGENT_URL is not set. The Ciso widget cannot reach the agent function.",
+  );
+}
+
+if (!SUPABASE_ANON_KEY) {
+  console.warn(
+    "[Ciso] VITE_SUPABASE_ANON_KEY is not set. The Ciso widget may not work in production.",
+  );
+}
+
+export type CisoMode = "user" | "admin";
+
+export async function callCisoAgent(
+  userMessages: CisoMessage[],
+  mode: CisoMode = "user",
+) {
+  const systemPrompt =
+    mode === "admin" ? CISO_ADMIN_SYSTEM_PROMPT : CISO_USER_SYSTEM_PROMPT;
+
+  const messages: CisoMessage[] = [
+    { role: "system", content: systemPrompt },
+    ...userMessages,
+  ];
+
+  if (!AGENT_URL) {
+    throw new Error("Ciso agent URL is not configured");
+  }
+
+  const res = await fetch(AGENT_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SUPABASE_ANON_KEY ?? "",
+      Authorization: SUPABASE_ANON_KEY ? `Bearer ${SUPABASE_ANON_KEY}` : "",
+    },
+    body: JSON.stringify({
+      model: "gpt-4.1-mini",
+      messages,
+      admin: mode === "admin",
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error("[Ciso] Agent error:", res.status, text);
+    throw new Error("Ciso agent error");
+  }
+
+  const data = await res.json();
+  const reply: string =
+    data?.choices?.[0]?.message?.content ?? "Sorry, I couldn't generate a reply.";
+
+  return reply;
+}


### PR DESCRIPTION
## Summary
- add Ciso agent client that injects user/admin system prompts and forwards messages to the Supabase function
- create a floating Ciso support widget for chatting with the agent from any page
- mount the widget globally so it is available throughout the app and document env expectations via runtime warnings

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-unused-vars rule missing in backend/services/payment-provider.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7472e7588328ab3c8124442d93cb)