### PR TITLE
Align SMTP settings and redirect configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,13 +102,14 @@ AUTH_BYPASS_MODE_ENABLED="false"
 # --- Email / SMTP Configuration ---
 # SMTP settings for email delivery via PrivateEmail (Namecheap)
 # Used by Supabase for sending authentication and transactional emails
-SMTP_HOST="smtp.privateemail.com"
+# IMPORTANT: Generate an app password in PrivateEmail and use it here to avoid 535 auth errors.
+SMTP_HOST="mail.privateemail.com"
 SMTP_PORT="587"
-SMTP_SECURE="false" # true for port 465, false for 587
+SMTP_SECURE="false" # true for port 465, false for 587 (STARTTLS when false)
 SMTP_USERNAME="support@wathaci.com"
 SMTP_USER="support@wathaci.com" # Legacy compatibility
 SMTP_AUTH_METHOD="LOGIN"
-SMTP_PASSWORD="your-smtp-password-from-namecheap"
+SMTP_PASSWORD="your-privateemail-app-password"
 FROM_EMAIL="support@wathaci.com"
 REPLY_TO_EMAIL="support@wathaci.com"
 SMTP_FROM_EMAIL="support@wathaci.com"
@@ -122,6 +123,7 @@ SUPABASE_SMTP_SENDER_NAME="Wathaci"
 # Email Confirmation Redirect URLs
 # URL to redirect users after they click the email confirmation link
 # For local development, use localhost with the appropriate port
+# For production (Vercel), set to https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app/signin
 VITE_EMAIL_CONFIRMATION_REDIRECT_URL="http://127.0.0.1:3000/signin"
 # Alternative: use a path-only redirect (will use the app's base URL)
 # VITE_EMAIL_CONFIRMATION_REDIRECT_PATH="/signin"

--- a/.env.template
+++ b/.env.template
@@ -89,7 +89,7 @@ VITE_WATHACI_CISO_AGENT_URL="http://localhost:54321/functions/v1/ciso-agent"
 # For local development only, you can use these variables with local Supabase:
 
 # SMTP Host (PrivateEmail/Namecheap)
-SMTP_HOST="smtp.privateemail.com"
+SMTP_HOST="mail.privateemail.com"
 
 # SMTP Port (465 = TLS, 587 = STARTTLS)
 SMTP_PORT="587"
@@ -105,12 +105,12 @@ SMTP_USER="support@wathaci.com" # legacy compatibility
 # SMTP authentication method
 SMTP_AUTH_METHOD="LOGIN"
 
-# SMTP Password
+# SMTP Password (use a PrivateEmail app password to avoid 535 authentication errors)
 # SECURITY: This should ONLY be set in:
 #   1. Local .env.local (for local Supabase development)
 #   2. Supabase Dashboard SMTP settings (for production)
 # NEVER commit this password or add to Vercel environment variables
-SMTP_PASSWORD="your-privateemail-password-here"
+SMTP_PASSWORD="your-privateemail-app-password"
 
 # Email "From" address
 # Must match SMTP_USERNAME and be verified in PrivateEmail

--- a/EMAIL_CONFIGURATION_GUIDE.md
+++ b/EMAIL_CONFIGURATION_GUIDE.md
@@ -35,10 +35,10 @@ The platform uses PrivateEmail hosted by Namecheap for SMTP email delivery.
 
 **Outgoing Server Settings (SMTP):**
 - **Server:** mail.privateemail.com
-- **Port:** 465
+- **Port:** 587
 - **Username:** support@wathaci.com
-- **Connection:** SSL/TLS
-- **Password:** Your account password (stored in environment secrets)
+- **Connection:** STARTTLS (explicit TLS)
+- **Password:** PrivateEmail **app password** (not the mailbox login)
 
 ## Environment Variables
 
@@ -47,9 +47,9 @@ Add the following environment variables to your `.env.local` and `.env.productio
 ```bash
 # Email / SMTP Configuration
 SMTP_HOST="mail.privateemail.com"
-SMTP_PORT="465"
+SMTP_PORT="587" # STARTTLS
 SMTP_USER="support@wathaci.com"
-SMTP_PASSWORD="your-smtp-password"
+SMTP_PASSWORD="<your PrivateEmail app password>"
 SMTP_FROM_EMAIL="support@wathaci.com"
 SMTP_FROM_NAME="Wathaci"
 
@@ -72,7 +72,7 @@ SUPABASE_SMTP_SENDER_NAME="Wathaci"
 [auth.email.smtp]
 enabled = true
 host = "mail.privateemail.com"
-port = 465
+port = 587
 user = "support@wathaci.com"
 pass = "env(SMTP_PASSWORD)"
 admin_email = "support@wathaci.com"
@@ -89,20 +89,26 @@ npm run supabase:start
 1. Log in to your Supabase dashboard
 2. Navigate to: **Project Settings → Authentication → SMTP Settings**
 3. Enable custom SMTP
-4. Configure the following:
+4. Configure the following (use the PrivateEmail **app password**):
    - **Sender email:** support@wathaci.com
    - **Sender name:** Wathaci
    - **Host:** mail.privateemail.com
-   - **Port:** 465
+   - **Port:** 587
    - **Username:** support@wathaci.com
-   - **Password:** [Your SMTP password]
-   - **Enable SSL:** Yes
+   - **Password:** [PrivateEmail app password]
+   - **Enable STARTTLS/SSL:** Enabled (STARTTLS on port 587)
 
 5. Navigate to: **Project Settings → Authentication → Email Templates**
 6. Update each template (Confirmation, Reset Password, Magic Link, etc.) to use:
    - **From:** support@wathaci.com
    - **Reply-to:** support@wathaci.com
    - Include the support footer in all templates
+
+7. In **Authentication → URL Configuration**, allow the application redirect URLs:
+   - `http://localhost:3000`
+   - `https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app`
+   - `https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app/signin`
+   - `https://app.wathaci.com` and `https://app.wathaci.com/signin` (production)
 
 ## DNS Configuration
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -127,6 +127,8 @@ site_url = "env(VITE_SITE_URL)"
 additional_redirect_urls = [
   "https://127.0.0.1:3000",
   "http://localhost:3000",
+  "https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app",
+  "https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app/signin",
   "https://app.wathaci.com/signin",
   "https://app.wathaci.com",
   "https://www.wathaci.com",
@@ -195,8 +197,8 @@ otp_expiry = 3600
 # For production, configure PrivateEmail SMTP settings
 [auth.email.smtp]
 enabled = true
-# Use StartTLS on 587 to avoid implicit TLS auth errors with PrivateEmail
-host = "smtp.privateemail.com"
+# Use PrivateEmail over STARTTLS on 587. The host must be mail.privateemail.com for successful auth.
+host = "mail.privateemail.com"
 port = 587
 user = "support@wathaci.com"
 pass = "env(SMTP_PASSWORD)"


### PR DESCRIPTION
## Summary
- switch SMTP configuration to mail.privateemail.com on STARTTLS/587 and document using a PrivateEmail app password
- update environment templates to reflect the corrected SMTP details and Vercel confirmation redirect
- allow the new Vercel frontend URLs in Supabase auth redirect settings for clean confirmations

## Testing
- Not run (documentation and configuration updates only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935bb869b9c8328b5cc4af28b1335af)