### PR TITLE
Allow production signup redirects and clarify signup failures

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -841,11 +841,15 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       let errorMessage = error.message || 'Failed to create account';
 
       // Check for common error patterns and provide helpful messages
-      if (errorMessage.includes('network') || errorMessage.includes('fetch')) {
+      const normalizedError = errorMessage.toLowerCase();
+
+      if (error.status === 500 || normalizedError.includes('unexpected_failure')) {
+        errorMessage = 'We hit a temporary issue creating your account. Please try again shortly or contact support if this repeats.';
+      } else if (normalizedError.includes('network') || normalizedError.includes('fetch')) {
         errorMessage = 'We couldn\'t reach WATHACI servers right now. Please try again shortly.';
-      } else if (errorMessage.includes('already exists') || errorMessage.includes('already registered')) {
+      } else if (normalizedError.includes('already exists') || normalizedError.includes('already registered')) {
         errorMessage = 'An account with this email already exists. Please sign in instead or use a different email.';
-      } else if (errorMessage.includes('password')) {
+      } else if (normalizedError.includes('password')) {
         errorMessage = 'Password does not meet requirements. Please use a stronger password.';
       }
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -122,7 +122,16 @@ enabled = true
 # in emails.
 site_url = "env(VITE_SITE_URL)"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000", "http://localhost:3000"]
+# Allow production redirect targets so email confirmation links resolve without 500s
+# when users sign up from app.wathaci.com or the marketing site.
+additional_redirect_urls = [
+  "https://127.0.0.1:3000",
+  "http://localhost:3000",
+  "https://app.wathaci.com/signin",
+  "https://app.wathaci.com",
+  "https://www.wathaci.com",
+  "https://www.wathaci.com/signin"
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # Path to JWT signing key. DO NOT commit your signing keys file to git.


### PR DESCRIPTION
## Summary
- allow Supabase auth to redirect back to app.wathaci.com and www.wathaci.com during signup flows
- surface clearer messaging for 500/unexpected_failure responses during signup so users get guidance instead of a generic error

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b1d690788328b622db7a5ae20927)