### PR TITLE
Adjust SMTP settings and improve email failure messaging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,9 +102,9 @@ AUTH_BYPASS_MODE_ENABLED="false"
 # --- Email / SMTP Configuration ---
 # SMTP settings for email delivery via PrivateEmail (Namecheap)
 # Used by Supabase for sending authentication and transactional emails
-SMTP_HOST="mail.privateemail.com"
-SMTP_PORT="465"
-SMTP_SECURE="true" # true for port 465, false for 587
+SMTP_HOST="smtp.privateemail.com"
+SMTP_PORT="587"
+SMTP_SECURE="false" # true for port 465, false for 587
 SMTP_USERNAME="support@wathaci.com"
 SMTP_USER="support@wathaci.com" # Legacy compatibility
 SMTP_AUTH_METHOD="LOGIN"

--- a/.env.template
+++ b/.env.template
@@ -89,13 +89,13 @@ VITE_WATHACI_CISO_AGENT_URL="http://localhost:54321/functions/v1/ciso-agent"
 # For local development only, you can use these variables with local Supabase:
 
 # SMTP Host (PrivateEmail/Namecheap)
-SMTP_HOST="mail.privateemail.com"
+SMTP_HOST="smtp.privateemail.com"
 
 # SMTP Port (465 = TLS, 587 = STARTTLS)
-SMTP_PORT="465"
+SMTP_PORT="587"
 
 # Set true for implicit TLS (465); false for STARTTLS (587)
-SMTP_SECURE="true"
+SMTP_SECURE="false"
 
 # SMTP Username (your platform email)
 # This is the email address that will send all emails

--- a/src/lib/authErrorHandler.ts
+++ b/src/lib/authErrorHandler.ts
@@ -71,6 +71,24 @@ function parseSupabaseAuthError(error: AuthError): DetailedAuthError {
     };
   }
 
+  // SMTP/confirmation email failures
+  if (
+    message.includes('confirmation email') ||
+    message.includes('smtp') ||
+    message.includes('authentication failed') ||
+    message.includes('535')
+  ) {
+    return {
+      friendlyMessage:
+        "We couldn't send the confirmation email right now. Please try again in a few minutes or contact support@wathaci.com.",
+      errorCode: 'EMAIL_DELIVERY_FAILED',
+      originalMessage: error.message,
+      category: 'network',
+      suggestedAction: 'Retry later or reach out to support if the issue continues.',
+      shouldReport: true,
+    };
+  }
+
   // Explicit Supabase rate limiting
   if (status === 429 || code === '429' || message.includes('rate limit')) {
     return {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -195,8 +195,9 @@ otp_expiry = 3600
 # For production, configure PrivateEmail SMTP settings
 [auth.email.smtp]
 enabled = true
-host = "mail.privateemail.com"
-port = 465
+# Use StartTLS on 587 to avoid implicit TLS auth errors with PrivateEmail
+host = "smtp.privateemail.com"
+port = 587
 user = "support@wathaci.com"
 pass = "env(SMTP_PASSWORD)"
 admin_email = "support@wathaci.com"


### PR DESCRIPTION
## Summary
- Switch Supabase SMTP configuration to PrivateEmail StartTLS (smtp.privateemail.com:587)
- Align environment templates with the new SMTP host/port and secure flag defaults
- Add user-friendly handling for confirmation email/SMTP authentication failures during signup

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b7d8d1888328b3bceb55c954685c)