### PR TITLE
Fix missing PrivateRoute import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { getPaymentConfig } from "@/lib/payment-config";
 import CisoWidget from "@/components/CisoWidget";
 import AppLayout from "./components/AppLayout";
 import { RequireAuth, RequireCompletedProfile } from "./components/auth/RequireAuth";
+import PrivateRoute from "./components/PrivateRoute";
 import "./i18n";
 
 const queryClient = new QueryClient();


### PR DESCRIPTION
## Summary
- add the missing PrivateRoute import to the App component so protected routes render correctly

## Testing
- npm run lint (fails: existing eslint rule configuration errors in backend/services/payment-provider.js)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ac17d1a48328a8eb4d3e64c87b99)