### PR TITLE
Align backend dev server with frontend

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -28,9 +28,16 @@ const parseAllowedOrigins = (value = '') =>
     .filter(origin => Boolean(origin) && origin !== '*');
 
 const defaultAllowedOrigins = [
+  // Production deployments
   'https://www.wathaci.com',
   'https://wathaci-connect-platform.vercel.app',
   'https://wathaci-connect-platform-amukenas-projects.vercel.app',
+  // Local development (aligned with Vite dev server)
+  'http://localhost:8080',
+  'http://127.0.0.1:8080',
+  // Legacy Vite defaults (in case the dev server port changes)
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
 ];
 
 const configuredOrigins = parseAllowedOrigins(

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,10 +2,10 @@
   "name": "wathaci-connect-backend",
   "version": "1.0.0",
   "description": "Backend API for Wathaci Connect",
-  "main": "server.js",
+  "main": "index.js",
   "scripts": {
-    "dev": "nodemon server.js",
-    "start": "node server.js"
+    "dev": "nodemon index.js",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- allow localhost Vite origins in backend CORS defaults so the frontend can reach the API during development
- run the full Express app (`index.js`) for dev and start scripts to expose the expected API surface locally

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932dfa844ec83288e1bbe2506a79a51)