### PR TITLE
Add structured context support for Ciso agent

### DIFF
--- a/src/components/CisoWidget.tsx
+++ b/src/components/CisoWidget.tsx
@@ -27,7 +27,6 @@ const CisoWidget: React.FC = () => {
         role: "guest",
         flow: "inline-widget",
         step: "chat",
-        lastError: null,
       });
       const assistantMessage: CisoMessage = {
         role: "assistant",

--- a/src/components/PaymentCheckout.tsx
+++ b/src/components/PaymentCheckout.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
-import { callCisoAgent, type CisoMessage } from "../lib/cisoClient";
+import {
+  callCisoAgent,
+  type CisoContext,
+  type CisoMessage,
+} from "../lib/cisoClient";
 
 type BillingCycle = "monthly" | "annual";
 
@@ -89,7 +93,7 @@ const PaymentCheckout: React.FC = () => {
     setCisoAnswer(null);
 
     const contextPayload = {
-      userRole: "SME",
+      userRole: "sme",
       flow: "checkout",
       step: "plan-selection-and-payment",
       plan: {
@@ -122,13 +126,23 @@ const PaymentCheckout: React.FC = () => {
       },
     ];
 
+    const cisoContext: CisoContext = {
+      role: "sme",
+      flow: "checkout",
+      step: "plan-selection-and-payment",
+      lastError: lastPaymentError || undefined,
+      extra: {
+        planId: selectedPlan.id,
+        planName: selectedPlan.name,
+        currency: selectedPlan.currency,
+        gateway,
+        isTrial,
+        customerEmail: customerEmail || null,
+      },
+    };
+
     try {
-      const reply = await callCisoAgent(messages, "user", {
-        role: "SME",
-        flow: "checkout",
-        step: "plan-selection-and-payment",
-        lastError: lastPaymentError,
-      });
+      const reply = await callCisoAgent(messages, "user", cisoContext);
       setCisoAnswer(reply);
     } catch (err) {
       console.error(err);

--- a/src/components/SmeSignupForm.tsx
+++ b/src/components/SmeSignupForm.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
-import { callCisoAgent, type CisoMessage } from "@/lib/cisoClient";
+import {
+  callCisoAgent,
+  type CisoContext,
+  type CisoMessage,
+} from "@/lib/cisoClient";
 
 type SignupStep = "basic-info" | "business-details" | "confirm";
 
@@ -57,7 +61,7 @@ const SmeSignupForm: React.FC = () => {
 
     // Build a rich context message for Ciso
     const contextPayload = {
-      userRole: "SME",
+      userRole: "sme",
       flow: "signup",
       step,
       form: {
@@ -85,13 +89,19 @@ const SmeSignupForm: React.FC = () => {
       },
     ];
 
+    const cisoContext: CisoContext = {
+      role: "sme",
+      flow: "signup",
+      step,
+      lastError: signupError || undefined,
+      extra: {
+        country,
+        sector,
+      },
+    };
+
     try {
-      const reply = await callCisoAgent(messages, "user", {
-        role: "SME",
-        flow: "signup",
-        step,
-        lastError: signupError,
-      });
+      const reply = await callCisoAgent(messages, "user", cisoContext);
       setCisoAnswer(reply);
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- add a typed `CisoContext` and forward optional context payloads to the agent request
- send structured signup and checkout context from the frontend, keeping natural language context intact
- leverage the provided context in the edge agent when filtering knowledge by role and flow

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff8780d388328ae915abc18a5d0a5)