### PR TITLE
Fix recursive profiles admin policy

### DIFF
--- a/supabase/migrations/20260207120000_fix_profiles_rls_recursion.sql
+++ b/supabase/migrations/20260207120000_fix_profiles_rls_recursion.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+-- Remove the recursive admin policy that selected from public.profiles inside its own RLS predicate.
+DROP POLICY IF EXISTS profiles_admin_all ON public.profiles;
+
+-- Helper to evaluate admin access without invoking RLS on public.profiles (avoids recursion).
+CREATE OR REPLACE FUNCTION public.is_profile_admin(p_uid uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.id = COALESCE(p_uid, auth.uid())
+      AND p.account_type = 'ADMIN'
+  );
+END;
+$$;
+
+-- Ensure callers have explicit execute privileges.
+REVOKE ALL ON FUNCTION public.is_profile_admin(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_profile_admin(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.is_profile_admin(uuid) TO service_role;
+
+-- Recreate the admin-all policy using the helper function (non-recursive).
+CREATE POLICY profiles_admin_all ON public.profiles
+  FOR ALL
+  TO authenticated
+  USING (public.is_profile_admin(auth.uid()))
+  WITH CHECK (public.is_profile_admin(auth.uid()));
+
+-- Document the prior recursion issue to prevent regressions.
+COMMENT ON TABLE public.profiles IS
+  'Profiles table. Previous admin policy queried the same table inside its predicate, which caused Postgres error 42P17 (infinite recursion) via PostgREST. Keep predicates non-recursive (use public.is_profile_admin).';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- drop the recursive profiles admin policy that self-selected from public.profiles
- add a SECURITY DEFINER helper to evaluate admin access without triggering RLS recursion
- recreate the admin policy using the helper and document the prior 42P17 issue on the table

## Testing
- not run (not applicable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693660ead960832884ff271bcd0fa4ee)