### PR TITLE
Update signup flow for autoconfirmed accounts

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -986,15 +986,15 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     }
 
     // Show success message
-    // Note: If email confirmation is enabled in Supabase, the session won't be active yet
+    // If Supabase hasn't started a session yet, let the user know they can still sign in right away
     const refreshedState = await refreshUser();
     const sessionActive = !!refreshedState.user;
-    
+
     toast({
       title: "Account created!",
       description: sessionActive
         ? "You're all set! Complete your profile to get started."
-        : "Please check your email to verify your account.",
+        : "Your account is ready. You can sign in right away to continue.",
     });
 
     if (!user) {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -91,7 +91,7 @@ export const SignUp = () => {
                 <h2 className="text-2xl font-semibold text-green-900">Account created</h2>
                 <p className="text-base text-green-900">
                   {confirmationRequired
-                    ? "Please check your email to confirm your address before logging in."
+                    ? "Your account is ready. You can sign in now to continue setup."
                     : "You can now sign in and complete your profile setup."}
                 </p>
                 {emailForConfirmation ? (

--- a/src/pages/ZaqaSignup.tsx
+++ b/src/pages/ZaqaSignup.tsx
@@ -146,8 +146,7 @@ export const ZaqaSignup = () => {
         return;
       }
 
-      // Check if email confirmation is required
-      // If session is null but user exists, email confirmation is required
+      // Check if a session is active; if not, prompt the user to sign in manually (no email verification required)
       const requiresConfirmation = !authData.session && authData.user;
       setEmailConfirmationRequired(requiresConfirmation);
 
@@ -493,19 +492,12 @@ export const ZaqaSignup = () => {
             </CardHeader>
             <CardContent className="space-y-6">
               {emailConfirmationRequired ? (
-                <>
-                  <Alert className="border-blue-200 bg-blue-50">
-                    <AlertDescription className="text-sm">
-                      <strong className="font-semibold">Please check your email to confirm your account.</strong>
-                      <br />
-                      We've sent a confirmation link to <strong>{email}</strong>. Click the link in the email
-                      to activate your account, then return here to log in.
-                    </AlertDescription>
-                  </Alert>
-                  <p className="text-sm text-gray-600">
-                    Didn't receive the email? Check your spam folder or contact support if you need assistance.
-                  </p>
-                </>
+                <Alert className="border-blue-200 bg-blue-50">
+                  <AlertDescription className="text-sm">
+                    Your account has been created. You can sign in right away—if you don't see a session yet, log in
+                    with your email and password to continue.
+                  </AlertDescription>
+                </Alert>
               ) : (
                 <Alert className="border-green-200 bg-green-50">
                   <AlertDescription className="text-sm">


### PR DESCRIPTION
## Summary
- update AppContext signup toast to guide users to sign in immediately when no session is returned
- adjust SignUp page success messaging to remove email confirmation dependency
- refresh Zaqa signup success screen to encourage immediate login instead of waiting for confirmation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935eca3ca088328a3419246eeca3ffa)