### PR TITLE
Fix profiles table definition and row-level security

### DIFF
--- a/docs/profiles-schema.md
+++ b/docs/profiles-schema.md
@@ -1,0 +1,37 @@
+# Profiles Table Reference
+
+This document records the expected shape and access rules for `public.profiles` so we can quickly verify the REST endpoint health.
+
+## Table definition
+
+`public.profiles` is a regular Postgres table keyed to `auth.users(id)`.
+
+| column | type | notes |
+| --- | --- | --- |
+| id | uuid | Primary key. References `auth.users(id)` with `ON DELETE CASCADE`. |
+| email | text | Optional; synced from `auth.users` when absent. |
+| full_name | text | Optional display name. |
+| account_type | text | Must be one of `sme`, `professional`, `investor`, `donor`, or `government_institution`. |
+| profile_completed | boolean | Defaults to `false`; cannot be null. |
+| country | text | Optional. |
+| city | text | Optional. |
+| phone | text | Optional. |
+| profile_photo_url | text | Optional. |
+| short_bio | text | Optional summary. |
+| created_at | timestamptz | Defaults to `now()`. |
+| updated_at | timestamptz | Defaults to `now()`, refreshed by trigger on updates. |
+
+## Triggers
+
+- `sync_profile_email_trigger` (before insert/update) populates `email` from `auth.users` when missing.
+- `profiles_set_updated_at` (before update) keeps `updated_at` current.
+
+## Row-Level Security
+
+RLS is enabled with minimal policies:
+
+- **Users can view own profile** – `auth.uid() = id` for `SELECT`.
+- **Users can update own profile** – `auth.uid() = id` for `UPDATE` (both `USING` and `WITH CHECK`).
+- **Service role full access** – unrestricted access for `service_role` (all commands).
+
+These policies are intentionally simple to avoid recursive predicates that previously caused `42P17` errors in PostgREST.

--- a/supabase/migrations/20260621120000_fix_profiles_table.sql
+++ b/supabase/migrations/20260621120000_fix_profiles_table.sql
@@ -1,0 +1,149 @@
+BEGIN;
+
+-- Ensure no conflicting view shadowing the profiles table.
+DROP VIEW IF EXISTS public.profiles CASCADE;
+
+-- Create a clean profiles table if it does not already exist.
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id uuid PRIMARY KEY,
+  email text,
+  full_name text,
+  account_type text,
+  profile_completed boolean NOT NULL DEFAULT false,
+  country text,
+  city text,
+  phone text,
+  profile_photo_url text,
+  short_bio text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Align column set and defaults even if the table already existed.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS email text,
+  ADD COLUMN IF NOT EXISTS full_name text,
+  ADD COLUMN IF NOT EXISTS account_type text,
+  ADD COLUMN IF NOT EXISTS profile_completed boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS country text,
+  ADD COLUMN IF NOT EXISTS city text,
+  ADD COLUMN IF NOT EXISTS phone text,
+  ADD COLUMN IF NOT EXISTS profile_photo_url text,
+  ADD COLUMN IF NOT EXISTS short_bio text,
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE public.profiles
+  ALTER COLUMN profile_completed SET DEFAULT false,
+  ALTER COLUMN profile_completed SET NOT NULL,
+  ALTER COLUMN created_at SET DEFAULT now(),
+  ALTER COLUMN updated_at SET DEFAULT now();
+
+-- Keep the primary key and foreign key intact.
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_pkey,
+  ADD CONSTRAINT profiles_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_id_fkey,
+  ADD CONSTRAINT profiles_id_fkey FOREIGN KEY (id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+-- Simplify account_type validation to a straightforward CHECK.
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_account_type_check,
+  ADD CONSTRAINT profiles_account_type_check CHECK (
+    account_type IN (
+      'sme',
+      'professional',
+      'investor',
+      'donor',
+      'government_institution'
+    )
+  );
+
+-- Refresh bookkeeping triggers with simple, valid functions.
+CREATE OR REPLACE FUNCTION public.set_profiles_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_profile_email()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.email IS NULL THEN
+    SELECT email INTO NEW.email FROM auth.users WHERE id = NEW.id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS sync_profile_email_trigger ON public.profiles;
+CREATE TRIGGER sync_profile_email_trigger
+BEFORE INSERT OR UPDATE ON public.profiles
+FOR EACH ROW EXECUTE FUNCTION public.sync_profile_email();
+
+DROP TRIGGER IF EXISTS profiles_set_updated_at ON public.profiles;
+DROP TRIGGER IF EXISTS set_profiles_updated_at ON public.profiles;
+DROP TRIGGER IF EXISTS profiles_updated_at_trigger ON public.profiles;
+CREATE TRIGGER profiles_set_updated_at
+BEFORE UPDATE ON public.profiles
+FOR EACH ROW EXECUTE FUNCTION public.set_profiles_updated_at();
+
+-- Reset RLS to minimal, valid policies.
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+  pol record;
+BEGIN
+  FOR pol IN
+    SELECT polname FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'profiles'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.profiles', pol.polname);
+  END LOOP;
+END$$;
+
+CREATE POLICY "Users can view own profile"
+  ON public.profiles
+  FOR SELECT
+  USING (auth.uid() = id);
+
+CREATE POLICY "Users can update own profile"
+  ON public.profiles
+  FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "Service role full access"
+  ON public.profiles
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Seed or refresh the known test profile for regression checks.
+INSERT INTO public.profiles (id, email, full_name, account_type, profile_completed)
+VALUES (
+  'e986f7a8-3eb4-4a22-a798-e9e5566bcdf4',
+  'amukenam@gmail.com',
+  'Amukena Mukumbuta',
+  'sme',
+  false
+)
+ON CONFLICT (id) DO UPDATE
+  SET email = EXCLUDED.email,
+      full_name = EXCLUDED.full_name,
+      account_type = EXCLUDED.account_type,
+      profile_completed = EXCLUDED.profile_completed;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- replace the profiles relation with a clean table schema and simple account_type check constraint
- refresh triggers and RLS policies with minimal, non-recursive definitions and service role access
- upsert a known profile record and document the expected profiles schema for future checks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367cb72b3483288fd65b61ad769eae)