### PR TITLE
Add account-type profile schemas and update profile types

### DIFF
--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -21,11 +21,12 @@ export interface User {
 
 export type AccountType =
   | 'sole_proprietor'
-  | 'professional'
   | 'sme'
+  | 'professional'
   | 'investor'
   | 'donor'
   | 'government'
+  | 'government_institution'
   | 'admin';
 
 // ================================
@@ -35,6 +36,7 @@ export type AccountType =
 export interface BaseProfile {
   id: string;
   email: string;
+  full_name?: string | null;
   account_type: AccountType;
   profile_completed: boolean;
   accepted_terms: boolean;
@@ -50,8 +52,11 @@ export interface PersonalInfo {
   first_name?: string;
   last_name?: string;
   phone: string;
-  msisdn?: string;
   country: string;
+  city?: string;
+  profile_photo_url?: string | null;
+  short_bio?: string | null;
+  msisdn?: string;
   address?: string;
   coordinates?: {
     lat: number;
@@ -528,80 +533,154 @@ export interface SMEReadinessScore {
 
 export interface ProfessionalProfileRow {
   id: string;
-  user_id: string;
-  entity_type: 'individual' | 'firm' | 'company';
-  full_name: string;
-  organisation_name?: string | null;
-  bio?: string | null;
-  primary_expertise: string[];
-  secondary_skills: string[];
+  profile_id: string;
+  display_name: string;
+  is_company: boolean;
+  professional_bio?: string | null;
+  primary_expertise: string[] | null;
+  secondary_skills: string[] | null;
   years_of_experience?: number | null;
   current_organisation?: string | null;
-  qualifications?: string | null;
-  top_sectors: string[];
+  qualifications?: string[] | null;
+  top_sectors_served?: string[] | null;
   notable_projects?: string | null;
-  services_offered: string[];
-  expected_rates?: string | null;
+  services_offered?: string[] | null;
+  rate_type?: string | null;
+  rate_currency?: string | null;
+  rate_min?: number | null;
+  rate_max?: number | null;
+  availability?: string | null;
   location_city?: string | null;
   location_country?: string | null;
   phone?: string | null;
   email?: string | null;
+  website?: string | null;
   linkedin_url?: string | null;
-  website_url?: string | null;
   portfolio_url?: string | null;
-  availability?: 'part_time' | 'full_time' | 'occasional' | null;
-  notes?: string | null;
-  profile_photo_url?: string | null;
-  logo_url?: string | null;
+  languages?: string[] | null;
+  willing_to_travel?: boolean | null;
+  remote_only?: boolean | null;
+  serves_regions?: string[] | null;
+  accepting_new_clients: boolean;
+  tags?: string[] | null;
   created_at?: string | null;
   updated_at?: string | null;
 }
 
 export interface SmeProfileRow {
   id: string;
-  user_id: string;
+  profile_id: string;
   business_name: string;
+  registration_status?: string | null;
   registration_number?: string | null;
-  registration_type?: string | null;
+  legal_form?: string | null;
+  year_established?: number | null;
   sector?: string | null;
-  subsector?: string | null;
-  years_in_operation?: number | null;
-  employee_count?: number | null;
-  turnover_bracket?: string | null;
-  products_overview?: string | null;
-  target_market?: string | null;
+  sub_sector?: string | null;
+  description?: string | null;
+  website?: string | null;
+  primary_products_services?: string | null;
+  employees_full_time?: number | null;
+  employees_part_time?: number | null;
+  annual_turnover_band?: string | null;
+  growth_stage?: string | null;
+  funding_need: boolean;
+  funding_purpose?: string | null;
+  funding_amount_min?: number | null;
+  funding_amount_max?: number | null;
+  impact_focus?: Record<string, unknown> | null;
   location_city?: string | null;
   location_country?: string | null;
-  contact_name?: string | null;
-  contact_phone?: string | null;
-  business_email?: string | null;
-  website_url?: string | null;
-  social_links: string[];
-  main_challenges: string[];
-  support_needs: string[];
-  logo_url?: string | null;
-  photos: string[];
+  markets_served?: string | null;
+  preferred_support_types?: string[] | null;
+  is_visible: boolean;
+  tags?: string[] | null;
   created_at?: string | null;
   updated_at?: string | null;
 }
 
 export interface InvestorProfileRow {
   id: string;
-  user_id: string;
+  profile_id: string;
   organisation_name: string;
   investor_type?: string | null;
+  contact_person_name?: string | null;
+  contact_email?: string | null;
+  contact_phone?: string | null;
+  website?: string | null;
+  hq_country?: string | null;
+  hq_city?: string | null;
+  regions_focus?: string[] | null;
   ticket_size_min?: number | null;
   ticket_size_max?: number | null;
-  preferred_sectors: string[];
-  country_focus: string[];
-  stage_preference: string[];
-  instruments: string[];
-  impact_focus: string[];
-  contact_person?: string | null;
-  contact_role?: string | null;
-  website_url?: string | null;
-  linkedin_url?: string | null;
-  logo_url?: string | null;
+  ticket_currency?: string | null;
+  investment_stage?: string[] | null;
+  instruments?: string[] | null;
+  sectors_focus?: string[] | null;
+  exclusion_list?: string[] | null;
+  impact_focus?: Record<string, unknown> | null;
+  average_horizon_years?: number | null;
+  portfolio_size?: number | null;
+  portfolio_highlights?: string | null;
+  ticket_frequency?: string | null;
+  is_accepting_deals: boolean;
+  deal_filters?: Record<string, unknown> | null;
+  tags?: string[] | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface DonorProfileRow {
+  id: string;
+  profile_id: string;
+  organisation_name: string;
+  donor_type?: string | null;
+  contact_person_name?: string | null;
+  contact_email?: string | null;
+  contact_phone?: string | null;
+  website?: string | null;
+  hq_country?: string | null;
+  hq_city?: string | null;
+  countries_focus?: string[] | null;
+  thematic_focus?: string[] | null;
+  funding_modalities?: string[] | null;
+  typical_grant_min?: number | null;
+  typical_grant_max?: number | null;
+  grant_currency?: string | null;
+  eligible_beneficiaries?: string[] | null;
+  current_programmes?: string | null;
+  open_calls_url?: string | null;
+  application_cycles?: string | null;
+  reporting_requirements_summary?: string | null;
+  impact_themes?: Record<string, unknown> | null;
+  accepting_applications: boolean;
+  tags?: string[] | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface GovernmentInstitutionProfileRow {
+  id: string;
+  profile_id: string;
+  institution_name: string;
+  institution_type?: string | null;
+  mandate_summary?: string | null;
+  ministry_or_parent?: string | null;
+  contact_person_name?: string | null;
+  contact_email?: string | null;
+  contact_phone?: string | null;
+  website?: string | null;
+  hq_address?: string | null;
+  hq_city?: string | null;
+  hq_country?: string | null;
+  sme_relevant_services?: string[] | null;
+  service_portal_url?: string | null;
+  key_programmes?: string | null;
+  regulatory_scope?: string[] | null;
+  target_segments?: string[] | null;
+  response_time_sla?: string | null;
+  office_hours?: string | null;
+  tags?: string[] | null;
   created_at?: string | null;
   updated_at?: string | null;
 }
@@ -640,6 +719,16 @@ export interface Database {
         Row: InvestorProfileRow;
         Insert: Partial<InvestorProfileRow>;
         Update: Partial<InvestorProfileRow>;
+      };
+      donor_profiles: {
+        Row: DonorProfileRow;
+        Insert: Partial<DonorProfileRow>;
+        Update: Partial<DonorProfileRow>;
+      };
+      government_institution_profiles: {
+        Row: GovernmentInstitutionProfileRow;
+        Insert: Partial<GovernmentInstitutionProfileRow>;
+        Update: Partial<GovernmentInstitutionProfileRow>;
       };
       sme_readiness_scores: {
         Row: SMEReadinessScore;

--- a/src/@types/supabase.types.ts
+++ b/src/@types/supabase.types.ts
@@ -13,12 +13,12 @@
 
 export type AccountType =
   | 'sole_proprietor'
-  | 'SME'
+  | 'sme'
+  | 'professional'
   | 'investor'
   | 'donor'
-  | 'professional'
   | 'government'
-  | 'NGO';
+  | 'government_institution';
 
 export type PaymentStatus = 'pending' | 'paid' | 'failed' | 'refunded';
 export type TransactionStatus = 'pending' | 'success' | 'failed' | 'cancelled';

--- a/src/data/accountTypes.ts
+++ b/src/data/accountTypes.ts
@@ -1,13 +1,12 @@
 import type { LucideIcon } from 'lucide-react';
-import { User, Users, Building, TrendingUp, Heart, Landmark } from 'lucide-react';
+import { Users, Building, TrendingUp, Heart, Landmark } from 'lucide-react';
 
 export type AccountTypeValue =
-  | 'sole_proprietor'
-  | 'professional'
   | 'sme'
+  | 'professional'
   | 'investor'
   | 'donor'
-  | 'government';
+  | 'government_institution';
 
 export interface AccountTypeDefinition {
   value: AccountTypeValue;
@@ -19,18 +18,6 @@ export interface AccountTypeDefinition {
 }
 
 export const accountTypes: AccountTypeDefinition[] = [
-  {
-    value: 'sole_proprietor',
-    label: 'Sole Proprietor',
-    description: 'For individual entrepreneurs and micro businesses building their first digital presence.',
-    icon: User,
-    idealFor: [
-      'Freelancers and independent consultants',
-      'Market vendors and small retail businesses',
-      'Founders testing new products or services'
-    ],
-    onboardingFocus: ['Business profile', 'Mobile money payments', 'Marketplace listing']
-  },
   {
     value: 'professional',
     label: 'Professional',
@@ -80,7 +67,7 @@ export const accountTypes: AccountTypeDefinition[] = [
     onboardingFocus: ['Program focus', 'Funding priorities', 'Impact metrics']
   },
   {
-    value: 'government',
+    value: 'government_institution',
     label: 'Government Institution',
     description: 'Enterprise workflows for public sector agencies supporting MSMEs.',
     icon: Landmark,

--- a/src/data/subscriptionPlans.ts
+++ b/src/data/subscriptionPlans.ts
@@ -22,7 +22,7 @@ export const subscriptionPlans: SubscriptionPlan[] = [
     features: ['Platform access', 'Basic matching', 'Email support', '5 connections/month'],
     popular: false,
     lencoAmount: 2500,
-    userTypes: ['sole_proprietor', 'professional'],
+    userTypes: ['professional'],
     category: 'basic'
   },
   {
@@ -34,7 +34,7 @@ export const subscriptionPlans: SubscriptionPlan[] = [
     features: ['Everything in Basic Monthly', '15 connections/month', 'Priority support'],
     popular: true,
     lencoAmount: 6000,
-    userTypes: ['sole_proprietor', 'professional'],
+    userTypes: ['professional'],
     category: 'basic'
   },
 
@@ -74,7 +74,7 @@ export const subscriptionPlans: SubscriptionPlan[] = [
     features: ['White-label solution', 'API access', 'Custom features', 'Account manager'],
     popular: false,
     lencoAmount: 20000,
-    userTypes: ['investor', 'donor', 'government'],
+    userTypes: ['investor', 'donor', 'government_institution'],
     category: 'enterprise'
   },
   {
@@ -86,7 +86,7 @@ export const subscriptionPlans: SubscriptionPlan[] = [
     features: ['Everything in Enterprise Monthly', 'Priority development', 'SLA guarantee'],
     popular: true,
     lencoAmount: 200000,
-    userTypes: ['investor', 'donor', 'government'],
+    userTypes: ['investor', 'donor', 'government_institution'],
     category: 'enterprise'
   }
 ];
@@ -97,12 +97,11 @@ export const getPlansForUserType = (userType: string): SubscriptionPlan[] => {
 
 export const getUserTypeLabel = (userType: string): string => {
   const labels: Record<string, string> = {
-    sole_proprietor: 'Sole Proprietor',
     professional: 'Professional',
     sme: 'Small & Medium Enterprise',
     investor: 'Investor',
     donor: 'Donor',
-    government: 'Government Institution'
+    government_institution: 'Government Institution'
   };
   return labels[userType] || userType;
 };

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,4 +1,11 @@
-export type AccountType = 'sme' | 'professional' | 'investor';
+export type AccountType =
+  | 'sole_proprietor'
+  | 'sme'
+  | 'professional'
+  | 'investor'
+  | 'donor'
+  | 'government'
+  | 'government_institution';
 
 export interface Profile {
   id: string;

--- a/supabase/migrations/20260611120000_account_type_profile_schemas.sql
+++ b/supabase/migrations/20260611120000_account_type_profile_schemas.sql
@@ -1,0 +1,433 @@
+BEGIN;
+
+-- Ensure account_type_enum exists with required values
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t WHERE t.typname = 'account_type_enum'
+  ) THEN
+    CREATE TYPE public.account_type_enum AS ENUM (
+      'sme',
+      'professional',
+      'investor',
+      'donor',
+      'government_institution'
+    );
+  END IF;
+END
+$$;
+
+-- Add any missing enum values
+DO $$
+DECLARE
+  v label := '';
+  required_values text[] := ARRAY[
+    'sme',
+    'professional',
+    'investor',
+    'donor',
+    'government_institution'
+  ];
+BEGIN
+  FOREACH v IN ARRAY required_values LOOP
+    BEGIN
+      EXECUTE format('ALTER TYPE public.account_type_enum ADD VALUE IF NOT EXISTS %L', v);
+    EXCEPTION
+      WHEN duplicate_object THEN
+        NULL;
+    END;
+  END LOOP;
+END
+$$;
+
+-- Standardise profiles table
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email text,
+  full_name text,
+  account_type public.account_type_enum,
+  profile_completed boolean NOT NULL DEFAULT false,
+  country text,
+  city text,
+  phone text,
+  profile_photo_url text,
+  short_bio text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+ALTER TABLE public.profiles
+  ALTER COLUMN profile_completed SET DEFAULT false,
+  ALTER COLUMN profile_completed SET NOT NULL,
+  ALTER COLUMN updated_at SET DEFAULT timezone('utc', now()),
+  ALTER COLUMN created_at SET DEFAULT timezone('utc', now());
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS full_name text,
+  ADD COLUMN IF NOT EXISTS country text,
+  ADD COLUMN IF NOT EXISTS city text,
+  ADD COLUMN IF NOT EXISTS phone text,
+  ADD COLUMN IF NOT EXISTS profile_photo_url text,
+  ADD COLUMN IF NOT EXISTS short_bio text;
+
+-- Keep profile email synced with auth.users
+CREATE OR REPLACE FUNCTION public.sync_profile_email()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  user_email text;
+BEGIN
+  SELECT email INTO user_email FROM auth.users WHERE id = NEW.id;
+  IF NEW.email IS NULL THEN
+    NEW.email := user_email;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- Keep updated_at current
+CREATE OR REPLACE FUNCTION public.set_current_timestamp_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = timezone('utc', now());
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS sync_profile_email_trigger ON public.profiles;
+CREATE TRIGGER sync_profile_email_trigger
+BEFORE INSERT OR UPDATE ON public.profiles
+FOR EACH ROW EXECUTE PROCEDURE public.sync_profile_email();
+
+DROP TRIGGER IF EXISTS profiles_updated_at_trigger ON public.profiles;
+CREATE TRIGGER profiles_updated_at_trigger
+BEFORE UPDATE ON public.profiles
+FOR EACH ROW EXECUTE PROCEDURE public.set_current_timestamp_updated_at();
+
+-- SME profiles
+CREATE TABLE IF NOT EXISTS public.sme_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  business_name text NOT NULL,
+  registration_status text,
+  registration_number text,
+  legal_form text,
+  year_established integer,
+  sector text,
+  sub_sector text,
+  description text,
+  website text,
+  primary_products_services text,
+  employees_full_time integer,
+  employees_part_time integer,
+  annual_turnover_band text,
+  growth_stage text,
+  funding_need boolean NOT NULL DEFAULT false,
+  funding_purpose text,
+  funding_amount_min numeric(18,2),
+  funding_amount_max numeric(18,2),
+  impact_focus jsonb,
+  location_city text,
+  location_country text,
+  markets_served text,
+  preferred_support_types text[],
+  is_visible boolean NOT NULL DEFAULT true,
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Professional profiles
+CREATE TABLE IF NOT EXISTS public.professional_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  display_name text NOT NULL,
+  is_company boolean NOT NULL DEFAULT false,
+  professional_bio text,
+  primary_expertise text[],
+  secondary_skills text[],
+  years_of_experience integer,
+  current_organisation text,
+  qualifications text[],
+  top_sectors_served text[],
+  notable_projects text,
+  services_offered text[],
+  rate_type text,
+  rate_currency text,
+  rate_min numeric(18,2),
+  rate_max numeric(18,2),
+  availability text,
+  location_city text,
+  location_country text,
+  phone text,
+  email text,
+  website text,
+  linkedin_url text,
+  portfolio_url text,
+  languages text[],
+  willing_to_travel boolean,
+  remote_only boolean,
+  serves_regions text[],
+  accepting_new_clients boolean NOT NULL DEFAULT true,
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Investor profiles
+CREATE TABLE IF NOT EXISTS public.investor_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  organisation_name text NOT NULL,
+  investor_type text,
+  contact_person_name text,
+  contact_email text,
+  contact_phone text,
+  website text,
+  hq_country text,
+  hq_city text,
+  regions_focus text[],
+  ticket_size_min numeric(18,2),
+  ticket_size_max numeric(18,2),
+  ticket_currency text,
+  investment_stage text[],
+  instruments text[],
+  sectors_focus text[],
+  exclusion_list text[],
+  impact_focus jsonb,
+  average_horizon_years integer,
+  portfolio_size integer,
+  portfolio_highlights text,
+  ticket_frequency text,
+  is_accepting_deals boolean NOT NULL DEFAULT true,
+  deal_filters jsonb,
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Donor profiles
+CREATE TABLE IF NOT EXISTS public.donor_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  organisation_name text NOT NULL,
+  donor_type text,
+  contact_person_name text,
+  contact_email text,
+  contact_phone text,
+  website text,
+  hq_country text,
+  hq_city text,
+  countries_focus text[],
+  thematic_focus text[],
+  funding_modalities text[],
+  typical_grant_min numeric(18,2),
+  typical_grant_max numeric(18,2),
+  grant_currency text,
+  eligible_beneficiaries text[],
+  current_programmes text,
+  open_calls_url text,
+  application_cycles text,
+  reporting_requirements_summary text,
+  impact_themes jsonb,
+  accepting_applications boolean NOT NULL DEFAULT true,
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Government institution profiles
+CREATE TABLE IF NOT EXISTS public.government_institution_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  institution_name text NOT NULL,
+  institution_type text,
+  mandate_summary text,
+  ministry_or_parent text,
+  contact_person_name text,
+  contact_email text,
+  contact_phone text,
+  website text,
+  hq_address text,
+  hq_city text,
+  hq_country text,
+  sme_relevant_services text[],
+  service_portal_url text,
+  key_programmes text,
+  regulatory_scope text[],
+  target_segments text[],
+  response_time_sla text,
+  office_hours text,
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Updated-at triggers for new tables
+CREATE TRIGGER sme_profiles_updated_at
+BEFORE UPDATE ON public.sme_profiles
+FOR EACH ROW EXECUTE PROCEDURE public.set_current_timestamp_updated_at();
+
+CREATE TRIGGER professional_profiles_updated_at
+BEFORE UPDATE ON public.professional_profiles
+FOR EACH ROW EXECUTE PROCEDURE public.set_current_timestamp_updated_at();
+
+CREATE TRIGGER investor_profiles_updated_at
+BEFORE UPDATE ON public.investor_profiles
+FOR EACH ROW EXECUTE PROCEDURE public.set_current_timestamp_updated_at();
+
+CREATE TRIGGER donor_profiles_updated_at
+BEFORE UPDATE ON public.donor_profiles
+FOR EACH ROW EXECUTE PROCEDURE public.set_current_timestamp_updated_at();
+
+CREATE TRIGGER government_institution_profiles_updated_at
+BEFORE UPDATE ON public.government_institution_profiles
+FOR EACH ROW EXECUTE PROCEDURE public.set_current_timestamp_updated_at();
+
+-- Enable RLS
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sme_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.professional_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.investor_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.donor_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.government_institution_profiles ENABLE ROW LEVEL SECURITY;
+
+-- Profiles policies
+DROP POLICY IF EXISTS profiles_select_own ON public.profiles;
+DROP POLICY IF EXISTS profiles_update_own ON public.profiles;
+DROP POLICY IF EXISTS profiles_insert_owner ON public.profiles;
+
+CREATE POLICY profiles_select_own ON public.profiles
+  FOR SELECT
+  USING (auth.uid() = id);
+
+CREATE POLICY profiles_update_own ON public.profiles
+  FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY profiles_insert_owner ON public.profiles
+  FOR INSERT
+  WITH CHECK (auth.uid() = id);
+
+-- SME policies
+DROP POLICY IF EXISTS sme_profiles_select_own ON public.sme_profiles;
+DROP POLICY IF EXISTS sme_profiles_update_own ON public.sme_profiles;
+DROP POLICY IF EXISTS sme_profiles_insert_own ON public.sme_profiles;
+DROP POLICY IF EXISTS sme_profiles_directory ON public.sme_profiles;
+
+CREATE POLICY sme_profiles_select_own ON public.sme_profiles
+  FOR SELECT
+  USING (auth.uid() = profile_id);
+
+CREATE POLICY sme_profiles_update_own ON public.sme_profiles
+  FOR UPDATE
+  USING (auth.uid() = profile_id)
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY sme_profiles_insert_own ON public.sme_profiles
+  FOR INSERT
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY sme_profiles_directory ON public.sme_profiles
+  FOR SELECT TO authenticated
+  USING (is_visible IS TRUE);
+
+-- Professional policies
+DROP POLICY IF EXISTS professional_profiles_select_own ON public.professional_profiles;
+DROP POLICY IF EXISTS professional_profiles_update_own ON public.professional_profiles;
+DROP POLICY IF EXISTS professional_profiles_insert_own ON public.professional_profiles;
+DROP POLICY IF EXISTS professional_profiles_directory ON public.professional_profiles;
+
+CREATE POLICY professional_profiles_select_own ON public.professional_profiles
+  FOR SELECT
+  USING (auth.uid() = profile_id);
+
+CREATE POLICY professional_profiles_update_own ON public.professional_profiles
+  FOR UPDATE
+  USING (auth.uid() = profile_id)
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY professional_profiles_insert_own ON public.professional_profiles
+  FOR INSERT
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY professional_profiles_directory ON public.professional_profiles
+  FOR SELECT TO authenticated
+  USING (accepting_new_clients IS TRUE);
+
+-- Investor policies
+DROP POLICY IF EXISTS investor_profiles_select_own ON public.investor_profiles;
+DROP POLICY IF EXISTS investor_profiles_update_own ON public.investor_profiles;
+DROP POLICY IF EXISTS investor_profiles_insert_own ON public.investor_profiles;
+DROP POLICY IF EXISTS investor_profiles_directory ON public.investor_profiles;
+
+CREATE POLICY investor_profiles_select_own ON public.investor_profiles
+  FOR SELECT
+  USING (auth.uid() = profile_id);
+
+CREATE POLICY investor_profiles_update_own ON public.investor_profiles
+  FOR UPDATE
+  USING (auth.uid() = profile_id)
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY investor_profiles_insert_own ON public.investor_profiles
+  FOR INSERT
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY investor_profiles_directory ON public.investor_profiles
+  FOR SELECT TO authenticated
+  USING (is_accepting_deals IS TRUE);
+
+-- Donor policies
+DROP POLICY IF EXISTS donor_profiles_select_own ON public.donor_profiles;
+DROP POLICY IF EXISTS donor_profiles_update_own ON public.donor_profiles;
+DROP POLICY IF EXISTS donor_profiles_insert_own ON public.donor_profiles;
+DROP POLICY IF EXISTS donor_profiles_directory ON public.donor_profiles;
+
+CREATE POLICY donor_profiles_select_own ON public.donor_profiles
+  FOR SELECT
+  USING (auth.uid() = profile_id);
+
+CREATE POLICY donor_profiles_update_own ON public.donor_profiles
+  FOR UPDATE
+  USING (auth.uid() = profile_id)
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY donor_profiles_insert_own ON public.donor_profiles
+  FOR INSERT
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY donor_profiles_directory ON public.donor_profiles
+  FOR SELECT TO authenticated
+  USING (accepting_applications IS TRUE);
+
+-- Government institution policies
+DROP POLICY IF EXISTS government_profiles_select_own ON public.government_institution_profiles;
+DROP POLICY IF EXISTS government_profiles_update_own ON public.government_institution_profiles;
+DROP POLICY IF EXISTS government_profiles_insert_own ON public.government_institution_profiles;
+DROP POLICY IF EXISTS government_profiles_directory ON public.government_institution_profiles;
+
+CREATE POLICY government_profiles_select_own ON public.government_institution_profiles
+  FOR SELECT
+  USING (auth.uid() = profile_id);
+
+CREATE POLICY government_profiles_update_own ON public.government_institution_profiles
+  FOR UPDATE
+  USING (auth.uid() = profile_id)
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY government_profiles_insert_own ON public.government_institution_profiles
+  FOR INSERT
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY government_profiles_directory ON public.government_institution_profiles
+  FOR SELECT TO authenticated
+  USING (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add migration that standardizes profiles and introduces account-type specific profile tables with RLS
- update shared account type unions and profile row definitions to cover donor and government institution accounts
- refresh account type selection data and subscription labels to match the new account types

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936779a746c8328ba08e6929095adbf)