### PR TITLE
Ensure profile upserts use auth user id

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -44,7 +44,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
 
       const { data: profile, error: profileError } = await supabaseClient
         .from("profiles")
-        .select("account_type, profile_completed, email")
+        .select("*")
         .eq("id", userId)
         .maybeSingle();
 
@@ -59,13 +59,19 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
       if (!resolvedProfile) {
         const { data: createdProfile, error: createError } = await supabaseClient
           .from("profiles")
-          .insert({
-            id: userId,
-            email: data.user?.email ?? email,
-            account_type: null,
-            profile_completed: false,
-          })
-          .select("account_type, profile_completed, email")
+          .upsert(
+            {
+              id: userId,
+              email: data.user?.email ?? email,
+              full_name:
+                ((data.user?.user_metadata as Record<string, unknown> | undefined)?.full_name as string | undefined) ?? null,
+              account_type:
+                ((data.user?.user_metadata as Record<string, unknown> | undefined)?.account_type as string | undefined) ?? null,
+              profile_completed: false,
+            },
+            { onConflict: "id" }
+          )
+          .select()
           .single();
 
         if (createError) {


### PR DESCRIPTION
## Summary
- ensure signup and login profile upserts reuse supabase auth user id and return the created profile
- redirect onboarding using the persisted account type after profile creation
- confirm row level security policies allow owners to select, update, and insert profiles

## Testing
- `npm test -- --runTestsByPath src/__tests__/profile-upsert.e2e.test.ts` *(fails: missing configuration such as SMTP server, Supabase env vars, backend dependencies like express)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693725b77b848328b52c7427fe59c2a3)