### PR TITLE
Send structured knowledge context with Ciso requests

### DIFF
--- a/src/components/CisoWidget.tsx
+++ b/src/components/CisoWidget.tsx
@@ -23,7 +23,12 @@ const CisoWidget: React.FC = () => {
     setIsLoading(true);
 
     try {
-      const reply = await callCisoAgent(newMessages, "user");
+      const reply = await callCisoAgent(newMessages, "user", {
+        role: "guest",
+        flow: "inline-widget",
+        step: "chat",
+        lastError: null,
+      });
       const assistantMessage: CisoMessage = {
         role: "assistant",
         content: reply,

--- a/src/components/PaymentCheckout.tsx
+++ b/src/components/PaymentCheckout.tsx
@@ -123,7 +123,12 @@ const PaymentCheckout: React.FC = () => {
     ];
 
     try {
-      const reply = await callCisoAgent(messages, "user");
+      const reply = await callCisoAgent(messages, "user", {
+        role: "SME",
+        flow: "checkout",
+        step: "plan-selection-and-payment",
+        lastError: lastPaymentError,
+      });
       setCisoAnswer(reply);
     } catch (err) {
       console.error(err);

--- a/src/components/SmeSignupForm.tsx
+++ b/src/components/SmeSignupForm.tsx
@@ -86,7 +86,12 @@ const SmeSignupForm: React.FC = () => {
     ];
 
     try {
-      const reply = await callCisoAgent(messages, "user");
+      const reply = await callCisoAgent(messages, "user", {
+        role: "SME",
+        flow: "signup",
+        step,
+        lastError: signupError,
+      });
       setCisoAnswer(reply);
     } catch (err) {
       console.error(err);

--- a/src/lib/cisoClient.ts
+++ b/src/lib/cisoClient.ts
@@ -5,6 +5,13 @@ export type CisoMessage = {
   content: string;
 };
 
+export type CisoKnowledgeContext = {
+  role?: string;
+  flow?: string;
+  step?: string;
+  lastError?: string | null;
+};
+
 export type CisoMode = "user" | "admin";
 
 const CISO_USER_SYSTEM_PROMPT = `
@@ -141,7 +148,10 @@ if (!SUPABASE_ANON_KEY) {
   );
 }
 
-async function fetchKnowledgeContext(userMessages: CisoMessage[]) {
+async function fetchKnowledgeContext(
+  userMessages: CisoMessage[],
+  context?: CisoKnowledgeContext,
+) {
   if (!CISO_KNOWLEDGE_URL) return null;
 
   try {
@@ -154,6 +164,7 @@ async function fetchKnowledgeContext(userMessages: CisoMessage[]) {
       },
       body: JSON.stringify({
         messages: userMessages,
+        context,
       }),
     });
 
@@ -187,11 +198,12 @@ async function fetchKnowledgeContext(userMessages: CisoMessage[]) {
 export async function callCisoAgent(
   userMessages: CisoMessage[],
   mode: CisoMode = "user",
+  context?: CisoKnowledgeContext,
 ) {
   const systemPrompt =
     mode === "admin" ? CISO_ADMIN_SYSTEM_PROMPT : CISO_USER_SYSTEM_PROMPT;
 
-  const knowledgeContext = await fetchKnowledgeContext(userMessages);
+  const knowledgeContext = await fetchKnowledgeContext(userMessages, context);
 
   const messages: CisoMessage[] = [
     { role: "system", content: systemPrompt },


### PR DESCRIPTION
## Summary
- send structured knowledge context fields alongside user messages when fetching Ciso knowledge
- propagate role/flow/step/lastError metadata from inline chat, signup, and checkout helpers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff4c7c1dc8328bf1e5ff2e5fcb4dc)