### PR TITLE
Add React env fallbacks for Ciso agent

### DIFF
--- a/docs/env.example
+++ b/docs/env.example
@@ -17,6 +17,10 @@ VITE_MAINTENANCE_ALLOWED_EMAIL_DOMAINS=admin@wathaci.com,wathaci.com
 VITE_SUPPORT_EMAIL=support@wathaci.com
 VITE_WATHACI_CISO_AGENT_URL=https://your-project.functions.supabase.co/agent
 VITE_WATHACI_CISO_KNOWLEDGE_URL=https://your-project.functions.supabase.co/ciso-knowledge
+REACT_APP_SUPABASE_ANON_KEY=public-anon-key
+REACT_APP_CISO_AGENT_URL=https://your-project.functions.supabase.co/ciso-agent
+REACT_APP_WATHACI_CISO_AGENT_URL=https://your-project.functions.supabase.co/agent
+REACT_APP_WATHACI_CISO_KNOWLEDGE_URL=https://your-project.functions.supabase.co/ciso-knowledge
 
 # Backend / Supabase secrets
 SUPABASE_URL=https://your-project.supabase.co

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,9 +3,12 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly REACT_APP_API_BASE_URL?: string;
+  readonly VITE_CISO_AGENT_URL?: string;
+  readonly REACT_APP_CISO_AGENT_URL?: string;
   readonly VITE_WATHACI_CISO_AGENT_URL?: string;
   readonly REACT_APP_WATHACI_CISO_AGENT_URL?: string;
   readonly VITE_WATHACI_CISO_KNOWLEDGE_URL?: string;
+  readonly REACT_APP_WATHACI_CISO_KNOWLEDGE_URL?: string;
   readonly VITE_SUPABASE_ANON_KEY?: string;
   readonly REACT_APP_SUPABASE_ANON_KEY?: string;
   readonly VITE_SUPABASE_URL?: string;

--- a/src/lib/cisoClient.ts
+++ b/src/lib/cisoClient.ts
@@ -61,10 +61,13 @@ const env =
 
 const AGENT_URL =
   env.VITE_CISO_AGENT_URL?.trim() ||
+  env.REACT_APP_CISO_AGENT_URL?.trim() ||
   env.VITE_WATHACI_CISO_AGENT_URL?.trim() ||
+  env.REACT_APP_WATHACI_CISO_AGENT_URL?.trim() ||
   "https://nrjcbdrzaxqvomeogptf.functions.supabase.co/ciso-agent";
 
-const SUPABASE_ANON_KEY = env.VITE_SUPABASE_ANON_KEY;
+const SUPABASE_ANON_KEY =
+  env.VITE_SUPABASE_ANON_KEY ?? env.REACT_APP_SUPABASE_ANON_KEY;
 
 const deriveUserQuery = (messages: CisoMessage[]): string => {
   if (!messages || messages.length === 0) return "";


### PR DESCRIPTION
## Summary
- add React-prefixed fallbacks for the Ciso agent URL and Supabase anon key so builds using REACT_APP vars still work
- document the React-prefixed Ciso environment variables and expose them through the ImportMetaEnv type definitions

## Testing
- npm test -- --runTestsByPath src/lib/__tests__/cisoClient.test.ts *(fails: repository test harness expects backend dependencies and SMTP/Twilio env vars that are unavailable in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936dee9fad8832894a68d7af54fe048)