### PR TITLE
Switch domain configuration to wathaci.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,15 +122,14 @@ SUPABASE_SMTP_SENDER_NAME="Wathaci"
 
 # Email Confirmation Redirect URLs
 # URL to redirect users after they click the email confirmation link
-# For local development, use localhost with the appropriate port
-# For production (Vercel), set to https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app/signin
-VITE_EMAIL_CONFIRMATION_REDIRECT_URL="http://127.0.0.1:3000/signin"
+# Production should always use the canonical domain callback endpoint
+VITE_EMAIL_CONFIRMATION_REDIRECT_URL="https://wathaci.com/auth/callback"
 # Alternative: use a path-only redirect (will use the app's base URL)
-# VITE_EMAIL_CONFIRMATION_REDIRECT_PATH="/signin"
+# VITE_EMAIL_CONFIRMATION_REDIRECT_PATH="/auth/callback"
 
 # Application Base URL (used to construct absolute redirect URLs)
-VITE_APP_BASE_URL="http://127.0.0.1:3000"
-VITE_SITE_URL="http://127.0.0.1:3000"
+VITE_APP_BASE_URL="https://wathaci.com"
+VITE_SITE_URL="https://wathaci.com"
 
 # --- Twilio Configuration (OTP via SMS & WhatsApp) ---
 # Configure these to enable OTP verification via SMS and WhatsApp

--- a/.env.preview
+++ b/.env.preview
@@ -1,4 +1,4 @@
 # Preview deployment configuration
 VITE_API_BASE_URL="https://wathaci-connect-platform2.vercel.app"
-ALLOWED_ORIGINS="https://www.wathaci.com,https://wathaci-connect-platform.vercel.app,https://wathaci-connect-platform-amukenas-projects.vercel.app"
-FRONTEND_URL="https://www.wathaci.com"
+ALLOWED_ORIGINS="https://wathaci.com,https://wathaci-connect-platform.vercel.app,https://wathaci-connect-platform-amukenas-projects.vercel.app"
+FRONTEND_URL="https://wathaci.com"

--- a/EMAIL_CONFIGURATION_GUIDE.md
+++ b/EMAIL_CONFIGURATION_GUIDE.md
@@ -108,7 +108,7 @@ npm run supabase:start
    - `http://localhost:3000`
    - `https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app`
    - `https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app/signin`
-   - `https://app.wathaci.com` and `https://app.wathaci.com/signin` (production)
+   - `https://wathaci.com` and `https://wathaci.com/signin` (production)
 
 ## DNS Configuration
 

--- a/EMAIL_CONFIRMATION_SETUP.md
+++ b/EMAIL_CONFIRMATION_SETUP.md
@@ -23,14 +23,14 @@ Add these variables to your environment files (`.env.local` for development, `.e
 ```bash
 # Email Confirmation Redirect URLs
 # URL to redirect users after they click the email confirmation link
-VITE_EMAIL_CONFIRMATION_REDIRECT_URL="https://app.wathaci.com/signin"
+VITE_EMAIL_CONFIRMATION_REDIRECT_URL="https://wathaci.com/auth/callback"
 
 # Alternative: use a path-only redirect (will use the app's base URL)
-# VITE_EMAIL_CONFIRMATION_REDIRECT_PATH="/signin"
+# VITE_EMAIL_CONFIRMATION_REDIRECT_PATH="/auth/callback"
 
 # Application Base URL (used to construct absolute redirect URLs)
-VITE_APP_BASE_URL="https://app.wathaci.com"
-VITE_SITE_URL="https://app.wathaci.com"
+VITE_APP_BASE_URL="https://wathaci.com"
+VITE_SITE_URL="https://wathaci.com"
 ```
 
 ### 2. Supabase Configuration
@@ -93,15 +93,15 @@ The app uses a helper function (`getEmailConfirmationRedirectUrl()`) to construc
 
 1. **Absolute URL**: `VITE_EMAIL_CONFIRMATION_REDIRECT_URL`
    - Use this if you want to specify a complete URL
-   - Example: `https://app.wathaci.com/signin`
+  - Example: `https://wathaci.com/auth/callback`
 
 2. **Path + Base URL**: `VITE_EMAIL_CONFIRMATION_REDIRECT_PATH` + `VITE_APP_BASE_URL`
    - Use this if you want to specify just the path
-   - Example: `/signin` + `https://app.wathaci.com` = `https://app.wathaci.com/signin`
+  - Example: `/auth/callback` + `https://wathaci.com` = `https://wathaci.com/auth/callback`
 
 3. **Fallback Path + Base URL**: Default path (`/signin`) + `VITE_APP_BASE_URL`
    - Used when no specific redirect is configured
-   - Example: `/signin` + `https://app.wathaci.com` = `https://app.wathaci.com/signin`
+  - Example: `/auth/callback` + `https://wathaci.com` = `https://wathaci.com/auth/callback`
 
 ### Base URL Resolution
 

--- a/EMAIL_OTP_FIX_SUMMARY.md
+++ b/EMAIL_OTP_FIX_SUMMARY.md
@@ -120,9 +120,9 @@ VITE_EMAIL_CONFIRMATION_REDIRECT_URL="http://127.0.0.1:3000/signin"
 
 ### Production
 ```bash
-VITE_APP_BASE_URL="https://app.wathaci.com"
-VITE_SITE_URL="https://app.wathaci.com"
-VITE_EMAIL_CONFIRMATION_REDIRECT_URL="https://app.wathaci.com/signin"
+VITE_APP_BASE_URL="https://wathaci.com"
+VITE_SITE_URL="https://wathaci.com"
+VITE_EMAIL_CONFIRMATION_REDIRECT_URL="https://wathaci.com/auth/callback"
 SMTP_PASSWORD="[your-smtp-password-here]"
 ```
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -29,7 +29,7 @@ const parseAllowedOrigins = (value = '') =>
 
 const defaultAllowedOrigins = [
   // Production deployments
-  'https://www.wathaci.com',
+  'https://wathaci.com',
   'https://wathaci-connect-platform.vercel.app',
   'https://wathaci-connect-platform-amukenas-projects.vercel.app',
   // Local development (aligned with Vite dev server)

--- a/docs/POST_LAUNCH_SMOKE_TEST_SCHEDULE.md
+++ b/docs/POST_LAUNCH_SMOKE_TEST_SCHEDULE.md
@@ -6,7 +6,7 @@ Immediately after a production release, run the following smoke checks to confir
 ## Schedule & Assignments
 | Time (relative) | Check | Owner | Procedure |
 | --- | --- | --- | --- |
-| T0 + 5 min | HTTPS availability | Priya Natarajan | Use the status dashboard or run `curl -I https://app.wathaci.com` to verify a 200/301 response. Confirm certificate validity and that the response time is below 500 ms. |
+| T0 + 5 min | HTTPS availability | Priya Natarajan | Use the status dashboard or run `curl -I https://wathaci.com` to verify a 200/301 response. Confirm certificate validity and that the response time is below 500 ms. |
 | T0 + 10 min | Webhook trigger path | Mateo Ruiz | From the staging workspace, send the `order.created` test payload to production via the admin console. Confirm the webhook endpoint returns HTTP 202 and that the downstream fulfillment service logs the event. |
 
 ## Monitoring During Stabilization Window

--- a/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+++ b/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
@@ -220,7 +220,7 @@ location / {
 If deploying to a new domain:
 1. Update DNS records to point to hosting platform
 2. Wait for DNS propagation (can take up to 48 hours)
-3. Verify DNS with: `nslookup app.wathaci.com`
+3. Verify DNS with: `nslookup wathaci.com`
 
 ### Step 5: Configure SSL/HTTPS
 

--- a/docs/SMTP_AUTH_RECOVERY.md
+++ b/docs/SMTP_AUTH_RECOVERY.md
@@ -52,7 +52,7 @@ Eliminate guessing by testing the mailbox outside Supabase:
 Use exactly the host/port/TLS combination that succeeds here in Supabase Auth.
 
 ## 4) Retest hosted signup end-to-end
-1. From the frontend (`http://localhost:3000` or `https://www.wathaci.com`), perform a fresh signup with a new email, e.g. `smtp.test+1@wathaci.com`.
+1. From the frontend (`http://localhost:3000` or `https://wathaci.com`), perform a fresh signup with a new email, e.g. `smtp.test+1@wathaci.com`.
 2. Alternatively, use the Auth REST endpoint directly:
    ```bash
    SUPABASE_URL="https://nrjcbdrzaxqvomeogptf.supabase.co"

--- a/docs/SUPABASE_SMTP_TROUBLESHOOTING.md
+++ b/docs/SUPABASE_SMTP_TROUBLESHOOTING.md
@@ -49,16 +49,16 @@ Authentication must succeed (no `535`). Send a test email to confirm deliverabil
 
 ## 3) Verify redirect and site URLs
 
-In **Authentication → URL Configuration**, ensure all production URLs are whitelisted so `redirect_to=https://app.wathaci.com/signin` does not get rejected:
+In **Authentication → URL Configuration**, ensure all production URLs are whitelisted so `redirect_to=https://wathaci.com/auth/callback` does not get rejected:
 
-- `https://www.wathaci.com`
-- `https://app.wathaci.com`
-- `https://app.wathaci.com/signin`
+- `https://wathaci.com`
+- `https://wathaci.com`
+- `https://wathaci.com/auth/callback`
 - Optionally `http://localhost:3000` for local testing.
 
 ## 4) Re-test production signup
 
-1. From `https://www.wathaci.com`, sign up with a fresh email (e.g., `prod.test+1@wathaci.com`).
-2. Confirm the `/auth/v1/signup?redirect_to=https%3A%2F%2Fapp.wathaci.com%2Fsignin` call returns 200 (no 500 or `unexpected_failure`).
-3. Ensure the confirmation email arrives from `support@wathaci.com` and the link redirects successfully to `https://app.wathaci.com/signin`.
+1. From `https://wathaci.com`, sign up with a fresh email (e.g., `prod.test+1@wathaci.com`).
+2. Confirm the `/auth/v1/signup?redirect_to=https%3A%2F%2Fwathaci.com%2Fauth%2Fcallback` call returns 200 (no 500 or `unexpected_failure`).
+3. Ensure the confirmation email arrives from `support@wathaci.com` and the link redirects successfully to `https://wathaci.com/auth/callback`.
 4. Back in **Logs → Auth**, filter recent `/signup` events and verify there are no new `500: Error sending confirmation email` entries and no `535 5.7.8` errors.

--- a/src/lib/emailRedirect.ts
+++ b/src/lib/emailRedirect.ts
@@ -10,6 +10,8 @@
  * Tries multiple environment variables and falls back to window.location.origin
  */
 const getAppBaseUrl = (): string | undefined => {
+  const defaultBaseUrl = 'https://wathaci.com';
+
   // Try various environment variable names
   const envKeys = [
     'VITE_APP_BASE_URL',
@@ -25,6 +27,11 @@ const getAppBaseUrl = (): string | undefined => {
         return trimmed;
       }
     }
+  }
+
+  // Prefer the canonical domain when no environment variable is provided
+  if (defaultBaseUrl) {
+    return defaultBaseUrl;
   }
 
   // Fallback to window.location.origin if available

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -4,6 +4,24 @@ export interface LogContext {
   [key: string]: any;
 }
 
+const DEFAULT_SITE_ORIGIN = 'https://wathaci.com';
+const ORIGIN_ENV_KEYS = ['VITE_APP_BASE_URL', 'VITE_SITE_URL', 'VITE_PUBLIC_SITE_URL'];
+
+const resolveBaseOrigin = (): string => {
+  for (const key of ORIGIN_ENV_KEYS) {
+    const value = typeof import.meta !== 'undefined' ? (import.meta as any)?.env?.[key] : undefined;
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+
+  return DEFAULT_SITE_ORIGIN;
+};
+
 function sendToMonitoringService(log: any) {
   try {
     const isBrowserEnvironment =
@@ -13,7 +31,7 @@ function sendToMonitoringService(log: any) {
       return;
     }
 
-    const endpoint = new URL('/api/logs', window.location.origin);
+    const endpoint = new URL('/api/logs', resolveBaseOrigin());
 
     fetch(endpoint, {
       method: 'POST',

--- a/src/lib/services/lenco-payment-service.ts
+++ b/src/lib/services/lenco-payment-service.ts
@@ -19,9 +19,17 @@ import {
 import { logger } from '../logger';
 import { supabase } from '../supabase-enhanced';
 
-const FALLBACK_APP_ORIGIN = 'https://localhost.test';
+const DEFAULT_APP_ORIGIN = 'https://wathaci.com';
+const ORIGIN_ENV_KEYS = ['VITE_APP_BASE_URL', 'VITE_SITE_URL', 'VITE_PUBLIC_SITE_URL'];
 
 const getRuntimeOrigin = (): string => {
+  for (const key of ORIGIN_ENV_KEYS) {
+    const value = typeof import.meta !== 'undefined' ? (import.meta as any)?.env?.[key] : undefined;
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
   if (typeof window !== 'undefined' && window.location?.origin) {
     return window.location.origin;
   }
@@ -30,7 +38,7 @@ const getRuntimeOrigin = (): string => {
     return (globalThis as any).__APP_URL__ as string;
   }
 
-  return FALLBACK_APP_ORIGIN;
+  return DEFAULT_APP_ORIGIN;
 };
 
 const persistPaymentReference = (reference: string) => {

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -123,6 +123,7 @@ const offlineAccounts: OfflineAccount[] = [
 ];
 
 const FALLBACK_EMAIL_REDIRECT_PATH = '/signin';
+const DEFAULT_APP_BASE_URL = 'https://wathaci.com';
 
 const APP_BASE_URL_KEYS = [
   'VITE_APP_BASE_URL',
@@ -177,6 +178,11 @@ const getRuntimeBaseUrl = (): string | undefined => {
         return normalized;
       }
     }
+  }
+
+  const defaultBase = normalizeBaseUrl(DEFAULT_APP_BASE_URL);
+  if (defaultBase) {
+    return defaultBase;
   }
 
   if (typeof window !== 'undefined' && window.location?.origin) {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -123,16 +123,18 @@ enabled = true
 site_url = "env(VITE_SITE_URL)"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 # Allow production redirect targets so email confirmation links resolve without 500s
-# when users sign up from app.wathaci.com or the marketing site.
+# when users sign up from wathaci.com or the marketing site.
 additional_redirect_urls = [
   "https://127.0.0.1:3000",
   "http://localhost:3000",
   "https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app",
   "https://wathaci-connect-platform-8fy8qoekg-amukenas-projects.vercel.app/signin",
-  "https://app.wathaci.com/signin",
-  "https://app.wathaci.com",
-  "https://www.wathaci.com",
-  "https://www.wathaci.com/signin"
+  "https://wathaci.com",
+  "https://wathaci.com/signin",
+  "https://wathaci.com/signup",
+  "https://wathaci.com/reset-password",
+  "https://wathaci.com/account",
+  "https://wathaci.com/auth/callback"
 ]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -63,13 +63,13 @@ test('CORS headers are properly set for allowed origins', async () => {
     // Test with origin header
     const res = await fetch(`http://localhost:${port}/health`, {
       headers: {
-        'Origin': 'https://www.wathaci.com',
+        'Origin': 'https://wathaci.com',
       },
     });
 
     // CORS should allow configured origins
     const allowOriginHeader = res.headers.get('access-control-allow-origin');
-    assert.ok(allowOriginHeader === '*' || allowOriginHeader === 'https://www.wathaci.com');
+    assert.ok(allowOriginHeader === '*' || allowOriginHeader === 'https://wathaci.com');
     
     const allowMethodsHeader = res.headers.get('access-control-allow-methods');
     assert.ok(allowMethodsHeader?.includes('GET'));
@@ -87,7 +87,7 @@ test('OPTIONS request returns proper CORS headers', async () => {
     const res = await fetch(`http://localhost:${port}/users`, {
       method: 'OPTIONS',
       headers: {
-        'Origin': 'https://www.wathaci.com',
+        'Origin': 'https://wathaci.com',
       },
     });
     
@@ -117,7 +117,7 @@ test('User registration endpoint is accessible from frontend', async () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Origin': 'https://www.wathaci.com',
+          'Origin': 'https://wathaci.com',
         },
         body: JSON.stringify(userData),
       });
@@ -150,7 +150,7 @@ test('OTP send endpoint is accessible from frontend', async () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Origin': 'https://www.wathaci.com',
+          'Origin': 'https://wathaci.com',
         },
         body: JSON.stringify(otpRequest),
       });
@@ -180,7 +180,7 @@ test('Log endpoint accepts frontend logs', async () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Origin': 'https://www.wathaci.com',
+          'Origin': 'https://wathaci.com',
         },
         body: JSON.stringify(logEntry),
       });
@@ -201,7 +201,7 @@ test('Payment readiness endpoint is accessible', async () => {
   try {
       const res = await fetch(`http://localhost:${port}/api/payment/readiness`, {
         headers: {
-          'Origin': 'https://www.wathaci.com',
+          'Origin': 'https://wathaci.com',
         },
       });
     


### PR DESCRIPTION
## Summary
- Update Supabase auth redirects, environment defaults, and documentation to point to https://wathaci.com and its callback endpoint
- Align frontend runtime origin helpers, backend CORS defaults, and integration tests with the canonical domain
- Refresh preview and production guidance so whitelists and redirect URLs use the new host

## Testing
- npm test -- --runTestsByPath test/integration.test.js *(fails: missing env vars and dependencies such as express/twilio in the test harness)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69365b4729108328a5925d8c433d1aa7)