### PR TITLE
Add onboarding profile gating and account selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AppProvider } from "@/contexts/AppContext";
 import { LoadingScreen } from "@/components/LoadingScreen";
-import { PrivateRoute } from "./components/PrivateRoute";
 import { AccountTypeRoute } from "./components/AccountTypeRoute";
 import { ConfigurationError } from "@/components/ConfigurationError";
 import { RouteChangeDebugger } from "@/components/RouteChangeDebugger";
@@ -15,6 +14,7 @@ import { supabaseConfigStatus } from "@/config/appConfig";
 import { getPaymentConfig } from "@/lib/payment-config";
 import CisoWidget from "@/components/CisoWidget";
 import AppLayout from "./components/AppLayout";
+import { RequireAuth, RequireCompletedProfile } from "./components/auth/RequireAuth";
 import "./i18n";
 
 const queryClient = new QueryClient();
@@ -94,6 +94,11 @@ const CreditPassport = lazy(() => import("./pages/CreditPassport"));
 const OnboardingLanding = lazy(() =>
   import("./pages/OnboardingLanding").then((module) => ({ default: module.OnboardingLanding }))
 );
+const AccountTypeSelectionPage = lazy(() =>
+  import("./pages/onboarding/AccountTypeSelectionPage").then((module) => ({
+    default: module.AccountTypeSelectionPage,
+  }))
+);
 
 // Onboarding pages
 const SmeNeedsAssessmentPage = lazy(() =>
@@ -160,6 +165,14 @@ const withAppLayout = (element: ReactNode, options: { showFooter?: boolean } = {
   <AppLayout showFooter={options.showFooter ?? true}>{element}</AppLayout>
 );
 
+const withAuth = (element: ReactNode) => <RequireAuth>{element}</RequireAuth>;
+
+const withCompletedProfile = (element: ReactNode) => (
+  <RequireAuth>
+    <RequireCompletedProfile>{element}</RequireCompletedProfile>
+  </RequireAuth>
+);
+
 
 export const AppRoutes = () => (
   <Suspense fallback={<LoadingScreen />}>
@@ -179,17 +192,17 @@ export const AppRoutes = () => (
       <Route path="/reset-password" element={withAppLayout(<ResetPassword />, { showFooter: false })} />
       <Route path="/get-started" element={withAppLayout(<GetStartedPage />)} />
       <Route path="/onboarding" element={withAppLayout(<OnboardingLanding />, { showFooter: false })} />
+      <Route
+        path="/onboarding/account-type"
+        element={withAppLayout(withAuth(<AccountTypeSelectionPage />), { showFooter: false })}
+      />
       <Route path="/profile-setup" element={withAppLayout(<ProfileSetup />, { showFooter: false })} />
       <Route path="/profile-review" element={withAppLayout(<ProfileReview />, { showFooter: false })} />
       <Route path="/subscription-plans" element={withAppLayout(<SubscriptionPlans />)} />
       <Route path="/partnership-hub" element={<PartnershipHub />} />
       <Route
         path="/funding-hub"
-        element={
-          <PrivateRoute>
-            <FundingHub />
-          </PrivateRoute>
-        }
+        element={withCompletedProfile(<FundingHub />)}
       />
       <Route path="/privacy-policy" element={withAppLayout(<PrivacyPolicy />)} />
       <Route path="/terms-of-service" element={withAppLayout(<TermsOfService />)} />
@@ -198,19 +211,13 @@ export const AppRoutes = () => (
       <Route path="/checkout" element={<PaymentPage />} />
       <Route
         path="/messages"
-        element={
-          <PrivateRoute>
-            <Messages />
-          </PrivateRoute>
-        }
+        element={withCompletedProfile(<Messages />)}
       />
       <Route
         path="/sme-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <SMEAssessment />
-            </PrivateRoute>,
+            withCompletedProfile(<SMEAssessment />),
             { showFooter: false }
           )
         }
@@ -219,9 +226,7 @@ export const AppRoutes = () => (
         path="/investor-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <InvestorAssessment />
-            </PrivateRoute>,
+            withCompletedProfile(<InvestorAssessment />),
             { showFooter: false }
           )
         }
@@ -230,9 +235,7 @@ export const AppRoutes = () => (
         path="/donor-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <DonorAssessment />
-            </PrivateRoute>,
+            withCompletedProfile(<DonorAssessment />),
             { showFooter: false }
           )
         }
@@ -241,9 +244,7 @@ export const AppRoutes = () => (
         path="/professional-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <ProfessionalAssessment />
-            </PrivateRoute>,
+            withCompletedProfile(<ProfessionalAssessment />),
             { showFooter: false }
           )
         }
@@ -252,9 +253,7 @@ export const AppRoutes = () => (
         path="/government-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <GovernmentAssessment />
-            </PrivateRoute>,
+            withCompletedProfile(<GovernmentAssessment />),
             { showFooter: false }
           )
         }
@@ -265,9 +264,7 @@ export const AppRoutes = () => (
         path="/onboarding/sme/needs-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <SmeNeedsAssessmentPage />
-            </PrivateRoute>,
+            withAuth(<SmeNeedsAssessmentPage />),
             { showFooter: false }
           )
         }
@@ -276,11 +273,11 @@ export const AppRoutes = () => (
         path="/onboarding/sme"
         element={
           withAppLayout(
-            <PrivateRoute>
+            withAuth(
               <AccountTypeRoute allowed={["sme"]}>
                 <SmeOnboardingPage />
               </AccountTypeRoute>
-            </PrivateRoute>,
+            ),
             { showFooter: false }
           )
         }
@@ -289,9 +286,7 @@ export const AppRoutes = () => (
         path="/onboarding/professional/needs-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <ProfessionalNeedsAssessmentPage />
-            </PrivateRoute>,
+            withAuth(<ProfessionalNeedsAssessmentPage />),
             { showFooter: false }
           )
         }
@@ -300,11 +295,11 @@ export const AppRoutes = () => (
         path="/onboarding/professional"
         element={
           withAppLayout(
-            <PrivateRoute>
+            withAuth(
               <AccountTypeRoute allowed={["professional"]}>
                 <ProfessionalOnboardingPage />
               </AccountTypeRoute>
-            </PrivateRoute>,
+            ),
             { showFooter: false }
           )
         }
@@ -313,9 +308,7 @@ export const AppRoutes = () => (
         path="/onboarding/donor/needs-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <DonorNeedsAssessmentPage />
-            </PrivateRoute>,
+            withAuth(<DonorNeedsAssessmentPage />),
             { showFooter: false }
           )
         }
@@ -324,9 +317,7 @@ export const AppRoutes = () => (
         path="/onboarding/investor/needs-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <InvestorNeedsAssessmentPage />
-            </PrivateRoute>,
+            withAuth(<InvestorNeedsAssessmentPage />),
             { showFooter: false }
           )
         }
@@ -335,11 +326,11 @@ export const AppRoutes = () => (
         path="/onboarding/investor"
         element={
           withAppLayout(
-            <PrivateRoute>
+            withAuth(
               <AccountTypeRoute allowed={["investor", "donor"]}>
                 <InvestorOnboardingPage />
               </AccountTypeRoute>
-            </PrivateRoute>,
+            ),
             { showFooter: false }
           )
         }
@@ -348,9 +339,7 @@ export const AppRoutes = () => (
         path="/onboarding/government/needs-assessment"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <GovernmentNeedsAssessmentPage />
-            </PrivateRoute>,
+            withAuth(<GovernmentNeedsAssessmentPage />),
             { showFooter: false }
           )
         }
@@ -359,19 +348,11 @@ export const AppRoutes = () => (
       {/* SME Readiness feature routes */}
       <Route
         path="/readiness"
-        element={
-          <PrivateRoute>
-            <ReadinessCheck />
-          </PrivateRoute>
-        }
+        element={withCompletedProfile(<ReadinessCheck />)}
       />
       <Route
         path="/readiness/result"
-        element={
-          <PrivateRoute>
-            <ReadinessResult />
-          </PrivateRoute>
-        }
+        element={withCompletedProfile(<ReadinessResult />)}
       />
       
       {/* Compliance Hub route */}
@@ -379,28 +360,18 @@ export const AppRoutes = () => (
         path="/compliance"
         element={
           withAppLayout(
-            <PrivateRoute>
-              <ComplianceDashboard />
-            </PrivateRoute>
+            withCompletedProfile(<ComplianceDashboard />),
           )
         }
       />
 
       <Route
         path="/ai-documents"
-        element={
-          <PrivateRoute>
-            <DocumentGenerators />
-          </PrivateRoute>
-        }
+        element={withCompletedProfile(<DocumentGenerators />)}
       />
       <Route
         path="/credit-passport"
-        element={
-          <PrivateRoute>
-            <CreditPassport />
-          </PrivateRoute>
-        }
+        element={withCompletedProfile(<CreditPassport />)}
       />
 
       <Route path="*" element={withAppLayout(<NotFound />, { showFooter: false })} />

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,69 @@
+import { ReactNode, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/lib/supabaseClient';
+import { useProfile } from '@/hooks/useProfile';
+
+interface RequireAuthProps {
+  children: ReactNode;
+}
+
+export function RequireAuth({ children }: RequireAuthProps) {
+  const [checking, setChecking] = useState(true);
+  const [authenticated, setAuthenticated] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const check = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!session) {
+        setAuthenticated(false);
+        navigate('/signin', { replace: true });
+      } else {
+        setAuthenticated(true);
+      }
+      setChecking(false);
+    };
+
+    check();
+  }, [navigate]);
+
+  if (checking) return <div>Checking authentication…</div>;
+  if (!authenticated) return null;
+
+  return <>{children}</>;
+}
+
+interface RequireCompletedProfileProps {
+  children: ReactNode;
+}
+
+export function RequireCompletedProfile({ children }: RequireCompletedProfileProps) {
+  const { loading, profile, error } = useProfile();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (loading) return;
+
+    if (error || !profile) {
+      navigate('/onboarding/account-type', { replace: true });
+      return;
+    }
+
+    if (!profile.account_type) {
+      navigate('/onboarding/account-type', { replace: true });
+      return;
+    }
+
+    if (!profile.profile_completed) {
+      navigate(`/onboarding/${profile.account_type}`, { replace: true });
+    }
+  }, [loading, profile, error, navigate]);
+
+  if (loading) return <div>Loading your profile…</div>;
+  if (error) return <div>Something went wrong loading your profile.</div>;
+
+  return <>{children}</>;
+}

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import AccountTypeSelector from "@/components/auth/AccountTypeSelector";
 import SignupForm from "@/components/auth/SignupForm";
@@ -10,6 +10,7 @@ import { getMaintenanceConfig } from "@/config/featureFlags";
 import { BypassModeBanner } from "@/components/BypassModeBanner";
 
 export const SignUp = () => {
+  const navigate = useNavigate();
   const maintenance = getMaintenanceConfig();
   const maintenanceActive = maintenance.enabled;
   const signUpDisabled = maintenanceActive && !maintenance.allowSignUp;
@@ -28,6 +29,10 @@ export const SignUp = () => {
   const handleSignupSuccess = (email: string, requiresEmailConfirmation: boolean) => {
     setEmailForConfirmation(email);
     setConfirmationRequired(requiresEmailConfirmation);
+
+    if (!requiresEmailConfirmation) {
+      navigate("/onboarding/account-type");
+    }
   };
 
   const headline = useMemo(() => "Sign up. It is fast and easy.", []);

--- a/src/pages/onboarding/AccountTypeSelectionPage.tsx
+++ b/src/pages/onboarding/AccountTypeSelectionPage.tsx
@@ -1,0 +1,87 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/lib/supabaseClient';
+import { useProfile } from '@/hooks/useProfile';
+import type { AccountType } from '@/types/profile';
+
+export function AccountTypeSelectionPage() {
+  const { loading, profile, error, refresh } = useProfile();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!loading && profile?.account_type) {
+      navigate(`/onboarding/${profile.account_type}`, { replace: true });
+    }
+  }, [loading, profile, navigate]);
+
+  const handleSelect = async (accountType: AccountType) => {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      navigate('/signin');
+      return;
+    }
+
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({ account_type: accountType })
+      .eq('id', user.id);
+
+    if (updateError) {
+      console.error('Error setting account_type', updateError);
+      alert('Failed to set account type. Please try again.');
+      return;
+    }
+
+    await refresh();
+    navigate(`/onboarding/${accountType}`);
+  };
+
+  if (loading) return <div>Loading your profile…</div>;
+  if (error) return <div>Could not load profile. Please refresh.</div>;
+
+  return (
+    <div className="max-w-xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Welcome to Wathaci Connect</h1>
+      <p className="mb-6">
+        Choose the type of account that best describes how you want to use the platform.
+      </p>
+
+      <div className="space-y-4">
+        <button
+          onClick={() => handleSelect('sme')}
+          className="w-full border rounded-lg p-4 text-left hover:bg-gray-50"
+        >
+          <h2 className="font-semibold">SME / Business Owner</h2>
+          <p className="text-sm text-gray-600">
+            Create a business profile, showcase your products/services, and connect with experts.
+          </p>
+        </button>
+
+        <button
+          onClick={() => handleSelect('professional')}
+          className="w-full border rounded-lg p-4 text-left hover:bg-gray-50"
+        >
+          <h2 className="font-semibold">Professional / Freelancer</h2>
+          <p className="text-sm text-gray-600">
+            Offer consulting, professional services, and support SMEs in your areas of expertise.
+          </p>
+        </button>
+
+        <button
+          onClick={() => handleSelect('investor')}
+          className="w-full border rounded-lg p-4 text-left hover:bg-gray-50"
+        >
+          <h2 className="font-semibold">Investor / Support Partner</h2>
+          <p className="text-sm text-gray-600">
+            Discover SMEs, explore opportunities, and support high-potential businesses.
+          </p>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default AccountTypeSelectionPage;

--- a/src/pages/onboarding/InvestorOnboardingPage.tsx
+++ b/src/pages/onboarding/InvestorOnboardingPage.tsx
@@ -147,6 +147,16 @@ export const InvestorOnboardingPage = () => {
     setLoading(true);
     try {
       await upsertInvestorProfile(data);
+      if (user?.id) {
+        const { error: profileUpdateError } = await supabaseClient
+          .from('profiles')
+          .update({ account_type: 'investor', profile_completed: true })
+          .eq('id', user.id);
+
+        if (profileUpdateError) {
+          console.error('[onboarding] Failed to mark investor profile complete', profileUpdateError);
+        }
+      }
       toast({ title: 'Profile saved', description: 'Your investment preferences have been updated.' });
       if (!stayOnPage) {
         navigate('/onboarding/investor/needs-assessment');

--- a/src/pages/onboarding/ProfessionalOnboardingPage.tsx
+++ b/src/pages/onboarding/ProfessionalOnboardingPage.tsx
@@ -336,6 +336,17 @@ export const ProfessionalOnboardingPage = () => {
         current_organisation: data.entity_type === 'individual' ? data.current_organisation || null : data.current_organisation || data.organisation_name || null,
       });
 
+      if (user?.id) {
+        const { error: profileUpdateError } = await supabaseClient
+          .from('profiles')
+          .update({ account_type: 'professional', profile_completed: true })
+          .eq('id', user.id);
+
+        if (profileUpdateError) {
+          console.error('[onboarding] Failed to mark professional profile complete', profileUpdateError);
+        }
+      }
+
       toast({
         title: 'Your professional profile has been saved.',
         description: 'SMEs will soon be able to discover and work with you.',

--- a/src/pages/onboarding/SmeOnboardingPage.tsx
+++ b/src/pages/onboarding/SmeOnboardingPage.tsx
@@ -179,6 +179,17 @@ export const SmeOnboardingPage = () => {
         social_links: data.social_links?.split(',').map((link) => link.trim()).filter(Boolean),
       });
 
+      if (user?.id) {
+        const { error: profileUpdateError } = await supabaseClient
+          .from('profiles')
+          .update({ account_type: 'sme', profile_completed: true })
+          .eq('id', user.id);
+
+        if (profileUpdateError) {
+          console.error('[onboarding] Failed to mark profile complete', profileUpdateError);
+        }
+      }
+
       toast({ title: 'SME profile saved', description: 'Your business details have been recorded.' });
       if (!stayOnPage) {
         navigate('/onboarding/sme/needs-assessment');

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,8 @@
+export type AccountType = 'sme' | 'professional' | 'investor';
+
+export interface Profile {
+  id: string;
+  email: string | null;
+  account_type: AccountType | null;
+  profile_completed: boolean;
+}


### PR DESCRIPTION
## Summary
- add shared profile types and hook for loading Supabase profiles
- introduce auth/profile wrappers plus account-type selection onboarding entry
- gate private routes with profile completion and mark onboarding submissions as completed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693668f50a548328bfaf0ad6dbcc5acf)