### PR TITLE
Add Ciso edge function and wire frontend to new endpoint

### DIFF
--- a/src/lib/__tests__/cisoClient.test.ts
+++ b/src/lib/__tests__/cisoClient.test.ts
@@ -13,7 +13,7 @@ const originalEnv = { ...process.env };
 const setBaseEnv = () => {
   process.env = {
     ...originalEnv,
-    VITE_CISO_AGENT_URL: 'http://localhost:9999/agent',
+    VITE_CISO_AGENT_URL: 'http://localhost:9999/ciso-agent',
     VITE_SUPABASE_ANON_KEY: 'anon-key',
   };
 };
@@ -44,7 +44,7 @@ describe('callCisoAgent', () => {
 
     expect(reply).toBe('Hello from Ciso');
     expect(global.fetch).toHaveBeenCalledWith(
-      'http://localhost:9999/agent',
+      'http://localhost:9999/ciso-agent',
       expect.any(Object),
     );
   });

--- a/src/lib/cisoClient.ts
+++ b/src/lib/cisoClient.ts
@@ -62,7 +62,7 @@ const env =
 const AGENT_URL =
   env.VITE_CISO_AGENT_URL?.trim() ||
   env.VITE_WATHACI_CISO_AGENT_URL?.trim() ||
-  "https://nrjcbdrzaxqvomeogptf.functions.supabase.co/agent";
+  "https://nrjcbdrzaxqvomeogptf.functions.supabase.co/ciso-agent";
 
 const SUPABASE_ANON_KEY = env.VITE_SUPABASE_ANON_KEY;
 

--- a/supabase/functions/ciso-agent/index.ts
+++ b/supabase/functions/ciso-agent/index.ts
@@ -1,0 +1,217 @@
+// supabase/functions/ciso-agent/index.ts
+// Deno runtime
+
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY")!;
+
+// Optional: name of RPC / table for KB search
+const CISO_MATCH_RPC = Deno.env.get("CISO_MATCH_RPC") ?? "match_ciso_documents";
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { persistSession: false },
+});
+
+type ChatRequest = {
+  query: string;
+  user_id?: string;
+  context?: Record<string, unknown>;
+};
+
+type ChatResponse = {
+  answer: string;
+  source?: "knowledge_base" | "openai" | "mixed";
+  references?: Array<{ id: string; score: number }>;
+};
+
+async function callOpenAI(prompt: string): Promise<string> {
+  if (!OPENAI_API_KEY) {
+    return "Ciso is not fully configured yet (missing OpenAI key). Please contact support@wathaci.com.";
+  }
+
+  const body = {
+    model: "gpt-4.1-mini",
+    messages: [
+      {
+        role: "system",
+        content: `
+You are Ciso, the AI assistant for the Wathaci platform.
+Be concise, friendly and practical.
+Explain things clearly for African SMEs, investors, professionals, donors and government users.
+If something relates to Wathaci-specific flows (accounts, onboarding, payments, profiles),
+answer as if you are part of the platform and give step-by-step guidance.
+Don't mention that you are using OpenAI.
+        `.trim(),
+      },
+      { role: "user", content: prompt },
+    ],
+  };
+
+  const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    console.error("OpenAI error:", await resp.text());
+    return "I’m having trouble reaching my AI brain right now. Please try again in a moment.";
+  }
+
+  const data = await resp.json();
+  return data.choices?.[0]?.message?.content ?? "I could not generate a response.";
+}
+
+async function searchKnowledgeBase(query: string) {
+  try {
+    // 1. Create embedding using OpenAI (or any other embeddings service you prefer)
+    const embeddingResp = await fetch(
+      "https://api.openai.com/v1/embeddings",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${OPENAI_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "text-embedding-3-small",
+          input: query,
+        }),
+      },
+    );
+
+    if (!embeddingResp.ok) {
+      console.error("Embedding error:", await embeddingResp.text());
+      return { matches: [], error: "embedding_failed" as const };
+    }
+
+    const embeddingData = await embeddingResp.json();
+    const embedding = embeddingData.data?.[0]?.embedding as number[] | undefined;
+    if (!embedding) return { matches: [], error: "no_embedding" as const };
+
+    // 2. Call your match RPC (you’ll add this below in SQL)
+    const { data, error } = await supabase.rpc(CISO_MATCH_RPC, {
+      query_embedding: embedding,
+      similarity_threshold: 0.75,
+      match_count: 5,
+    });
+
+    if (error) {
+      console.error("KB search RPC error:", error);
+      return { matches: [], error: "rpc_error" as const };
+    }
+
+    return { matches: data ?? [], error: null };
+  } catch (err) {
+    console.error("KB search exception:", err);
+    return { matches: [], error: "exception" as const };
+  }
+}
+
+function buildAnswerFromMatches(matches: any[], query: string): string {
+  const contextText = matches
+    .map((m) => m.content ?? m.chunk ?? "")
+    .filter(Boolean)
+    .join("\n\n---\n\n");
+
+  return `
+Using Wathaci's internal knowledge base, here is a helpful answer:
+
+Question:
+${query}
+
+Relevant information:
+${contextText}
+
+Now answer in a concise way (3–7 short paragraphs, plus bullets if useful),
+focused on practical steps for the user.
+`.trim();
+}
+
+serve(async (req) => {
+  // CORS
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return new Response("Only POST allowed", { status: 405 });
+  }
+
+  try {
+    const body = (await req.json()) as ChatRequest | null;
+    const query = body?.query?.trim();
+
+    if (!query) {
+      return new Response(
+        JSON.stringify({ error: "Missing query" }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // 1) Search KB first
+    const { matches, error: kbError } = await searchKnowledgeBase(query);
+    let answer: string;
+    let source: ChatResponse["source"] = "openai";
+    let references: ChatResponse["references"] = [];
+
+    if (matches && matches.length > 0 && !kbError) {
+      const kbPrompt = buildAnswerFromMatches(matches, query);
+      answer = await callOpenAI(kbPrompt);
+      source = "knowledge_base";
+      references = matches.map((m: any) => ({
+        id: m.id ?? m.document_id ?? "",
+        score: m.similarity ?? m.score ?? 0,
+      }));
+    } else {
+      // 2) Fallback: general OpenAI answer
+      answer = await callOpenAI(query);
+      source = "openai";
+    }
+
+    const payload: ChatResponse = { answer, source, references };
+
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (err) {
+    console.error("Ciso agent fatal error:", err);
+    return new Response(
+      JSON.stringify({
+        error: "ciso_agent_error",
+        message: "Ciso failed to answer this question.",
+      }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add Supabase edge function for the Ciso agent that combines KB search and OpenAI responses
- point the frontend Ciso client to the new ciso-agent endpoint by default
- update unit tests to expect the new endpoint

## Testing
- npm run test:jest -- src/lib/__tests__/cisoClient.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936b0a6e88c832890bcb0ff40045ee2)