### PR TITLE
Disable email confirmations and mailer

### DIFF
--- a/docs/DISABLE_EMAIL_CONFIRMATION.md
+++ b/docs/DISABLE_EMAIL_CONFIRMATION.md
@@ -1,0 +1,30 @@
+# Disabling Supabase email confirmations
+
+This project needs email/password signups to succeed without requiring a confirmation email. For the hosted project (`nrjcbdrzaxqvomeogptf`) and local Supabase CLI environments, use the steps below.
+
+## Hosted dashboard settings
+1. Open **Supabase Dashboard → Authentication → Providers → Email** (or **Authentication → Settings → Email** in the newer UI).
+2. Turn **off** the toggle for **Confirm email** / **Require email confirmation** so new users are auto-confirmed.
+3. Leave **Secure email change** enabled if desired; it does not affect initial signup.
+4. Save changes.
+
+With confirmation disabled, new users created via `supabase.auth.signUp` should immediately be treated as confirmed and can sign in right away.
+
+## Prevent mailer invocations during signup
+Even with confirmations off, ensure the mailer is not called on signup by disabling SMTP while confirmations are disabled:
+
+```
+Authentication → Email → SMTP → toggle off
+```
+
+This avoids `/auth/v1/signup` failing with SMTP errors such as `535 5.7.8`.
+
+To re-enable confirmation emails later, turn **Confirm email** back **on** and re-enable your SMTP settings.
+
+## Local Supabase CLI configuration
+The local Supabase configuration mirrors the hosted setup for predictable behavior:
+
+- `[auth.email].enable_confirmations = false` auto-confirms email/password users.
+- `[auth.email.smtp].enabled = false` keeps the mailer disabled while confirmations are off.
+
+Apply these settings locally by running `supabase start` after pulling the repo so the local GoTrue respects the updated configuration.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -183,8 +183,8 @@ enable_signup = true
 # If enabled, a user will be required to confirm any email change on both the old, and new email
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
-# If enabled, users need to confirm their email address before signing in.
-enable_confirmations = true
+# Auto-confirm email/password users so signup does not trigger a confirmation email flow.
+enable_confirmations = false
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
@@ -196,7 +196,8 @@ otp_expiry = 3600
 # Use a production-ready SMTP server
 # For production, configure PrivateEmail SMTP settings
 [auth.email.smtp]
-enabled = true
+# Disable SMTP to prevent GoTrue from invoking the mailer during signup while confirmations are off.
+enabled = false
 # Use PrivateEmail over STARTTLS on 587. The host must be mail.privateemail.com for successful auth.
 host = "mail.privateemail.com"
 port = 587


### PR DESCRIPTION
## Summary
- disable email confirmations and SMTP in Supabase config to auto-confirm email/password signups
- add documentation for turning off confirmations and SMTP in the Supabase dashboard and local CLI

## Testing
- not run (configuration-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935ef1f232c8328918a3f6c7b4e5f0e)