### PR TITLE
Refactor Supabase client to singleton

### DIFF
--- a/src/components/AccessGate.tsx
+++ b/src/components/AccessGate.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Lock, Eye } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import {
   SUBSCRIPTION_BYPASS_FEATURES,
   SUBSCRIPTION_DEBUG_BYPASS_ENABLED,

--- a/src/components/CurrencyConverter.tsx
+++ b/src/components/CurrencyConverter.tsx
@@ -4,7 +4,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { currencies } from '../data/countries';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 
 interface ConversionResult {
   originalAmount: number;

--- a/src/components/DonorNeedsAssessment.tsx
+++ b/src/components/DonorNeedsAssessment.tsx
@@ -24,7 +24,7 @@ import {
   Lightbulb
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 
 // Assessment form validation schema

--- a/src/components/DueDiligenceUpload.tsx
+++ b/src/components/DueDiligenceUpload.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { Upload, FileText, CheckCircle, XCircle, Clock, AlertTriangle } from 'lucide-react';
 
 interface Document {

--- a/src/components/FreelancerDirectory.tsx
+++ b/src/components/FreelancerDirectory.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import { Star, MapPin, Clock, Search, Filter, Linkedin } from 'lucide-react';
 import PriceNegotiation from '@/components/PriceNegotiation';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 
 interface Freelancer {
   id: string;

--- a/src/components/FreelancerMatcher.tsx
+++ b/src/components/FreelancerMatcher.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { Search, MapPin, DollarSign, Star, Loader2, Linkedin } from 'lucide-react';
 
 interface Freelancer {

--- a/src/components/GapMatcher.tsx
+++ b/src/components/GapMatcher.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button } from './ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Textarea } from './ui/textarea';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { generateProfessionalMatches } from '@/data/marketplace';
 import { useAppContext } from '../contexts/AppContext';
 

--- a/src/components/GovernmentNeedsAssessment.tsx
+++ b/src/components/GovernmentNeedsAssessment.tsx
@@ -24,7 +24,7 @@ import {
   Lightbulb
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 
 // Assessment form validation schema

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Upload, X } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useToast } from '@/hooks/use-toast';
 
 interface ImageUploadProps {

--- a/src/components/InvestorNeedsAssessment.tsx
+++ b/src/components/InvestorNeedsAssessment.tsx
@@ -24,7 +24,7 @@ import {
   Lightbulb
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 
 // Assessment form validation schema

--- a/src/components/NegotiationHistory.tsx
+++ b/src/components/NegotiationHistory.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { MessageCircle, Clock, CheckCircle, XCircle } from 'lucide-react';
 
 interface NegotiationRecord {

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -4,7 +4,7 @@ import { Button } from './ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Badge } from './ui/badge';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from './ui/sheet';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useAppContext } from '../contexts/AppContext';
 
 interface Notification {

--- a/src/components/PriceNegotiation.tsx
+++ b/src/components/PriceNegotiation.tsx
@@ -9,7 +9,7 @@ import { DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { LencoPayment } from './LencoPayment';
 import { NegotiationHistory } from './NegotiationHistory';
 import ZRATaxCalculator from './ZRATaxCalculator';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useToast } from '@/hooks/use-toast';
 import { MessageCircle, DollarSign, CheckCircle, History } from 'lucide-react';
 

--- a/src/components/ProfessionalNeedsAssessment.tsx
+++ b/src/components/ProfessionalNeedsAssessment.tsx
@@ -24,7 +24,7 @@ import {
   Lightbulb
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 
 // Assessment form validation schema

--- a/src/components/ProfileReview.tsx
+++ b/src/components/ProfileReview.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';

--- a/src/components/SMENeedsAssessment.tsx
+++ b/src/components/SMENeedsAssessment.tsx
@@ -26,7 +26,7 @@ import {
   Lightbulb
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 
 // Assessment form validation schema

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { Building2, Users, Briefcase, TrendingUp, Heart, DollarSign, Target, Award, Globe } from 'lucide-react';
 
 interface Stats {

--- a/src/components/SubscriptionCard.tsx
+++ b/src/components/SubscriptionCard.tsx
@@ -6,7 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Check, CreditCard, Smartphone, Loader2, AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { subscriptionService } from '@/lib/services/subscription-service';

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Star } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 
 interface Testimonial {
   id: string;

--- a/src/components/TrialBanner.tsx
+++ b/src/components/TrialBanner.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Clock, Crown } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useNavigate } from 'react-router-dom';
 import { isSubscriptionTemporarilyDisabled, SUBSCRIPTION_GRACE_LABEL } from '@/lib/subscriptionWindow';
 

--- a/src/components/__tests__/AccessGate.test.tsx
+++ b/src/components/__tests__/AccessGate.test.tsx
@@ -12,7 +12,7 @@ jest.mock('@/lib/supabase-enhanced', () => ({
   },
 }));
 
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 const mockGetUser = supabase.auth.getUser as jest.Mock;
 const mockFrom = supabase.from as jest.Mock;
 

--- a/src/components/funding/FundingHub.tsx
+++ b/src/components/funding/FundingHub.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { OpportunityCard } from './OpportunityCard';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { Search, Filter, Sparkles } from 'lucide-react';
 import { InvestmentTips } from '@/components/InvestmentTips';
 

--- a/src/components/funding/FundingMatcher.tsx
+++ b/src/components/funding/FundingMatcher.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { Search, TrendingUp, DollarSign, Clock, Loader2 } from 'lucide-react';
 
 interface FundingMatcherProps {

--- a/src/components/funding/LiveFundingMatcher.tsx
+++ b/src/components/funding/LiveFundingMatcher.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Search, Filter, TrendingUp, Users, Clock, Award } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 
 interface LiveFundingMatcherProps {
   viewOnly?: boolean;

--- a/src/components/industry/IndustryMatcher.tsx
+++ b/src/components/industry/IndustryMatcher.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Loader2, Target, Users, DollarSign, Handshake } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 
 interface IndustryMatch {
   freelancers: string[];

--- a/src/components/investor/CoInvestmentHub.tsx
+++ b/src/components/investor/CoInvestmentHub.tsx
@@ -6,7 +6,7 @@ import { Progress } from '@/components/ui/progress';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 import { Users, TrendingUp, Calendar, Plus, DollarSign } from 'lucide-react';
 

--- a/src/components/investor/InterestTracker.tsx
+++ b/src/components/investor/InterestTracker.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 import { Eye, MessageCircle, TrendingUp, Heart, Calendar } from 'lucide-react';
 

--- a/src/components/investor/SMEDirectory.tsx
+++ b/src/components/investor/SMEDirectory.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { Search, MapPin, Users, TrendingUp, Heart, DollarSign } from 'lucide-react';
 
 interface SME {

--- a/src/components/marketplace/AIAssistant.tsx
+++ b/src/components/marketplace/AIAssistant.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { MessageCircle, Send, Bot, User, X } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { generateAssistantResponse } from '@/data/marketplace';
 import { supabaseConfigStatus } from '@/config/appConfig';
 

--- a/src/components/marketplace/AIPricingSuggestions.tsx
+++ b/src/components/marketplace/AIPricingSuggestions.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { TrendingUp, DollarSign, BarChart3, Lightbulb } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { generatePricingAnalysis } from '@/data/marketplace';
 
 interface PricingSuggestion {

--- a/src/components/marketplace/AIRecommendations.tsx
+++ b/src/components/marketplace/AIRecommendations.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Sparkles, TrendingUp, Users, Clock } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { buildMarketplaceRecommendations } from '@/data/marketplace';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 

--- a/src/components/marketplace/AISearch.tsx
+++ b/src/components/marketplace/AISearch.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { Search, Sparkles, X } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { runMarketplaceSearch } from '@/data/marketplace';
 
 interface AISearchProps {

--- a/src/components/marketplace/ComplianceGate.tsx
+++ b/src/components/marketplace/ComplianceGate.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { Shield, AlertTriangle, CheckCircle, FileText, Upload } from 'lucide-react';
 
 interface ComplianceGateProps {

--- a/src/components/marketplace/IntegratedMarketplace.tsx
+++ b/src/components/marketplace/IntegratedMarketplace.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { ServiceProviderCard } from './ServiceProviderCard';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { Search, Filter, Grid, List, Loader2, Users, Building, BookOpen, ShoppingCart } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import {

--- a/src/components/messaging/MessageCenter.tsx
+++ b/src/components/messaging/MessageCenter.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { MessageSquare, Send, User } from 'lucide-react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useToast } from '@/hooks/use-toast';
 import { userService } from '@/lib/services';
 

--- a/src/components/messaging/__tests__/MessageCenter.test.tsx
+++ b/src/components/messaging/__tests__/MessageCenter.test.tsx
@@ -15,7 +15,7 @@ jest.mock('@/lib/supabase-enhanced', () => {
   };
 });
 
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 jest.mock('@/lib/services', () => ({
   userService: {
     searchUsers: jest.fn(),

--- a/src/hooks/use-payment-status.ts
+++ b/src/hooks/use-payment-status.ts
@@ -4,7 +4,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useToast } from '@/hooks/use-toast';
 import { withSupportContact } from '@/lib/supportEmail';
 

--- a/src/lib/__tests__/supabase-enhanced.test.ts
+++ b/src/lib/__tests__/supabase-enhanced.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 
-describe('supabase-enhanced environment handling', () => {
+describe('supabase client environment handling', () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
@@ -25,7 +25,7 @@ describe('supabase-enhanced environment handling', () => {
       createClient,
     }));
 
-    await import('../supabase-enhanced');
+    await import('../supabaseClient');
 
     expect(createClient).toHaveBeenCalledWith(
       'https://example.supabase.co',
@@ -44,10 +44,10 @@ describe('supabase-enhanced environment handling', () => {
       createClient,
     }));
 
-    const { supabase } = await import('../supabase-enhanced');
+    const { supabaseClient } = await import('../supabaseClient');
 
     expect(createClient).not.toHaveBeenCalled();
-    expect(typeof supabase).toBe('object');
+    expect(typeof supabaseClient).toBe('object');
   });
 
   it('falls back to legacy VITE_SUPABASE_KEY configuration', async () => {
@@ -60,7 +60,7 @@ describe('supabase-enhanced environment handling', () => {
       createClient,
     }));
 
-    await import('../supabase-enhanced');
+    await import('../supabaseClient');
 
     expect(createClient).toHaveBeenCalledWith(
       'https://legacy.supabase.co',

--- a/src/lib/services/__tests__/lenco-transfer-recipient-service.test.ts
+++ b/src/lib/services/__tests__/lenco-transfer-recipient-service.test.ts
@@ -1,5 +1,5 @@
 import { lencoTransferRecipientService } from '../lenco-transfer-recipient-service';
-import { supabase } from '../../supabase-enhanced';
+import { supabaseClient } from '../../supabaseClient';
 
 jest.mock('@supabase/supabase-js', () => ({
   createClient: jest.fn(() => ({
@@ -42,8 +42,8 @@ jest.mock('../../logger', () => ({
 }));
 
 describe('LencoTransferRecipientService', () => {
-  const originalInvoke = supabase.functions.invoke;
-  const invokeSpy = jest.spyOn(supabase.functions, 'invoke');
+  const originalInvoke = supabaseClient.functions.invoke;
+  const invokeSpy = jest.spyOn(supabaseClient.functions, 'invoke');
 
   beforeEach(() => {
     invokeSpy.mockClear();

--- a/src/lib/services/base-service.ts
+++ b/src/lib/services/base-service.ts
@@ -3,7 +3,8 @@
  * and utilities that other service classes can extend.
  */
 
-import { supabase, withErrorHandling } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
+import { withErrorHandling } from '@/lib/supabase-enhanced';
 import type { DatabaseResponse, PaginatedResponse, PaginationParams } from '@/@types/database';
 
 export abstract class BaseService<T = any> {
@@ -19,7 +20,7 @@ export abstract class BaseService<T = any> {
   async findById(id: string, select: string = '*'): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
       async () =>
-        supabase
+        supabaseClient
           .from(this.tableName)
           .select(select)
           .eq('id', id)
@@ -42,7 +43,7 @@ export abstract class BaseService<T = any> {
         const from = (page - 1) * limit;
         const to = from + limit - 1;
 
-        let query = supabase
+        let query = supabaseClient
           .from(this.tableName)
           .select(select, { count: 'exact' })
           .range(from, to)
@@ -92,7 +93,7 @@ export abstract class BaseService<T = any> {
   async create(data: Partial<T>): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
       async () =>
-        supabase
+        supabaseClient
           .from(this.tableName)
           .insert(data)
           .select()
@@ -107,7 +108,7 @@ export abstract class BaseService<T = any> {
   async update(id: string, data: Partial<T>): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
       async () =>
-        supabase
+        supabaseClient
           .from(this.tableName)
           .update({ ...data, updated_at: new Date().toISOString() })
           .eq('id', id)
@@ -123,7 +124,7 @@ export abstract class BaseService<T = any> {
   async upsert(data: Partial<T>): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
       async () =>
-        supabase
+        supabaseClient
           .from(this.tableName)
           .upsert(data)
           .select()
@@ -138,7 +139,7 @@ export abstract class BaseService<T = any> {
   async delete(id: string): Promise<DatabaseResponse<void>> {
     return withErrorHandling(
       async () => {
-        const result = await supabase
+        const result = await supabaseClient
           .from(this.tableName)
           .delete()
           .eq('id', id);
@@ -155,7 +156,7 @@ export abstract class BaseService<T = any> {
   async softDelete(id: string): Promise<DatabaseResponse<T>> {
     return withErrorHandling(
       async () =>
-        supabase
+        supabaseClient
           .from(this.tableName)
           .update({
             deleted_at: new Date().toISOString(),
@@ -174,7 +175,7 @@ export abstract class BaseService<T = any> {
   async exists(id: string): Promise<DatabaseResponse<boolean>> {
     return withErrorHandling(
       async () => {
-        const result = await supabase
+        const result = await supabaseClient
           .from(this.tableName)
           .select('id')
           .eq('id', id)
@@ -195,7 +196,7 @@ export abstract class BaseService<T = any> {
   async count(filters: Record<string, any> = {}): Promise<DatabaseResponse<number>> {
     return withErrorHandling(
       async () => {
-        let query = supabase
+        let query = supabaseClient
           .from(this.tableName)
           .select('*', { count: 'exact', head: true });
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -67,12 +67,8 @@ export type {
 };
 
 // Enhanced Supabase client and utilities
-export {
-  supabase,
-  withErrorHandling,
-  testConnection,
-  healthCheck
-} from '../supabase-enhanced';
+export { supabaseClient as supabase } from '../supabaseClient';
+export { withErrorHandling, testConnection, healthCheck } from '../supabase-enhanced';
 
 export type {
   HealthCheckResult,

--- a/src/lib/services/lenco-payment-service.ts
+++ b/src/lib/services/lenco-payment-service.ts
@@ -17,7 +17,7 @@ import {
   getPlatformFeePercentage
 } from '../payment-config';
 import { logger } from '../logger';
-import { supabase } from '../supabase-enhanced';
+import { supabaseClient } from '../supabaseClient';
 
 const DEFAULT_APP_ORIGIN = 'https://wathaci.com';
 const ORIGIN_ENV_KEYS = ['VITE_APP_BASE_URL', 'VITE_SITE_URL', 'VITE_PUBLIC_SITE_URL'];
@@ -381,7 +381,7 @@ export class LencoPaymentService {
     }
 
     try {
-      const { data: response, error } = await supabase.functions.invoke('lenco-payment', {
+      const { data: response, error } = await supabaseClient.functions.invoke('lenco-payment', {
         body: {
           action,
           ...data

--- a/src/lib/services/lenco-transfer-recipient-service.ts
+++ b/src/lib/services/lenco-transfer-recipient-service.ts
@@ -1,5 +1,5 @@
 import { logger } from '../logger';
-import { supabase } from '../supabase-enhanced';
+import { supabaseClient } from '../supabaseClient';
 
 export interface TransferRecipientRequest {
   walletNumber: string;
@@ -54,7 +54,7 @@ class LencoTransferRecipientService {
     }
 
     try {
-      const { data, error } = await supabase.functions.invoke('lenco-transfer-recipient', {
+      const { data, error } = await supabaseClient.functions.invoke('lenco-transfer-recipient', {
         body: {
           walletNumber: sanitizedWalletNumber,
         },

--- a/src/lib/services/payment-analytics-service.ts
+++ b/src/lib/services/payment-analytics-service.ts
@@ -4,7 +4,7 @@
  */
 
 import { getPlatformFeePercentage } from '../payment-config';
-import { supabase } from '../supabase-enhanced';
+import { supabaseClient } from '../supabaseClient';
 
 export interface PaymentAnalytics {
   totalRevenue: number;
@@ -333,7 +333,7 @@ export class PaymentAnalyticsService {
   ): Promise<PaymentHistoryItem[]> {
     const { start, end } = this.getDateRangeBounds(startDate, endDate);
 
-    let query = supabase
+    let query = supabaseClient
       .from('payments')
       .select(
         'id, reference, amount, currency, status, payment_method, provider, description, created_at, paid_at, user_id, metadata'
@@ -461,7 +461,7 @@ export class PaymentAnalyticsService {
 
     const { start } = this.getDateRangeBounds(startDate, startDate);
 
-    const { data: priorPayments, error } = await supabase
+    const { data: priorPayments, error } = await supabaseClient
       .from('payments')
       .select('user_id')
       .in('user_id', uniqueUserIds)

--- a/src/lib/services/payment-security-service.ts
+++ b/src/lib/services/payment-security-service.ts
@@ -3,7 +3,7 @@
  * Handles payment security, fraud detection, and compliance
  */
 
-import { supabase } from '../supabase-enhanced';
+import { supabaseClient } from '../supabaseClient';
 
 export interface SecurityCheck {
   type: 'fraud' | 'compliance' | 'validation';
@@ -345,7 +345,7 @@ export class PaymentSecurityService {
   private async getDailyTransactionTotal(userId: string, date: string): Promise<number> {
     const { start, end } = this.getDayBounds(date);
 
-    const { data, error } = await supabase
+    const { data, error } = await supabaseClient
       .from('payments')
       .select('amount, status')
       .eq('user_id', userId)
@@ -372,7 +372,7 @@ export class PaymentSecurityService {
   private async getRecentTransactionCount(userId: string, timeWindow: number): Promise<number> {
     const windowStart = new Date(Date.now() - timeWindow).toISOString();
 
-    const { data, error } = await supabase
+    const { data, error } = await supabaseClient
       .from('payments')
       .select('id')
       .eq('user_id', userId)
@@ -386,7 +386,7 @@ export class PaymentSecurityService {
   }
 
   private async getUserTypicalLocations(userId: string): Promise<string[]> {
-    const { data, error } = await supabase
+    const { data, error } = await supabaseClient
       .from('payments')
       .select('metadata')
       .eq('user_id', userId)
@@ -455,7 +455,7 @@ export class PaymentSecurityService {
   private async getUserPaymentHistory(userId: string): Promise<Array<{ amount: number; method: string }>> {
     const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
 
-    const { data, error } = await supabase
+    const { data, error } = await supabaseClient
       .from('payments')
       .select('amount, payment_method, status')
       .eq('user_id', userId)

--- a/src/lib/services/resource-purchase-service.ts
+++ b/src/lib/services/resource-purchase-service.ts
@@ -1,5 +1,6 @@
 import { BaseService } from './base-service';
-import { supabase, withErrorHandling } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
+import { withErrorHandling } from '@/lib/supabase-enhanced';
 import type { ResourcePurchase, DatabaseResponse } from '@/@types/database';
 
 export class ResourcePurchaseService extends BaseService<ResourcePurchase> {
@@ -10,7 +11,7 @@ export class ResourcePurchaseService extends BaseService<ResourcePurchase> {
   async hasPurchased(userId: string, resourceId: number): Promise<DatabaseResponse<boolean>> {
     return withErrorHandling(
       async () => {
-        const { data, error } = await supabase
+        const { data, error } = await supabaseClient
           .from(this.tableName)
           .select('id')
           .eq('user_id', userId)

--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -2,7 +2,8 @@
  * Supabase client configuration
  */
 
-import { createClient } from '@supabase/supabase-js';
+import { supabaseClient as supabaseBrowserClient } from './supabaseClient';
+import type { SupabaseClient as SupabaseBrowserClient } from './supabaseClient';
 import type { MarketplaceService } from '@/data/marketplace';
 import {
   marketplaceProducts as datasetProducts,
@@ -16,7 +17,7 @@ import {
 } from '@/data/marketplace';
 import { SUPPORT_EMAIL } from './supportEmail';
 
-type SupabaseClientLike = ReturnType<typeof createClient> | ReturnType<typeof createMockSupabaseClient>;
+type SupabaseClientLike = SupabaseBrowserClient | ReturnType<typeof createMockSupabaseClient>;
 
 const sanitizeEnvValue = (value: unknown): string | undefined => {
   if (typeof value !== 'string') {
@@ -752,16 +753,7 @@ function createMockSupabaseClient() {
 const forcedMockSupabaseClient = missingSupabaseConfig && !allowMockSupabaseClient;
 const supabaseConfigWarning = missingSupabaseConfig ? missingConfigMessage : undefined;
 
-const supabaseClient: SupabaseClientLike =
-  supabaseUrl && supabaseKey
-    ? createClient(supabaseUrl, supabaseKey, {
-        auth: {
-          autoRefreshToken: true,
-          persistSession: true,
-          detectSessionInUrl: true
-        }
-      })
-    : createMockSupabaseClient();
+const supabaseClient: SupabaseClientLike = supabaseBrowserClient || createMockSupabaseClient();
 
 export const supabaseAuthConfigStatus = {
   hasValidConfig: !missingSupabaseConfig,

--- a/src/pages/DonorAssessment.tsx
+++ b/src/pages/DonorAssessment.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 
 interface AssessmentData {
   assessment: any;

--- a/src/pages/GovernmentAssessment.tsx
+++ b/src/pages/GovernmentAssessment.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 
 interface AssessmentData {
   assessment: any;

--- a/src/pages/InvestorAssessment.tsx
+++ b/src/pages/InvestorAssessment.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 
 interface AssessmentData {
   assessment: any;

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -15,7 +15,7 @@ import { ComplianceGate } from '@/components/marketplace/ComplianceGate';
 import { SubscriptionBanner } from '@/components/SubscriptionBanner';
 import { LencoPayment } from '@/components/LencoPayment';
 import { PaymentStatusTracker } from '@/components/PaymentStatusTracker';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
 import { SUPPORT_EMAIL } from '@/lib/supportEmail';

--- a/src/pages/PartnershipHub.tsx
+++ b/src/pages/PartnershipHub.tsx
@@ -7,7 +7,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import IndustryMatcher from '@/components/industry/IndustryMatcher';
 import { Handshake, Users, TrendingUp, Award, Building, Globe, CheckCircle, Star, Target } from 'lucide-react';
 import AppLayout from '@/components/AppLayout';

--- a/src/pages/ProfessionalAssessment.tsx
+++ b/src/pages/ProfessionalAssessment.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAppContext } from '@/contexts/AppContext';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { getProfessionalProfile } from '@/lib/api/profile-onboarding';
 
 interface AssessmentData {

--- a/src/pages/ProfileSetup.tsx
+++ b/src/pages/ProfileSetup.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { ProfileForm } from '@/components/ProfileForm';
 import { DueDiligenceUpload } from '@/components/DueDiligenceUpload';
 import { useToast } from '@/hooks/use-toast';

--- a/src/pages/SMEAssessment.tsx
+++ b/src/pages/SMEAssessment.tsx
@@ -4,7 +4,7 @@ import { SMENeedsAssessment } from '@/components/SMENeedsAssessment';
 import { AssessmentResults } from '@/components/AssessmentResults';
 import { useAppContext } from '@/contexts/AppContext';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/lib/supabase-enhanced';
+import { supabaseClient } from '@/lib/supabaseClient';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, CheckCircle, TrendingUp } from 'lucide-react';


### PR DESCRIPTION
## Summary
- centralize Supabase browser client creation with a singleton that uses a unique auth storage key
- update supabase-enhanced utilities and service/component imports to reuse the shared client
- refresh Supabase environment handling tests to cover the singleton module

## Testing
- `npm test -- --runTestsByPath src/lib/__tests__/supabase-enhanced.test.ts` *(fails: missing env/test dependencies in unrelated suites)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fdaeceb483289f4ee6566e5abe25)