### PR TITLE
Ensure onboarding profile creation and gating

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -177,7 +177,23 @@ export const AppRoutes = () => (
       <Route path="/signup-zaqa" element={withAppLayout(<ZaqaSignup />, { showFooter: false })} />
       <Route path="/forgot-password" element={withAppLayout(<ForgotPassword />, { showFooter: false })} />
       <Route path="/reset-password" element={withAppLayout(<ResetPassword />, { showFooter: false })} />
-      <Route path="/get-started" element={withAppLayout(<GetStartedPage />)} />
+      <Route
+        path="/get-started"
+        element={withAppLayout(
+          <PrivateRoute>
+            <GetStartedPage />
+          </PrivateRoute>
+        )}
+      />
+      <Route
+        path="/onboarding/account-type"
+        element={withAppLayout(
+          <PrivateRoute>
+            <GetStartedPage />
+          </PrivateRoute>,
+          { showFooter: false }
+        )}
+      />
       <Route path="/onboarding" element={withAppLayout(<OnboardingLanding />, { showFooter: false })} />
       <Route path="/profile-setup" element={withAppLayout(<ProfileSetup />, { showFooter: false })} />
       <Route path="/profile-review" element={withAppLayout(<ProfileReview />, { showFooter: false })} />

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { normalizeMsisdn } from '@/utils/phone';
 import { isStrongPassword, PASSWORD_MIN_LENGTH, passwordStrengthMessage } from '@/utils/password';
+import { getOnboardingStartPath, normalizeAccountType } from '@/lib/onboardingPaths';
 
 const CREDENTIALS_STORAGE_KEY = 'wathaci-auth-credentials';
 
@@ -176,9 +177,12 @@ export const AuthForm = ({ mode, redirectTo, onSuccess, disabled = false, disabl
     }
 
     // Smart redirect based on profile completion status
-    if (!profile || !user.profile_completed) {
-      // User needs to complete profile setup
-      navigate('/profile-setup', { replace: true });
+    const normalizedAccountType = normalizeAccountType(profile?.account_type ?? user.account_type);
+    const onboardingPath = getOnboardingStartPath(normalizedAccountType);
+    const profileIsComplete = profile?.profile_completed ?? user.profile_completed;
+
+    if (!profile || !profileIsComplete) {
+      navigate(onboardingPath, { replace: true });
     } else if (redirectTo) {
       // Use provided redirect destination
       navigate(redirectTo, { replace: true });

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,7 +1,10 @@
-import { ReactNode } from "react";
-import { Navigate } from "react-router-dom";
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import { Navigate, useLocation } from "react-router-dom";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
 import { LoadingScreen } from "@/components/LoadingScreen";
+import { useAppContext } from "@/contexts/AppContext";
+import { getOnboardingStartPath, isOnboardingPath, normalizeAccountType } from "@/lib/onboardingPaths";
+import { logger } from "@/lib/logger";
 
 interface PrivateRouteProps {
   children: ReactNode;
@@ -9,13 +12,49 @@ interface PrivateRouteProps {
 
 export const PrivateRoute = ({ children }: PrivateRouteProps) => {
   const { user, loading } = useSupabaseAuth();
+  const { profile, refreshUser } = useAppContext();
+  const location = useLocation();
+  const [checkingProfile, setCheckingProfile] = useState(false);
 
-  if (loading) {
+  useEffect(() => {
+    if (!loading && user && !profile && !checkingProfile) {
+      setCheckingProfile(true);
+      refreshUser()
+        .catch((error) => {
+          logger.error("Failed to refresh profile inside PrivateRoute", error, {
+            event: "auth:guard:refresh-error",
+            userId: user.id,
+          });
+        })
+        .finally(() => setCheckingProfile(false));
+    }
+  }, [checkingProfile, loading, profile, refreshUser, user]);
+
+  const normalizedAccountType = useMemo(
+    () => normalizeAccountType(profile?.account_type ?? user?.account_type),
+    [profile?.account_type, user?.account_type]
+  );
+
+  const profileCompleted = profile?.profile_completed ?? user?.profile_completed ?? false;
+  const onboardingPath = getOnboardingStartPath(normalizedAccountType);
+  const inOnboarding = isOnboardingPath(location.pathname);
+
+  if (loading || checkingProfile) {
     return <LoadingScreen />;
   }
 
   if (!user) {
-    return <Navigate to="/signin" replace />;
+    return <Navigate to="/signin" state={{ from: location }} replace />;
+  }
+
+  if (!profileCompleted && !inOnboarding) {
+    logger.info("Redirecting authenticated user to onboarding", {
+      event: "auth:guard:onboarding-redirect",
+      userId: user.id,
+      target: onboardingPath,
+      accountType: normalizedAccountType,
+    });
+    return <Navigate to={onboardingPath} state={{ from: location }} replace />;
   }
 
   return <>{children}</>;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,16 +1,20 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   supabaseClient,
   getDashboardPathForAccountType,
   type AccountType,
 } from "@/lib/wathaciSupabaseClient";
 import { withSupportContact } from "@/lib/supportEmail";
+import { getOnboardingStartPath, normalizeAccountType } from "@/lib/onboardingPaths";
+import { logger } from "@/lib/logger";
 
 export interface LoginFormProps {
   onLogin?: (accountType: AccountType | null | undefined) => void;
 }
 
 export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -40,23 +44,60 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
 
       const { data: profile, error: profileError } = await supabaseClient
         .from("profiles")
-        .select("account_type")
+        .select("account_type, profile_completed, email")
         .eq("id", userId)
-        .single();
+        .maybeSingle();
 
-      if (profileError) {
+      let resolvedProfile = profile;
+
+      if (profileError && profileError.code !== "PGRST116") {
         console.error(profileError);
         setError(withSupportContact(profileError.message));
         return;
       }
 
-      const normalizedType = (typeof profile?.account_type === "string"
-        ? (profile.account_type.toLowerCase() as AccountType)
-        : null);
+      if (!resolvedProfile) {
+        const { data: createdProfile, error: createError } = await supabaseClient
+          .from("profiles")
+          .insert({
+            id: userId,
+            email: data.user?.email ?? email,
+            account_type: null,
+            profile_completed: false,
+          })
+          .select("account_type, profile_completed, email")
+          .single();
+
+        if (createError) {
+          console.error(createError);
+          setError(withSupportContact(createError.message));
+          return;
+        }
+
+        resolvedProfile = createdProfile;
+        logger.info("Created missing profile after sign in", {
+          event: "auth:login:create-profile",
+          userId,
+        });
+      }
+
+      const normalizedType = normalizeAccountType(resolvedProfile?.account_type as string | null);
+      const onboardingPath = getOnboardingStartPath(normalizedType);
+
+      if (!resolvedProfile?.profile_completed || !normalizedType) {
+        logger.info("Redirecting user to onboarding after sign in", {
+          event: "auth:login:onboarding-redirect",
+          userId,
+          accountType: normalizedType,
+        });
+        onLogin?.(normalizedType || undefined);
+        navigate(onboardingPath, { replace: true });
+        return;
+      }
 
       const destination = getDashboardPathForAccountType(normalizedType);
       onLogin?.(normalizedType || undefined);
-      window.location.href = destination;
+      navigate(destination, { replace: true });
     } catch (unknownError) {
       console.error(unknownError);
       setError(withSupportContact("Unable to login. Please try again"));

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import { type AccountTypeValue } from "@/data/accountTypes";
 import { supabaseClient as supabase } from "@/lib/supabaseClient";
@@ -25,6 +25,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertCircle, Loader2 } from "lucide-react";
+import { getOnboardingStartPath, normalizeAccountType } from "@/lib/onboardingPaths";
 
 const formSchema = z.object({
   fullName: z
@@ -82,6 +83,7 @@ export const SignupForm = ({
   onSuccess,
   disabled = false,
 }: SignupFormProps) => {
+  const navigate = useNavigate();
   const {
     register,
     handleSubmit,
@@ -272,6 +274,12 @@ export const SignupForm = ({
           values,
           normalizedAccountType
         );
+
+        const onboardingPath = getOnboardingStartPath(normalizeAccountType(normalizedAccountType));
+        clearSignupAttempts();
+        onSuccess(normalizedEmail, requiresConfirmation, normalizedMobileNumber || undefined);
+        navigate(onboardingPath, { replace: true });
+        return;
       }
 
       // Clear signup attempt tracking on success
@@ -323,6 +331,12 @@ export const SignupForm = ({
           values,
           normalizedAccountType
         );
+
+        const onboardingPath = getOnboardingStartPath(normalizeAccountType(normalizedAccountType));
+        clearSignupAttempts();
+        onSuccess(normalizedEmail, requiresEmailConfirmation, normalizedMobileNumber || undefined);
+        navigate(onboardingPath, { replace: true });
+        return;
       }
 
       // Clear signup attempt tracking on success

--- a/src/lib/onboardingPaths.ts
+++ b/src/lib/onboardingPaths.ts
@@ -1,0 +1,53 @@
+import { logger } from '@/lib/logger';
+
+export type OnboardingAccountType =
+  | 'sme'
+  | 'sole_proprietor'
+  | 'professional'
+  | 'investor'
+  | 'donor'
+  | 'government';
+
+export const normalizeAccountType = (accountType?: string | null): OnboardingAccountType | null => {
+  if (!accountType) return null;
+  const normalized = accountType.toString().trim().toLowerCase();
+
+  if (
+    normalized === 'sme' ||
+    normalized === 'sole_proprietor' ||
+    normalized === 'professional' ||
+    normalized === 'investor' ||
+    normalized === 'donor' ||
+    normalized === 'government'
+  ) {
+    return normalized;
+  }
+
+  logger.warn('Unknown account type encountered while normalizing', {
+    event: 'onboarding:account-type:unknown',
+    value: accountType,
+  });
+
+  return null;
+};
+
+export const getOnboardingStartPath = (accountType?: string | null): string => {
+  const normalized = normalizeAccountType(accountType);
+
+  switch (normalized) {
+    case 'sme':
+    case 'sole_proprietor':
+      return '/onboarding/sme';
+    case 'professional':
+      return '/onboarding/professional';
+    case 'investor':
+    case 'donor':
+      return '/onboarding/investor';
+    case 'government':
+      return '/onboarding/government/needs-assessment';
+    default:
+      return '/onboarding/account-type';
+  }
+};
+
+export const isOnboardingPath = (pathname: string): boolean => pathname.startsWith('/onboarding');

--- a/supabase/migrations/20260606120000_profile_onboarding_flow.sql
+++ b/supabase/migrations/20260606120000_profile_onboarding_flow.sql
@@ -1,0 +1,129 @@
+BEGIN;
+
+-- Ensure core profile columns exist and are nullable where onboarding requires selection later
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS id uuid,
+  ADD COLUMN IF NOT EXISTS email text,
+  ADD COLUMN IF NOT EXISTS account_type public.account_type_enum,
+  ADD COLUMN IF NOT EXISTS profile_completed boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS created_at timestamptz DEFAULT timezone('utc', now()),
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT timezone('utc', now());
+
+-- Keep profile_completed consistent and nullable columns relaxed for onboarding
+ALTER TABLE public.profiles ALTER COLUMN profile_completed SET DEFAULT false;
+UPDATE public.profiles SET profile_completed = COALESCE(profile_completed, false);
+ALTER TABLE public.profiles ALTER COLUMN profile_completed SET NOT NULL;
+
+ALTER TABLE public.profiles ALTER COLUMN account_type DROP NOT NULL;
+ALTER TABLE public.profiles ALTER COLUMN account_type DROP DEFAULT;
+
+-- Ensure primary key and foreign key constraints are present
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'profiles_pkey'
+      AND conrelid = 'public.profiles'::regclass
+  ) THEN
+    ALTER TABLE public.profiles ADD CONSTRAINT profiles_pkey PRIMARY KEY (id);
+  END IF;
+END
+$$;
+
+ALTER TABLE public.profiles ALTER COLUMN id SET NOT NULL;
+ALTER TABLE public.profiles DROP CONSTRAINT IF EXISTS profiles_id_fkey;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_id_fkey FOREIGN KEY (id) REFERENCES auth.users (id) ON DELETE CASCADE;
+
+-- Trigger to create a profile as soon as a new auth user is inserted
+CREATE OR REPLACE FUNCTION public.handle_new_user_profile()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.profiles p WHERE p.id = NEW.id
+  ) THEN
+    INSERT INTO public.profiles (id, email, account_type, profile_completed)
+    VALUES (
+      NEW.id,
+      NEW.email,
+      NULL,
+      false
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created_profile ON auth.users;
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created_profile
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE PROCEDURE public.handle_new_user_profile();
+
+-- RLS policies that allow users to manage only their own profile (plus admin helper)
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.is_profile_admin(p_uid uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.id = COALESCE(p_uid, auth.uid())
+      AND p.account_type::text = 'admin'
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.is_profile_admin(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_profile_admin(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.is_profile_admin(uuid) TO service_role;
+
+DROP POLICY IF EXISTS profiles_select_own ON public.profiles;
+DROP POLICY IF EXISTS profiles_update_own ON public.profiles;
+DROP POLICY IF EXISTS profiles_insert_owner ON public.profiles;
+DROP POLICY IF EXISTS profiles_admin_all ON public.profiles;
+
+CREATE POLICY profiles_select_own ON public.profiles
+  FOR SELECT
+  USING (id = auth.uid());
+
+CREATE POLICY profiles_update_own ON public.profiles
+  FOR UPDATE
+  USING (id = auth.uid())
+  WITH CHECK (id = auth.uid());
+
+CREATE POLICY profiles_insert_owner ON public.profiles
+  FOR INSERT
+  WITH CHECK (id = auth.uid());
+
+CREATE POLICY profiles_admin_all ON public.profiles
+  FOR ALL
+  TO authenticated
+  USING (public.is_profile_admin(auth.uid()))
+  WITH CHECK (public.is_profile_admin(auth.uid()));
+
+-- Backfill existing auth users without profiles to avoid onboarding dead ends
+INSERT INTO public.profiles (id, email, account_type, profile_completed)
+SELECT
+  u.id,
+  u.email,
+  NULL,
+  false
+FROM auth.users u
+LEFT JOIN public.profiles p ON p.id = u.id
+WHERE p.id IS NULL
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add database migration to harden profile schema, automatic creation trigger, and updated RLS policies for onboarding
- add shared onboarding path helper and enforce profile completion gating via PrivateRoute and auth flows
- redirect signup and login journeys to account-type onboarding while creating missing profiles when needed

## Testing
- npm test -- --runInBand onboarding.test.ts *(fails: requires email argument)*
- npx eslint src/components/PrivateRoute.tsx src/components/auth/LoginForm.tsx src/components/AuthForm.tsx src/components/auth/SignupForm.tsx src/lib/onboardingPaths.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693666a4b35883288fbdff5a0087e687)