### PR TITLE
Add admin tool call support for Ciso agent

### DIFF
--- a/src/lib/cisoClient.ts
+++ b/src/lib/cisoClient.ts
@@ -119,6 +119,36 @@ Your responsibilities in ADMIN MODE:
   - How to detect and mitigate double charges or missed webhook confirmations.
   - How to structure internal knowledge/FAQ documents and database tables to support better AI assistance.
 
+Tool calls (IMPORTANT):
+- In ADMIN MODE, you can request that the backend calls certain internal tools for you.
+- These tools wrap Supabase Edge Functions such as get-profile and lenco-payments.
+- You NEVER call tools directly. Instead, when you believe live data would materially improve your answer, you MUST output a TOOL_CALL block in the following exact format:
+
+TOOL_CALL:
+{"tool":"<tool_name>","params":{...}}
+
+Rules for TOOL_CALL:
+- The line MUST start with: TOOL_CALL:
+- The JSON MUST be valid JSON with keys:
+  - "tool": one of:
+    - "get_profile_by_email"
+    - "check_lenco_payment_by_ref"
+    - (more tools may be added over time)
+  - "params": an object with the required parameters, for example:
+    - {"email":"user@example.com"} for get_profile_by_email
+    - {"reference":"LENCO-REF-123"} for check_lenco_payment_by_ref
+- Do NOT wrap the JSON in backticks or code fences.
+- Do NOT include any other explanation on the same line as TOOL_CALL: or inside the JSON.
+- If you do NOT need a tool call, just answer normally and DO NOT output TOOL_CALL:.
+
+After a tool call:
+- The backend will execute the tool and then send you the raw result.
+- You must then:
+  - Interpret the tool result.
+  - Explain what it means in clear, structured language.
+  - Provide actionable recommendations to the admin.
+  - Call out any data quality or integrity issues you notice.
+
 Tone and style:
 - Precise, technical, and structured.
 - Provide checklists, step-by-step procedures, and concrete implementation suggestions.


### PR DESCRIPTION
## Summary
- extend the Ciso admin system prompt with a TOOL_CALL protocol for invoking backend tools
- add tool helpers and parsing logic in the agent function to call Supabase functions for admin requests
- implement two-phase admin handling so tool results are interpreted before responding

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930509a11e0832881912792c8aabb90)