### PR TITLE
Align profiles upsert schema and account types

### DIFF
--- a/src/__tests__/profile-upsert.e2e.test.ts
+++ b/src/__tests__/profile-upsert.e2e.test.ts
@@ -1,0 +1,54 @@
+import { createClient } from '@supabase/supabase-js';
+const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const describeIfConfigPresent = supabaseUrl && serviceRoleKey ? describe : describe.skip;
+
+describeIfConfigPresent('profiles upsert flow (service role)', () => {
+  const client = createClient(supabaseUrl as string, serviceRoleKey as string, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  it('creates or updates a profile row via onConflict=id', async () => {
+    const email = `profile-upsert-${Date.now()}@example.com`;
+    const password = 'TempPass123!';
+
+    const { data: userResult, error: userError } = await client.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    });
+
+    expect(userError).toBeNull();
+    expect(userResult?.user).toBeDefined();
+
+    const profilePayload = {
+      id: userResult!.user!.id,
+      email,
+      account_type: 'sme',
+      profile_completed: false,
+      msisdn: '+260' + Math.floor(Math.random() * 10_000_0000).toString().padStart(8, '0'),
+    } as const;
+
+    const { data, error } = await client
+      .from('profiles')
+      .upsert(profilePayload, { onConflict: 'id' })
+      .select()
+      .single();
+
+    expect(error).toBeNull();
+    expect(data?.id).toBe(profilePayload.id);
+    expect(data?.account_type).toBe('sme');
+
+    await client.auth.admin.deleteUser(userResult!.user!.id);
+  }, 30000);
+});
+
+// Keep a placeholder test so the file is recognized even without env vars
+if (!supabaseUrl || !serviceRoleKey) {
+  describe('profiles upsert flow (service role)', () => {
+    it.skip('requires VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY to run', () => {
+      expect(true).toBe(true);
+    });
+  });
+}

--- a/src/lib/onboardingPaths.ts
+++ b/src/lib/onboardingPaths.ts
@@ -2,25 +2,31 @@ import { logger } from '@/lib/logger';
 
 export type OnboardingAccountType =
   | 'sme'
-  | 'sole_proprietor'
   | 'professional'
   | 'investor'
   | 'donor'
-  | 'government';
+  | 'government_institution';
 
 export const normalizeAccountType = (accountType?: string | null): OnboardingAccountType | null => {
   if (!accountType) return null;
   const normalized = accountType.toString().trim().toLowerCase();
 
+  if (normalized === 'sole_proprietor') {
+    return 'sme';
+  }
+
+  if (normalized === 'government') {
+    return 'government_institution';
+  }
+
   if (
     normalized === 'sme' ||
-    normalized === 'sole_proprietor' ||
     normalized === 'professional' ||
     normalized === 'investor' ||
     normalized === 'donor' ||
-    normalized === 'government'
+    normalized === 'government_institution'
   ) {
-    return normalized;
+    return normalized as OnboardingAccountType;
   }
 
   logger.warn('Unknown account type encountered while normalizing', {
@@ -36,14 +42,13 @@ export const getOnboardingStartPath = (accountType?: string | null): string => {
 
   switch (normalized) {
     case 'sme':
-    case 'sole_proprietor':
       return '/onboarding/sme';
     case 'professional':
       return '/onboarding/professional';
     case 'investor':
     case 'donor':
       return '/onboarding/investor';
-    case 'government':
+    case 'government_institution':
       return '/onboarding/government/needs-assessment';
     default:
       return '/onboarding/account-type';

--- a/src/lib/wathaciSupabaseClient.ts
+++ b/src/lib/wathaciSupabaseClient.ts
@@ -11,16 +11,34 @@ export type AccountType = AccountTypeValue;
 
 export const accountTypePaths: Record<AccountType, string> = {
   sme: "/sme-assessment",
-  sole_proprietor: "/sme-assessment",
   investor: "/investor-assessment",
   professional: "/professional-assessment",
   donor: "/donor-assessment",
-  government: "/government-assessment",
+  government_institution: "/government-assessment",
+};
+
+const normalizeAccountType = (accountType?: string | null): AccountType | null => {
+  if (!accountType) return null;
+  const normalized = accountType.trim().toLowerCase();
+
+  if (normalized === "sole_proprietor") {
+    return "sme";
+  }
+
+  if (normalized === "government") {
+    return "government_institution";
+  }
+
+  if ((Object.keys(accountTypePaths) as string[]).includes(normalized)) {
+    return normalized as AccountType;
+  }
+
+  return null;
 };
 
 export const getDashboardPathForAccountType = (accountType?: string | null): string => {
-  if (!accountType) return "/profile-review";
+  const normalized = normalizeAccountType(accountType);
+  if (!normalized) return "/profile-review";
 
-  const normalized = accountType.trim().toLowerCase() as AccountTypeValue;
   return accountTypePaths[normalized] ?? "/profile-review";
 };

--- a/supabase/migrations/20260618123000_profiles_upsert_alignment.sql
+++ b/supabase/migrations/20260618123000_profiles_upsert_alignment.sql
@@ -1,0 +1,153 @@
+BEGIN;
+
+-- Ensure account_type_enum contains all values used by the application and legacy data
+DO $$
+DECLARE
+  v text;
+  required_values text[] := ARRAY['sme', 'professional', 'investor', 'donor', 'government_institution', 'sole_proprietor', 'government'];
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'account_type_enum'
+  ) THEN
+    EXECUTE 'CREATE TYPE public.account_type_enum AS ENUM (''sme'',''professional'',''investor'',''donor'',''government_institution'',''sole_proprietor'',''government'')';
+  ELSE
+    FOREACH v IN ARRAY required_values LOOP
+      BEGIN
+        EXECUTE format('ALTER TYPE public.account_type_enum ADD VALUE IF NOT EXISTS %L', v);
+      EXCEPTION
+        WHEN duplicate_object THEN NULL;
+      END;
+    END LOOP;
+  END IF;
+END
+$$;
+
+-- Base profiles table definition
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email text,
+  full_name text,
+  account_type public.account_type_enum NOT NULL DEFAULT 'sme',
+  profile_completed boolean NOT NULL DEFAULT false,
+  country text,
+  city text,
+  phone text,
+  profile_photo_url text,
+  short_bio text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Ensure required columns exist for signup/onboarding payloads
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS first_name text,
+  ADD COLUMN IF NOT EXISTS last_name text,
+  ADD COLUMN IF NOT EXISTS business_name text,
+  ADD COLUMN IF NOT EXISTS msisdn text,
+  ADD COLUMN IF NOT EXISTS accepted_terms boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS newsletter_opt_in boolean NOT NULL DEFAULT false;
+
+-- Keep constraints in place for upserts
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'profiles_pkey'
+  ) THEN
+    ALTER TABLE public.profiles ADD CONSTRAINT profiles_pkey PRIMARY KEY (id);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'profiles_id_fkey'
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_id_fkey FOREIGN KEY (id) REFERENCES auth.users (id) ON DELETE CASCADE;
+  END IF;
+END
+$$;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN id SET NOT NULL,
+  ALTER COLUMN profile_completed SET NOT NULL,
+  ALTER COLUMN profile_completed SET DEFAULT false,
+  ALTER COLUMN account_type SET NOT NULL,
+  ALTER COLUMN account_type SET DEFAULT 'sme';
+
+-- Maintain email and updated_at consistency
+CREATE OR REPLACE FUNCTION public.sync_profile_email()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  user_email text;
+BEGIN
+  SELECT email INTO user_email FROM auth.users WHERE id = NEW.id;
+  IF NEW.email IS NULL THEN
+    NEW.email := user_email;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.set_current_timestamp_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = timezone('utc', now());
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS sync_profile_email_trigger ON public.profiles;
+CREATE TRIGGER sync_profile_email_trigger
+BEFORE INSERT OR UPDATE ON public.profiles
+FOR EACH ROW EXECUTE PROCEDURE public.sync_profile_email();
+
+DROP TRIGGER IF EXISTS profiles_updated_at_trigger ON public.profiles;
+CREATE TRIGGER profiles_updated_at_trigger
+BEFORE UPDATE ON public.profiles
+FOR EACH ROW EXECUTE PROCEDURE public.set_current_timestamp_updated_at();
+
+-- Keep MSISDN validation aligned with payload expectations
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'profiles_msisdn_format_check'
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_msisdn_format_check
+      CHECK (msisdn IS NULL OR msisdn ~ '^\+?[0-9]{9,15}$');
+  END IF;
+END
+$$;
+
+-- RLS policies to allow authenticated users to manage their own profile
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS profiles_select_own ON public.profiles;
+DROP POLICY IF EXISTS profiles_update_own ON public.profiles;
+DROP POLICY IF EXISTS profiles_insert_owner ON public.profiles;
+
+CREATE POLICY profiles_select_own ON public.profiles
+  FOR SELECT
+  USING (auth.uid() = id);
+
+CREATE POLICY profiles_update_own ON public.profiles
+  FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY profiles_insert_owner ON public.profiles
+  FOR INSERT
+  WITH CHECK (auth.uid() = id);
+
+-- Refresh PostgREST schema cache to avoid stale column errors
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a migration to standardize the `profiles` table constraints, policies, and enum values, and refresh the PostgREST schema cache
- normalize onboarding account type handling and dashboard routing to match the schema while mapping legacy values safely
- add a service-role profile upsert test scaffold to validate the end-to-end signup payload

## Testing
- `npm test -- --runTestsByPath src/lib/__tests__/onboarding.test.ts src/__tests__/profile-upsert.e2e.test.ts` *(fails: upstream test runner executes unrelated scripts missing env/deps)*
- `npx jest --runInBand src/lib/__tests__/onboarding.test.ts src/__tests__/profile-upsert.e2e.test.ts --passWithNoTests` *(fails: jest config/import.meta and missing babel config resolution in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fd5889648328bc8b654efd6f7371)