### PR TITLE
Add mock getSession to fallback Supabase client

### DIFF
--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -381,6 +381,18 @@ function createMockSupabaseClient() {
 
   return {
     auth: {
+      getSession: async () => ({
+        data: {
+          session: currentUser
+            ? {
+                user: currentUser,
+                access_token: 'mock-access-token',
+                token_type: 'bearer',
+              }
+            : null,
+        },
+        error: null,
+      }),
       getUser: async () => ({ data: { user: currentUser }, error: null }),
       signInWithPassword: async ({ email, password }: { email: string; password: string }) => {
         const normalizedEmail = (email || '').toLowerCase();


### PR DESCRIPTION
## Summary
- add getSession implementation to the mock Supabase client to support anonymous Ciso calls

## Testing
- npm test -- --runTestsByPath src/lib/__tests__/cisoClient.test.ts src/lib/__tests__/supabase-enhanced.test.ts (fails: missing environment configuration and optional dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936f4fb789883288fe1344f3f7aba18)