### PR TITLE
Improve signup flow messaging and rate limit handling

### DIFF
--- a/src/components/auth/SignupFlow.tsx
+++ b/src/components/auth/SignupFlow.tsx
@@ -40,8 +40,7 @@ export const SignupFlow: React.FC = () => {
         <div className="mt-6 space-y-3 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800">
           <h2 className="text-xl font-semibold">Signup complete</h2>
           <p>
-            If email confirmation is enabled, check your inbox. After logging in you'll be redirected
-            based on your account type.
+            Your account is ready. Sign in with the credentials you just created to continue to your dashboard.
           </p>
           <ul className="list-disc space-y-1 pl-6 text-sm">
             <li>SME → /dashboard/sme</li>

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -843,7 +843,9 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       // Check for common error patterns and provide helpful messages
       const normalizedError = errorMessage.toLowerCase();
 
-      if (error.status === 500 || normalizedError.includes('unexpected_failure')) {
+      if (error.status === 429 || normalizedError.includes('rate limit')) {
+        errorMessage = 'Too many signup attempts in a short time. Please wait a moment before trying again.';
+      } else if (error.status === 500 || normalizedError.includes('unexpected_failure')) {
         errorMessage = 'We hit a temporary issue creating your account. Please try again shortly or contact support if this repeats.';
       } else if (normalizedError.includes('network') || normalizedError.includes('fetch')) {
         errorMessage = 'We couldn\'t reach WATHACI servers right now. Please try again shortly.';

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -90,16 +90,14 @@ export const SignUp = () => {
               <div className="space-y-4 rounded-2xl border border-green-100 bg-green-50 p-6">
                 <h2 className="text-2xl font-semibold text-green-900">Account created</h2>
                 <p className="text-base text-green-900">
-                  {confirmationRequired
-                    ? "Your account is ready. You can sign in now to continue setup."
-                    : "You can now sign in and complete your profile setup."}
+                  You can sign in immediately with your email and password to continue setting up your profile.
                 </p>
                 {emailForConfirmation ? (
-                  <p className="text-sm text-green-900">Confirmation sent to: {emailForConfirmation}</p>
+                  <p className="text-sm text-green-900">Registered email: {emailForConfirmation}</p>
                 ) : null}
                 {signInAvailable ? (
                   <Link to="/signin" className="font-semibold text-green-900 underline">
-                    Already have an account? Login
+                    Continue to login
                   </Link>
                 ) : null}
               </div>

--- a/src/pages/ZaqaSignup.tsx
+++ b/src/pages/ZaqaSignup.tsx
@@ -133,7 +133,13 @@ export const ZaqaSignup = () => {
 
       if (signUpError) {
         console.error('Sign-up error:', signUpError);
-        setError(withSupportContact(signUpError.message));
+        const normalized = signUpError.message?.toLowerCase?.() || '';
+        const isRateLimited = signUpError.status === 429 || normalized.includes('rate limit');
+        if (isRateLimited) {
+          setError('Too many signup attempts in a short time. Please wait and try again.');
+        } else {
+          setError(withSupportContact(signUpError.message));
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- add clearer rate-limit handling during signup to avoid confusing failures when email delivery is throttled
- update signup success messaging to emphasize immediate login instead of email confirmation
- refresh signup guidance across flows to direct users straight to their dashboards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935f38111f08328a6f467c73daada06)